### PR TITLE
Allow disabling timestamp in non-tty output.

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -32,8 +32,10 @@ func miniTS() int {
 
 type TextFormatter struct {
 	// Set to true to bypass checking for a TTY before outputting colors.
-	ForceColors      bool
-	DisableColors    bool
+	ForceColors   bool
+	DisableColors bool
+	// Set to true to disable timestamp logging (useful when the output
+	// is redirected to a logging system already adding a timestamp)
 	DisableTimestamp bool
 }
 


### PR DESCRIPTION
This is useful if the output is already being piped to a logger
daemon that will prefix the timestamp by itself (eg: on heroku).
