### PR TITLE
Added support to chain withfields

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -38,12 +38,7 @@ func (entry *Entry) String() (string, error) {
 }
 
 func (entry *Entry) WithField(key string, value interface{}) *Entry {
-	data := Fields{}
-	for k, v := range entry.Data {
-		data[k] = v
-	}
-	data[key] = value
-	return &Entry{Logger: entry.Logger, Data: data}
+	return entry.WithFields(Fields{key: value})
 }
 
 func (entry *Entry) WithFields(fields Fields) *Entry {

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -98,3 +98,33 @@ func TestInfoShouldNotAddSpacesBetweenStrings(t *testing.T) {
 		assert.Equal(t, fields["msg"], "testtest")
 	})
 }
+
+func TestWithFieldsShouldAllowAssignments(t *testing.T) {
+	var buffer bytes.Buffer
+	var fields Fields
+
+	logger := New()
+	logger.Out = &buffer
+	logger.Formatter = new(JSONFormatter)
+
+	localLog := logger.WithFields(Fields{
+		"key1": "value1",
+	})
+
+	localLog.WithField("key2", "value2").Info("test")
+	err := json.Unmarshal(buffer.Bytes(), &fields)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "value2", fields["key2"])
+	assert.Equal(t, "value1", fields["key1"])
+
+	buffer = bytes.Buffer{}
+	fields = Fields{}
+	localLog.Info("test")
+	err = json.Unmarshal(buffer.Bytes(), &fields)
+	assert.Nil(t, err)
+
+	_, ok := fields["key2"]
+	assert.Equal(t, false, ok)
+	assert.Equal(t, "value1", fields["key1"])
+}


### PR DESCRIPTION
`WithField` and `WithFields` right now doesn't chain properly. Meaning
that if you do something like:

```
localLog := logger.WithField("tag", "value")
localLog.WithField("v1", "value").Info("message1")
localLog.Info("message2")
```

The `v1` will be carried over to `message2`.

With this patch, each WithField/WithFields call are isolated.
