### PR TITLE
make sure no trailing spaces

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -107,18 +107,16 @@ func needsQuoting(text string) bool {
 func printKeyValue(b *bytes.Buffer, key, value interface{}) {
 	switch value.(type) {
 	case string:
-		if needsQuoting(value.(string)) {
-			fmt.Fprintf(b, "%v=%s ", key, value)
-		} else {
-			fmt.Fprintf(b, "%v=%q ", key, value)
-		}
+		break
 	case error:
-		if needsQuoting(value.(error).Error()) {
-			fmt.Fprintf(b, "%v=%s ", key, value)
-		} else {
-			fmt.Fprintf(b, "%v=%q ", key, value)
-		}
+		value = value.(error).Error()
 	default:
 		fmt.Fprintf(b, "%v=%v ", key, value)
+	}
+
+	if needsQuoting(value.(string)) {
+		fmt.Fprintf(b, "%v=%s ", key, value)
+	} else {
+		fmt.Fprintf(b, "%v=%q ", key, value)
 	}
 }

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -59,12 +59,12 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		printColored(b, entry, keys)
 	} else {
 		if !f.DisableTimestamp {
-			f.appendKeyValue(b, "time", entry.Time.Format(time.RFC3339))
+			printKeyValue(b, "time", entry.Time.Format(time.RFC3339))
 		}
-		f.appendKeyValue(b, "level", entry.Level.String())
-		f.appendKeyValue(b, "msg", entry.Message)
+		printKeyValue(b, "level", entry.Level.String())
+		printKeyValue(b, "msg", entry.Message)
 		for _, key := range keys {
-			f.appendKeyValue(b, key, entry.Data[key])
+			printKeyValue(b, key, entry.Data[key])
 		}
 	}
 
@@ -104,7 +104,7 @@ func needsQuoting(text string) bool {
 	return true
 }
 
-func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key, value interface{}) {
+func printKeyValue(b *bytes.Buffer, key, value interface{}) {
 	switch value.(type) {
 	case string:
 		if needsQuoting(value.(string)) {

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -69,7 +69,7 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	}
 
 	b.WriteByte('\n')
-	return b.Bytes(), nil
+	return b.Bytes()[1:], nil
 }
 
 func printColored(b *bytes.Buffer, entry *Entry, keys []string) {
@@ -85,7 +85,7 @@ func printColored(b *bytes.Buffer, entry *Entry, keys []string) {
 
 	levelText := strings.ToUpper(entry.Level.String())[0:4]
 
-	fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, miniTS(), entry.Message)
+	fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m[%04d] %-44s", levelColor, levelText, miniTS(), entry.Message)
 	for _, k := range keys {
 		v := entry.Data[k]
 		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%v", levelColor, k, v)
@@ -111,12 +111,12 @@ func printKeyValue(b *bytes.Buffer, key, value interface{}) {
 	case error:
 		value = value.(error).Error()
 	default:
-		fmt.Fprintf(b, "%v=%v ", key, value)
+		fmt.Fprintf(b, " %v=%v", key, value)
 	}
 
 	if needsQuoting(value.(string)) {
-		fmt.Fprintf(b, "%v=%s ", key, value)
+		fmt.Fprintf(b, " %v=%s", key, value)
 	} else {
-		fmt.Fprintf(b, "%v=%q ", key, value)
+		fmt.Fprintf(b, " %v=%q", key, value)
 	}
 }

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -31,3 +31,30 @@ func TestQuoting(t *testing.T) {
 	checkQuoting(false, errors.New("invalid"))
 	checkQuoting(true, errors.New("invalid argument"))
 }
+
+func TestTextPrint(t *testing.T) {
+	tf := &TextFormatter{DisableColors: true}
+	byts, _ := tf.Format(&Entry{Message: "msg content"})
+
+	// make sure no leading or trailing spaces
+	if string(byts) !=
+		"time=\"0001-01-01T00:00:00Z\" level=panic msg=\"msg content\"\n" {
+		t.Errorf("not expected: %q", string(byts))
+	}
+}
+
+func TestColorPrint(t *testing.T) {
+	tf := &TextFormatter{ForceColors: true}
+	entry := WithField("testkey", "value")
+	entry.Message = "msg content"
+	byts, _ := tf.Format(entry)
+
+	// make sure no leading or trailing spaces
+	if string(byts) !=
+		"\x1b[31mPANI\x1b[0m[0000] " +
+			// length 44 plus one space
+			"msg content                                  " +
+			"\x1b[31mtestkey\x1b[0m=value\n" {
+		t.Errorf("not expected: %q", string(byts))
+	}
+}


### PR DESCRIPTION
Closes #99 text log should not have trailing spaces.

just reorganize the patch into 3 commits:
03377c6 rename f.appendKeyValue to printKeyValue
a243bba share common calling path in printKeyValue
dcbe8d6 make sure no leading or trailing spaces

In benchmark testing, it increased ~300 ns/op in SmallTextFormatter,
that should be due to the extra slice operation [1:];
in LargeTextFormatter it reduced ~700 ns/op;

```text
BenchmarkSmallTextFormatter       200000             10683 ns/op           8.14 MB/s
BenchmarkLargeTextFormatter        30000             43537 ns/op           6.59 MB/s
```

```text
BenchmarkSmallTextFormatter       200000             10996 ns/op           7.82 MB/s
BenchmarkLargeTextFormatter        30000             42862 ns/op           6.67 MB/s
```

Signed-off-by: Derek Che <drc@yahoo-inc.com>