### PR TITLE
Text formatter: don't print empty space when no msg

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -65,7 +65,10 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	} else {
 		serialized = f.AppendKeyValue(serialized, "time", entry.Data["time"].(string))
 		serialized = f.AppendKeyValue(serialized, "level", entry.Data["level"].(string))
-		serialized = f.AppendKeyValue(serialized, "msg", entry.Data["msg"].(string))
+		msg := entry.Data["msg"].(string)
+		if len(msg) > 0 {
+			serialized = f.AppendKeyValue(serialized, "msg", msg)
+		}
 
 		for key, value := range entry.Data {
 			if key != "time" && key != "level" && key != "msg" {


### PR DESCRIPTION
The field system is great, it allows clearer logs, however the
result is that there may be nothing in the `entry.Data["msg"]`

Example:

``` go
logger.WithFields(logrus.Fields{
    "event": "doing-smth", "error": err, "object": obj,
}).Error()
```

But in this case 45 characters are empty when using the text formatter.

![screenshot from 2014-03-29 21 59 43](https://cloud.githubusercontent.com/assets/329969/2559803/934ce51a-b78d-11e3-98c2-eb5436540b31.png)

After this patch, when entry.Data["msg"] is empty, we get that:

![screenshot from 2014-03-29 22 01 27](https://cloud.githubusercontent.com/assets/329969/2559806/b8f35cb8-b78d-11e3-9645-34aef89c0efc.png) 

What do you think of that, how could it be improved?

Thank you
