### PR TITLE
Add Windows/FreeBSD support

### DIFF
--- a/terminal_darwin.go
+++ b/terminal_darwin.go
@@ -1,0 +1,12 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logrus
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+type Termios syscall.Termios

--- a/terminal_freebsd.go
+++ b/terminal_freebsd.go
@@ -1,0 +1,20 @@
+/*
+  Go 1.2 doesn't include Termios for FreeBSD. This should be added in 1.3 and this could be merged with terminal_darwin.
+*/
+package logrus
+
+import (
+	"syscall"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+type Termios struct {
+	Iflag  uint32
+	Oflag  uint32
+	Cflag  uint32
+	Lflag  uint32
+	Cc     [20]uint8
+	Ispeed uint32
+	Ospeed uint32
+}

--- a/terminal_linux.go
+++ b/terminal_linux.go
@@ -1,0 +1,12 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logrus
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TCGETS
+
+type Termios syscall.Termios

--- a/terminal_notwindows.go
+++ b/terminal_notwindows.go
@@ -1,0 +1,21 @@
+// Based on ssh/terminal:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,!appengine darwin freebsd
+
+package logrus
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal() bool {
+	fd := syscall.Stdout
+	var termios Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -1,0 +1,26 @@
+// Based on ssh/terminal:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package logrus
+
+import (
+	"syscall"
+	"unsafe"
+)
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal() bool {
+	fd := syscall.Stdout
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -2,11 +2,8 @@ package logrus
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
-
-	"github.com/burke/ttyutils"
 )
 
 const (
@@ -25,7 +22,7 @@ type TextFormatter struct {
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	var serialized []byte
 
-	if f.ForceColors || ttyutils.IsTerminal(os.Stdout.Fd()) {
+	if f.ForceColors || IsTerminal() {
 		levelText := strings.ToUpper(entry.Data["level"].(string))[0:4]
 
 		levelColor := blue


### PR DESCRIPTION
The ttyutils package doesn't support Windows or FreeBSD. Ported code from Google's ssh/terminal that supports Windows and added FreeBSD support. Keeping this within logrus avoids an unnecessary dependency on ssh/terminal.
