### PR TITLE
hooks: lock on the logger before printing to stderr, printf args

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -76,12 +76,16 @@ func (entry *Entry) log(level Level, msg string) {
 	entry.Message = msg
 
 	if err := entry.Logger.Hooks.Fire(level, entry); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to fire hook\n", err)
+		entry.Logger.mu.Lock()
+		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
+		entry.Logger.mu.Unlock()
 	}
 
 	reader, err := entry.Reader()
 	if err != nil {
+		entry.Logger.mu.Lock()
 		fmt.Fprintf(os.Stderr, "Failed to obtain reader, %v\n", err)
+		entry.Logger.mu.Unlock()
 	}
 
 	entry.Logger.mu.Lock()


### PR DESCRIPTION
Fixes two things:
- Missing printf argument.
- Prevent the logger from possibly mixing it's diagnostic output to stderr with concurrent logging.

r: @Sirupsen 
