### PR TITLE
Fix logger.StdLogger to really be a plugin stdlib/log.Logger.

### DIFF
--- a/logrus.go
+++ b/logrus.go
@@ -1,5 +1,9 @@
 package logrus
 
+import (
+	"log"
+)
+
 // Fields type, used to pass to `WithFields`.
 type Fields map[string]interface{}
 
@@ -27,10 +31,13 @@ const (
 	Debug
 )
 
-// StandardLogger is what your logrus-enabled library should take, that way
+// Won't compile if StdLogger can't be realized by a log.Logger
+var _ StdLogger = &log.Logger{}
+
+// StdLogger is what your logrus-enabled library should take, that way
 // it'll accept a stdlib logger and a logrus logger. There's no standard
 // interface, this is the closest we get, unfortunately.
-type StandardLogger interface {
+type StdLogger interface {
 	Print(...interface{})
 	Printf(string, ...interface{})
 	Println(...interface{})

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -33,24 +33,6 @@ func TestPrint(t *testing.T) {
 	})
 }
 
-func TestPrintf(t *testing.T) {
-	LogAndAssertJSON(t, func(log *Logger) {
-		log.Printf("%s", "test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test")
-		assert.Equal(t, fields["level"], "info")
-	})
-}
-
-func TestPrintln(t *testing.T) {
-	LogAndAssertJSON(t, func(log *Logger) {
-		log.Println("test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test")
-		assert.Equal(t, fields["level"], "info")
-	})
-}
-
 func TestInfo(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Info("test")


### PR DESCRIPTION
Typo in the interface makes that you can't replace all uses of `log.Logger` by a `logrus.StandardLogger`.  I've copy-pastaed the test for `log.Print` to use `Printf` and `Println`.  I think an actually better test would be to assert that all methods of `logrus.StandardLogger` are the implemented by `log.Logger`, maybe with reflection.

Also, `logrus.StandardLogger` is a mouthful, what do you think of `logrus.StdLogger`?
