### PR TITLE
Airbrake error fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ type MyJSONFormatter struct {
 log.SetFormatter(new(MyJSONFormatter))
 
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
-  // Note this doesn't include Time, Level and Message which are available on
+  // Note this doesn't include Time, Level and Args which are available on
   // the Entry. Consult `godoc` on information about those fields or read the
   // source of the official loggers.
   serialized, err := json.Marshal(entry.Data)

--- a/entry.go
+++ b/entry.go
@@ -99,7 +99,7 @@ func (entry *Entry) log(level Level, args ...interface{}) string {
 
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
-		entry.log(DebugLevel, args)
+		entry.log(DebugLevel, args...)
 	}
 }
 
@@ -109,32 +109,32 @@ func (entry *Entry) Print(args ...interface{}) {
 
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.Level >= InfoLevel {
-		entry.log(InfoLevel, args)
+		entry.log(InfoLevel, args...)
 	}
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
 	if entry.Logger.Level >= WarnLevel {
-		entry.log(WarnLevel, args)
+		entry.log(WarnLevel, args...)
 	}
 }
 
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.Level >= ErrorLevel {
-		entry.log(ErrorLevel, args)
+		entry.log(ErrorLevel, args...)
 	}
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
-		entry.log(FatalLevel, args)
+		entry.log(FatalLevel, args...)
 	}
 	os.Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
-		msg := entry.log(PanicLevel, args)
+		msg := entry.log(PanicLevel, args...)
 		panic(msg)
 	}
 	panic(fmt.Sprint(args...))

--- a/entry.go
+++ b/entry.go
@@ -24,8 +24,8 @@ type Entry struct {
 	// Level the log entry was logged at: Debug, Info, Warn, Error, Fatal or Panic
 	Level Level
 
-	// Message passed to Debug, Info, Warn, Error, Fatal or Panic
-	Message string
+	// Arguments passed to Debug, Info, Warn, Error, Fatal or Panic
+	Args []interface{}
 }
 
 var baseTimestamp time.Time
@@ -72,10 +72,10 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	return &Entry{Logger: entry.Logger, Data: data}
 }
 
-func (entry *Entry) log(level Level, msg string) string {
+func (entry *Entry) log(level Level, args ...interface{}) string {
 	entry.Time = time.Now()
 	entry.Level = level
-	entry.Message = msg
+	entry.Args = args
 
 	if err := entry.Logger.Hooks.Fire(level, entry); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fire hook", err)
@@ -99,7 +99,7 @@ func (entry *Entry) log(level Level, msg string) string {
 
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
-		entry.log(DebugLevel, fmt.Sprint(args...))
+		entry.log(DebugLevel, args)
 	}
 }
 
@@ -109,32 +109,32 @@ func (entry *Entry) Print(args ...interface{}) {
 
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.Level >= InfoLevel {
-		entry.log(InfoLevel, fmt.Sprint(args...))
+		entry.log(InfoLevel, args)
 	}
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
 	if entry.Logger.Level >= WarnLevel {
-		entry.log(WarnLevel, fmt.Sprint(args...))
+		entry.log(WarnLevel, args)
 	}
 }
 
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.Level >= ErrorLevel {
-		entry.log(ErrorLevel, fmt.Sprint(args...))
+		entry.log(ErrorLevel, args)
 	}
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
-		entry.log(FatalLevel, fmt.Sprint(args...))
+		entry.log(FatalLevel, args)
 	}
 	os.Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
-		msg := entry.log(PanicLevel, fmt.Sprint(args...))
+		msg := entry.log(PanicLevel, args)
 		panic(msg)
 	}
 	panic(fmt.Sprint(args...))

--- a/formatter.go
+++ b/formatter.go
@@ -44,7 +44,7 @@ func prefixFieldClashes(entry *Entry) {
 		entry.Data["fields.msg"] = entry.Data["msg"]
 	}
 
-	entry.Data["msg"] = fmt.Sprint(entry.Args)
+	entry.Data["msg"] = fmt.Sprint(entry.Args...)
 
 	_, ok = entry.Data["level"]
 	if ok {

--- a/formatter.go
+++ b/formatter.go
@@ -1,13 +1,14 @@
 package logrus
 
 import (
+	"fmt"
 	"time"
 )
 
 // The Formatter interface is used to implement a custom Formatter. It takes an
 // `Entry`. It exposes all the fields, including the default ones:
 //
-// * `entry.Data["msg"]`. The message passed from Info, Warn, Error ..
+// * `entry.Data["args"]`. The arguments passed from Info, Warn, Error ..
 // * `entry.Data["time"]`. The timestamp.
 // * `entry.Data["level"]. The level the entry was logged at.
 //
@@ -43,7 +44,7 @@ func prefixFieldClashes(entry *Entry) {
 		entry.Data["fields.msg"] = entry.Data["msg"]
 	}
 
-	entry.Data["msg"] = entry.Message
+	entry.Data["msg"] = fmt.Sprint(entry.Args)
 
 	_, ok = entry.Data["level"]
 	if ok {

--- a/hooks/airbrake/airbrake.go
+++ b/hooks/airbrake/airbrake.go
@@ -16,11 +16,11 @@ import (
 type AirbrakeHook struct{}
 
 func (hook *AirbrakeHook) Fire(entry *logrus.Entry) error {
-	errVal, ok := entry.Data["error"].(error)
-	if (!ok || errVal == nil) && len(entry.Args >= 1) {
-		errVal, ok = entry.Args[0].(error)
+	err, ok := entry.Data["error"].(error)
+	if (!ok || err == nil) && len(entry.Args) >= 1 {
+		err, ok = entry.Args[0].(error)
 	}
-	if !ok || errVal == nil {
+	if !ok || err == nil {
 		entry.Logger.WithFields(logrus.Fields{
 			"source":   "airbrake",
 			"endpoint": airbrake.Endpoint,

--- a/hooks/airbrake/airbrake.go
+++ b/hooks/airbrake/airbrake.go
@@ -16,20 +16,15 @@ import (
 type AirbrakeHook struct{}
 
 func (hook *AirbrakeHook) Fire(entry *logrus.Entry) error {
-	if entry.Data["error"] == nil {
-		entry.Logger.WithFields(logrus.Fields{
-			"source":   "airbrake",
-			"endpoint": airbrake.Endpoint,
-		}).Warn("Exceptions sent to Airbrake must have an 'error' key with the error")
-		return nil
+	errVal, ok := entry.Data["error"].(error)
+	if (!ok || errVal == nil) && len(entry.Args >= 1) {
+		errVal, ok = entry.Args[0].(error)
 	}
-
-	err, ok := entry.Data["error"].(error)
-	if !ok {
+	if !ok || errVal == nil {
 		entry.Logger.WithFields(logrus.Fields{
 			"source":   "airbrake",
 			"endpoint": airbrake.Endpoint,
-		}).Warn("Exceptions sent to Airbrake must have an `error` key of type `error`")
+		}).Warn("Exceptions sent to Airbrake must have an 'error' key or message of type `error`")
 		return nil
 	}
 


### PR DESCRIPTION
Fallback to `msg` in airbrake hook if:

- no `error` was provided (or it wasn't an `error` type)
- `msg` is an `error` type

For convenience since often `msg` will just contain the anyways.

Also fixes a panic if `error` was not an `error`.