### PR TITLE
syslog: let syslog output lookup level directly in Entry struct

### DIFF
--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -29,18 +29,18 @@ func (hook *SyslogHook) Fire(entry *logrus.Entry) error {
 		return err
 	}
 
-	switch entry.Data["level"] {
-	case "panic":
+	switch entry.Level {
+	case logrus.PanicLevel:
 		return hook.Writer.Crit(line)
-	case "fatal":
+	case logrus.FatalLevel:
 		return hook.Writer.Crit(line)
-	case "error":
+	case logrus.ErrorLevel:
 		return hook.Writer.Err(line)
-	case "warn":
+	case logrus.WarnLevel:
 		return hook.Writer.Warning(line)
-	case "info":
+	case logrus.InfoLevel:
 		return hook.Writer.Info(line)
-	case "debug":
+	case logrus.DebugLevel:
 		return hook.Writer.Debug(line)
 	default:
 		return nil


### PR DESCRIPTION
Log level has moved from `entry.Data["level"]` to `entry.Level`. Use
that to get the right level.

Fix: #82
