### PR TITLE
Breaking out msg/time/level

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -10,6 +10,9 @@ import (
 
 type Entry struct {
 	Logger *Logger
+	Time   time.Time
+	Level  Level
+	Msg    string
 	Data   Fields
 }
 
@@ -49,10 +52,10 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	return entry
 }
 
-func (entry *Entry) log(level string, levelInt Level, msg string) string {
-	entry.Data["time"] = time.Now().String()
-	entry.Data["level"] = level
-	entry.Data["msg"] = msg
+func (entry *Entry) log(levelInt Level, msg string) string {
+	entry.Time = time.Now()
+	entry.Level = levelInt
+	entry.Msg = msg
 
 	if err := entry.Logger.Hooks.Fire(levelInt, entry); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fire hook", err)
@@ -76,7 +79,7 @@ func (entry *Entry) log(level string, levelInt Level, msg string) string {
 
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.Level >= Debug {
-		entry.log("debug", Debug, fmt.Sprint(args...))
+		entry.log(Debug, fmt.Sprint(args...))
 	}
 }
 
@@ -86,32 +89,32 @@ func (entry *Entry) Print(args ...interface{}) {
 
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.Level >= Info {
-		entry.log("info", Info, fmt.Sprint(args...))
+		entry.log(Info, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
 	if entry.Logger.Level >= Warn {
-		entry.log("warning", Warn, fmt.Sprint(args...))
+		entry.log(Warn, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.Level >= Error {
-		entry.log("error", Error, fmt.Sprint(args...))
+		entry.log(Error, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= Fatal {
-		entry.log("fatal", Fatal, fmt.Sprint(args...))
+		entry.log(Fatal, fmt.Sprint(args...))
 	}
 	os.Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.Level >= Panic {
-		msg := entry.log("panic", Panic, fmt.Sprint(args...))
+		msg := entry.log(Panic, fmt.Sprint(args...))
 		panic(msg)
 	}
 	panic(fmt.Sprint(args...))

--- a/hook_test.go
+++ b/hook_test.go
@@ -34,7 +34,7 @@ func TestHookFires(t *testing.T) {
 		assert.Equal(t, hook.Fired, false)
 
 		log.Print("test")
-	}, func(fields Fields) {
+	}, func(entry *Entry) {
 		assert.Equal(t, hook.Fired, true)
 	})
 }
@@ -64,8 +64,8 @@ func TestHookCanModifyEntry(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Hooks.Add(hook)
 		log.WithField("wow", "elephant").Print("test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["wow"], "whale")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Data["wow"], "whale")
 	})
 }
 
@@ -78,8 +78,8 @@ func TestCanFireMultipleHooks(t *testing.T) {
 		log.Hooks.Add(hook2)
 
 		log.WithField("wow", "elephant").Print("test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["wow"], "whale")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Data["wow"], "whale")
 		assert.Equal(t, hook2.Fired, true)
 	})
 }
@@ -105,7 +105,7 @@ func TestErrorHookShouldntFireOnInfo(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Hooks.Add(hook)
 		log.Info("test")
-	}, func(fields Fields) {
+	}, func(entry *Entry) {
 		assert.Equal(t, hook.Fired, false)
 	})
 }
@@ -116,7 +116,7 @@ func TestErrorHookShouldFireOnError(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Hooks.Add(hook)
 		log.Error("test")
-	}, func(fields Fields) {
+	}, func(entry *Entry) {
 		assert.Equal(t, hook.Fired, true)
 	})
 }

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -3,15 +3,76 @@ package logrus
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 type JSONFormatter struct {
 }
 
+type jsonEntry struct {
+	Time  time.Time `json:"time"`
+	Level string    `json:"level"`
+	Msg   string    `json:"msg"`
+	Data  Fields    `json:"data,omitempty"`
+}
+
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
-	serialized, err := json.Marshal(entry.Data)
+	jsonEntry := jsonEntry{
+		Time: entry.Time,
+		Msg:  entry.Msg,
+		Data: entry.Data,
+	}
+
+	switch entry.Level {
+	case Debug:
+		jsonEntry.Level = "debug"
+	case Info:
+		jsonEntry.Level = "info"
+	case Warn:
+		jsonEntry.Level = "warn"
+	case Error:
+		jsonEntry.Level = "error"
+	case Fatal:
+		jsonEntry.Level = "fatal"
+	case Panic:
+		jsonEntry.Level = "panic"
+	}
+
+	serialized, err := json.Marshal(jsonEntry)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+		return nil, fmt.Errorf("Failed to marshal data to JSON, %v", err)
 	}
 	return append(serialized, '\n'), nil
+}
+
+func (f *JSONFormatter) Unformat(buffer []byte) (*Entry, error) {
+	var jsonEntry jsonEntry
+
+	err := json.Unmarshal(buffer, &jsonEntry)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal entry to JSON, %v", err)
+	}
+
+	entry := Entry{
+		Time: jsonEntry.Time,
+		Msg:  jsonEntry.Msg,
+		Data: jsonEntry.Data,
+	}
+
+	switch jsonEntry.Level {
+	case "debug":
+		entry.Level = Debug
+	case "info":
+		entry.Level = Info
+	case "warn":
+		entry.Level = Warn
+	case "error":
+		entry.Level = Error
+	case "fatal":
+		entry.Level = Fatal
+	case "panic":
+		entry.Level = Panic
+	}
+
+	return &entry, nil
 }

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -2,99 +2,100 @@ package logrus
 
 import (
 	"bytes"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func LogAndAssertJSON(t *testing.T, log func(*Logger), assertions func(fields Fields)) {
+func LogAndAssertJSON(t *testing.T, log func(*Logger), assertions func(entry *Entry)) {
 	var buffer bytes.Buffer
-	var fields Fields
 
 	logger := New()
 	logger.Out = &buffer
-	logger.Formatter = new(JSONFormatter)
+	formatter := new(JSONFormatter)
+	logger.Formatter = formatter
 
 	log(logger)
 
-	err := json.Unmarshal(buffer.Bytes(), &fields)
+	entry, err := formatter.Unformat(buffer.Bytes())
 	assert.Nil(t, err)
 
-	assertions(fields)
+	if assert.NotNil(t, entry) {
+		assertions(entry)
+	}
 }
 
 func TestPrint(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Print("test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test")
-		assert.Equal(t, fields["level"], "info")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "test")
+		assert.Equal(t, entry.Level, Info)
 	})
 }
 
 func TestInfo(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Info("test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test")
-		assert.Equal(t, fields["level"], "info")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "test")
+		assert.Equal(t, entry.Level, Info)
 	})
 }
 
 func TestWarn(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Warn("test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test")
-		assert.Equal(t, fields["level"], "warning")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "test")
+		assert.Equal(t, entry.Level, Warn)
 	})
 }
 
 func TestInfolnShouldAddSpacesBetweenStrings(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Infoln("test", "test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test test")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "test test")
 	})
 }
 
 func TestInfolnShouldAddSpacesBetweenStringAndNonstring(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Infoln("test", 10)
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test 10")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "test 10")
 	})
 }
 
 func TestInfolnShouldAddSpacesBetweenTwoNonStrings(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Infoln(10, 10)
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "10 10")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "10 10")
 	})
 }
 
 func TestInfoShouldAddSpacesBetweenTwoNonStrings(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Infoln(10, 10)
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "10 10")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "10 10")
 	})
 }
 
 func TestInfoShouldNotAddSpacesBetweenStringAndNonstring(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Info("test", 10)
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test10")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "test10")
 	})
 }
 
 func TestInfoShouldNotAddSpacesBetweenStrings(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Info("test", "test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "testtest")
+	}, func(entry *Entry) {
+		assert.Equal(t, entry.Msg, "testtest")
 	})
 }

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func LogAndAssertText(t *testing.T, log func(*Logger), assertions func(Fields)) {
+func LogAndAssertText(t *testing.T, log func(*Logger), assertions func(*Entry)) {
 	var buffer bytes.Buffer
 
 	logger := New()
@@ -21,26 +21,26 @@ func LogAndAssertText(t *testing.T, log func(*Logger), assertions func(Fields)) 
 	assert.Nil(t, err)
 
 	if assert.NotNil(t, entry) {
-		assertions(entry.Data)
+		assertions(entry)
 	}
 }
 
 func TestTextPrint(t *testing.T) {
 	LogAndAssertText(t, func(log *Logger) {
 		log.Print("test")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test")
-		assert.Equal(t, fields["level"], "info")
+	}, func(e *Entry) {
+		assert.Equal(t, e.Msg, "test", "Entry: %v", e)
+		assert.Equal(t, e.Level, Info)
 	})
 }
 
 func TestTextMultiData(t *testing.T) {
 	LogAndAssertText(t, func(log *Logger) {
 		log.WithField("wow", "pink elephant").WithField("such", "big whale").Print("test with spaces")
-	}, func(fields Fields) {
-		assert.Equal(t, fields["msg"], "test with spaces")
-		assert.Equal(t, fields["level"], "info")
-		assert.Equal(t, fields["wow"], "pink elephant")
-		assert.Equal(t, fields["such"], "big whale")
+	}, func(e *Entry) {
+		assert.Equal(t, e.Msg, "test with spaces", "Entry: %v", e)
+		assert.Equal(t, e.Level, Info)
+		assert.Equal(t, e.Data["wow"], "pink elephant")
+		assert.Equal(t, e.Data["such"], "big whale")
 	})
 }


### PR DESCRIPTION
The first commit (fe381bf) just adds some text_formatter unit tests.

7679f44 changes `Entry` to the structure I discuss in #29 and #30. It removes `msg`, `time`, and `level` from the `Data` map and makes them first-class `Entry` fields. This moves the mapping of level to string entirely into the formatters.

This modifies the default JSON format, causing it to encapsulate additional fields in a `data` sub-object. I believe this is a better JSON format because it doesn't have any magical fields. But it is trivial to implement the previous "flat" JSON in a formatter. Just copy the data map into a new map and merge-in the three magical fields, and marshal that. I'm happy to write a `FlatJSONFormatter` if you think it's useful to anyone.

I also changed the JSON encoding of Warn to "warn" rather than "warning" for consistency. That's trivially reverted in json_formatter.

I've added `Unformat()` methods on the formatters to assist in testing. I haven't added that as part of the `Formatter` interface, however. `Unformat()` may be very inconvenient to write for some formats, and I don't know if it's worth making it mandatory. It's probably worth adding an explicit `Unformatter` interface.

I haven't finished the text unformatter yet; I only handle the colorized case. Testing the other case is a bit of a headache currently because of how it checks for the terminal. It is probably worth reworking ForceColor to an enum (color/plain/auto). The whole auto-detect has a lot of tricky corner cases, anyway. If the log output isn't stdout, then it's not clear what to check. Personally, I'd like color/non-color to be split into separate formatters and let the caller work out what they want.

I'd also recommend that the formatters be moved into sub-packages like the hooks. There's no reason to build all the formatters (and their dependencies, like the JSON encoder) when you're likely to only use one of them. I have a custom formatter package, and don't use any of these. I can make that change if it's acceptable.
