### PR TITLE
hooks: Remove unnecessary explicit slice creation

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -9,10 +9,6 @@ type levelHooks map[Level][]Hook
 
 func (hooks levelHooks) Add(hook Hook) {
 	for _, level := range hook.Levels() {
-		if _, ok := hooks[level]; !ok {
-			hooks[level] = make([]Hook, 0, 1)
-		}
-
 		hooks[level] = append(hooks[level], hook)
 	}
 }


### PR DESCRIPTION
Appending to a nil slice creates it http://blog.golang.org/go-maps-in-action#TOC_4.
