### PR TITLE
added support for setting log level using strings: SetLogLevel()

### DIFF
--- a/logrus.go
+++ b/logrus.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"fmt"
 	"log"
 )
 
@@ -28,6 +29,27 @@ func (level Level) String() string {
 	}
 
 	return "unknown"
+}
+
+func ParseLevel(lvl string) (Level, error) {
+	switch lvl {
+	case "panic":
+		return PanicLevel, nil
+	case "fatal":
+		return FatalLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	case "warn", "warning":
+		return WarnLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "debug", "dbg":
+		return DebugLevel, nil
+	}
+
+	var l Level
+	return l, fmt.Errorf("not a valid logrus Level: %q", lvl)
+
 }
 
 // These are the different logging levels. You can set the logging level to log

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -171,3 +171,40 @@ func TestConvertLevelToString(t *testing.T) {
 	assert.Equal(t, "fatal", FatalLevel.String())
 	assert.Equal(t, "panic", PanicLevel.String())
 }
+
+func TestParseLevel(t *testing.T) {
+	l, err := ParseLevel("panic")
+	assert.Nil(t, err)
+	assert.Equal(t, PanicLevel, l)
+
+	l, err = ParseLevel("fatal")
+	assert.Nil(t, err)
+	assert.Equal(t, FatalLevel, l)
+
+	l, err = ParseLevel("error")
+	assert.Nil(t, err)
+	assert.Equal(t, ErrorLevel, l)
+
+	l, err = ParseLevel("warn")
+	assert.Nil(t, err)
+	assert.Equal(t, WarnLevel, l)
+
+	l, err = ParseLevel("warning")
+	assert.Nil(t, err)
+	assert.Equal(t, WarnLevel, l)
+
+	l, err = ParseLevel("info")
+	assert.Nil(t, err)
+	assert.Equal(t, InfoLevel, l)
+
+	l, err = ParseLevel("debug")
+	assert.Nil(t, err)
+	assert.Equal(t, DebugLevel, l)
+
+	l, err = ParseLevel("dbg")
+	assert.Nil(t, err)
+	assert.Equal(t, DebugLevel, l)
+
+	l, err = ParseLevel("invalid")
+	assert.Equal(t, "not a valid logrus Level: \"invalid\"", err.Error())
+}


### PR DESCRIPTION
A clean pull request for `SetLogLevel(level string)`, which adds setting the loglevel using strings. Makes it easier to set using configuration settings.

"warn" and "dbg" added as alternates to "warning" and "debug", respectively. 

Assumes lowercase.

Test cases added.
