### PR TITLE
documentation fix

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -38,7 +38,7 @@ type Logger struct {
 //      Out: os.Stderr,
 //      Formatter: new(JSONFormatter),
 //      Hooks: make(levelHooks),
-//      Level: logrus.Debug,
+//      Level: logrus.DebugLevel,
 //    }
 //
 // It's recommended to make this a global instance called `log`.


### PR DESCRIPTION
Little documentation fix (the example code was not compiling before).
I'll take this as a chance to ask you: Why is `levelHooks` private?

If I try to implement your example in a package that is not in logrus this does not work:

``` go
l := &logrus.Logger{
    Out: os.Stderr,
    Formatter: new(JSONFormatter),
    Hooks: make(levelHooks), // it does not compile because levelHooks is private
    Level: logrus.DebugLevel,
}
```
