### PR TITLE
Add support for saving HostNames to PaperTrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ func main() {
   // exported logger. See Godoc.
   log.Out = os.Stderr
 
-  log.WithFields(logrus.Fields{
+  log.WithFields(log.Fields{
     "animal": "walrus",
     "size":   10,
   }).Info("A group of walrus emerges from the ocean")

--- a/hooks/papertrail/README.md
+++ b/hooks/papertrail/README.md
@@ -21,6 +21,9 @@ func main() {
   log       := logrus.New()
   hook, err := logrus_papertrail.NewPapertrailHook("logs.papertrailapp.com", YOUR_PAPERTRAIL_UDP_PORT, YOUR_APP_NAME)
 
+  // If you want to logrus to send the hostname instead of the IP Address
+  hook.UseHostname()
+
   if err == nil {
     log.Hooks.Add(hook)
   }

--- a/hooks/papertrail/papertrail.go
+++ b/hooks/papertrail/papertrail.go
@@ -42,7 +42,7 @@ func NewPapertrailHook(host string, port int, appName string, useHostname bool) 
 // Fire is called when a log event is fired.
 func (hook *PapertrailHook) Fire(entry *logrus.Entry) error {
 	date := time.Now().Format(format)
-	payload := fmt.Sprintf("<22> %s%s %s: [%s] %s", date, hook.Hostname, hook.AppName, entry.Data["level"], entry.Message)
+	payload := fmt.Sprintf("<22> %s%s %s: [%s] %s", date, hook.Hostname, hook.AppName, entry.Level, entry.Message)
 
 	bytesWritten, err := hook.UDPConn.Write([]byte(payload))
 	if err != nil {

--- a/hooks/papertrail/papertrail.go
+++ b/hooks/papertrail/papertrail.go
@@ -37,7 +37,7 @@ func NewPapertrailHook(host string, port int, appName string) (*PapertrailHook, 
 // Fire is called when a log event is fired.
 func (hook *PapertrailHook) Fire(entry *logrus.Entry) error {
 	date := time.Now().Format(format)
-	payload := fmt.Sprintf("<22> %s%s %s: [%s] %s", date, hook.Hostname, hook.AppName, entry.Level, entry.Message)
+	payload := fmt.Sprintf("<22> %s %s %s: [%s] %s", date, hook.Hostname, hook.AppName, entry.Level, entry.Message)
 
 	bytesWritten, err := hook.UDPConn.Write([]byte(payload))
 	if err != nil {

--- a/hooks/papertrail/papertrail.go
+++ b/hooks/papertrail/papertrail.go
@@ -23,18 +23,8 @@ type PapertrailHook struct {
 }
 
 // NewPapertrailHook creates a hook to be added to an instance of logger.
-func NewPapertrailHook(host string, port int, appName string, useHostname bool) (*PapertrailHook, error) {
 	conn, err := net.Dial("udp", fmt.Sprintf("%s:%d", host, port))
 
-	var hostname string
-	if useHostname {
-		hn, err := os.Hostname()
-		if err == nil {
-			hostname = " " + hn
-		}
-	}
-
-	return &PapertrailHook{host, port, appName, hostname, conn}, err
 }
 
 // Fire is called when a log event is fired.

--- a/hooks/papertrail/papertrail.go
+++ b/hooks/papertrail/papertrail.go
@@ -15,22 +15,34 @@ const (
 
 // PapertrailHook to send logs to a logging service compatible with the Papertrail API.
 type PapertrailHook struct {
-	Host    string
-	Port    int
-	AppName string
-	UDPConn net.Conn
+	Host     string
+	Port     int
+	AppName  string
+	Hostname string
+	UDPConn  net.Conn
 }
 
 // NewPapertrailHook creates a hook to be added to an instance of logger.
-func NewPapertrailHook(host string, port int, appName string) (*PapertrailHook, error) {
+func NewPapertrailHook(host string, port int, appName string, useHostname bool) (*PapertrailHook, error) {
 	conn, err := net.Dial("udp", fmt.Sprintf("%s:%d", host, port))
-	return &PapertrailHook{host, port, appName, conn}, err
+
+	var hostname string
+	if useHostname {
+		hn, err := os.Hostname()
+		if err != nil {
+			hostname = ""
+		} else {
+			hostname = " " + hn
+		}
+	}
+
+	return &PapertrailHook{host, port, appName, hostname, conn}, err
 }
 
 // Fire is called when a log event is fired.
 func (hook *PapertrailHook) Fire(entry *logrus.Entry) error {
 	date := time.Now().Format(format)
-	payload := fmt.Sprintf("<22> %s %s: [%s] %s", date, hook.AppName, entry.Data["level"], entry.Message)
+	payload := fmt.Sprintf("<22> %s%s %s: [%s] %s", date, hook.Hostname, hook.AppName, entry.Data["level"], entry.Message)
 
 	bytesWritten, err := hook.UDPConn.Write([]byte(payload))
 	if err != nil {

--- a/hooks/papertrail/papertrail.go
+++ b/hooks/papertrail/papertrail.go
@@ -29,9 +29,7 @@ func NewPapertrailHook(host string, port int, appName string, useHostname bool) 
 	var hostname string
 	if useHostname {
 		hn, err := os.Hostname()
-		if err != nil {
-			hostname = ""
-		} else {
+		if err == nil {
 			hostname = " " + hn
 		}
 	}

--- a/hooks/papertrail/papertrail.go
+++ b/hooks/papertrail/papertrail.go
@@ -23,8 +23,15 @@ type PapertrailHook struct {
 }
 
 // NewPapertrailHook creates a hook to be added to an instance of logger.
+func NewPapertrailHook(host string, port int, appName string) (*PapertrailHook, error) {
 	conn, err := net.Dial("udp", fmt.Sprintf("%s:%d", host, port))
 
+	return &PapertrailHook{
+		Host:    host,
+		Port:    port,
+		AppName: appName,
+		UDPConn: conn,
+	}, err
 }
 
 // Fire is called when a log event is fired.
@@ -39,6 +46,12 @@ func (hook *PapertrailHook) Fire(entry *logrus.Entry) error {
 	}
 
 	return nil
+}
+
+// UseHostname is called to send the hostname to Papertrail
+// instead of an IP Address
+func (hook *PapertrailHook) UseHostname() {
+	hook.Hostname, _ = os.Hostname()
 }
 
 // Levels returns the available logging levels.

--- a/hooks/papertrail/papertrail_test.go
+++ b/hooks/papertrail/papertrail_test.go
@@ -2,6 +2,7 @@ package logrus_papertrail
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
@@ -12,6 +13,7 @@ func TestWritingToUDP(t *testing.T) {
 	port := 16661
 	udp.SetAddr(fmt.Sprintf(":%d", port))
 
+	hook, err := NewPapertrailHook("localhost", port, "test")
 	if err != nil {
 		t.Errorf("Unable to connect to local UDP server.")
 	}
@@ -22,4 +24,20 @@ func TestWritingToUDP(t *testing.T) {
 	udp.ShouldReceive(t, "foo", func() {
 		log.Info("foo")
 	})
+}
+
+func TestUseHostname(t *testing.T) {
+	port := 16661
+
+	hostname, _ := os.Hostname()
+	udp.SetAddr(fmt.Sprintf(":%d", port))
+
+	hook, err := NewPapertrailHook("localhost", port, "test")
+	if err != nil {
+		t.Errorf("Unable to connect to local UDP server.")
+	}
+	hook.UseHostname()
+	if hook.Hostname != hostname {
+		t.Errorf("Expected %s got %s", hostname, hook.Hostname)
+	}
 }

--- a/hooks/papertrail/papertrail_test.go
+++ b/hooks/papertrail/papertrail_test.go
@@ -12,7 +12,6 @@ func TestWritingToUDP(t *testing.T) {
 	port := 16661
 	udp.SetAddr(fmt.Sprintf(":%d", port))
 
-	hook, err := NewPapertrailHook("localhost", port, "test", true)
 	if err != nil {
 		t.Errorf("Unable to connect to local UDP server.")
 	}

--- a/hooks/papertrail/papertrail_test.go
+++ b/hooks/papertrail/papertrail_test.go
@@ -12,7 +12,7 @@ func TestWritingToUDP(t *testing.T) {
 	port := 16661
 	udp.SetAddr(fmt.Sprintf(":%d", port))
 
-	hook, err := NewPapertrailHook("localhost", port, "test")
+	hook, err := NewPapertrailHook("localhost", port, "test", true)
 	if err != nil {
 		t.Errorf("Unable to connect to local UDP server.")
 	}


### PR DESCRIPTION
Right now logs written to Papertrail use the IP Address of the server its coming from instead of optionally leveraging use of the Hostname. I have added a boolean flag to the `NewPapertrailHook` on whether or not to write logs using the hostname or IP Address.

It is API breaking sadly, but could not think of a cleaner way of implementing it easily.

For those interested here are the changes I have implemented:

Pre:
```Oct 31    10:39:02     54.183.247.158    OurApp:     Configuration file loaded successfully.```

Post:
```Oct 31    11:00:04     ourserver-name    OurApp:     Configuration file loaded successfully.```