### PR TITLE
Better API to prevent unnecessary argument evaluation

### DIFF
--- a/exported.go
+++ b/exported.go
@@ -39,6 +39,93 @@ func GetLevel() Level {
 	return std.Level
 }
 
+// Reports whether log level is at least debug level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+// when the log level isn't at least debug.
+func IsDebug() bool {
+	return std.Level >= DebugLevel
+}
+
+// Reports whether log level is at least info level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+// when the log level isn't at least debug.
+func IsInfo() bool {
+	return std.Level >= InfoLevel
+}
+
+// Reports whether log level is at least warning level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+// when the log level isn't at least debug.
+func IsWarn() bool {
+	return std.Level >= WarnLevel
+}
+
+// Reports whether log level is at least error level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+func IsError() bool {
+	return std.Level >= ErrorLevel
+}
+
+// Reports whether log level is at least fatal level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+func IsFatal() bool {
+	return std.Level >= FatalLevel
+}
+
+// Reports whether log level is at least panic level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+func IsPanic() bool {
+	return std.Level >= PanicLevel
+}
+
 // AddHook adds a hook to the standard logger hooks.
 func AddHook(hook Hook) {
 	std.mu.Lock()

--- a/logger.go
+++ b/logger.go
@@ -51,6 +51,93 @@ func New() *Logger {
 	}
 }
 
+// Reports whether log level is at least debug level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+// when the log level isn't at least debug.
+func (logger *Logger) IsDebug() bool {
+	return logger.Level >= DebugLevel
+}
+
+// Reports whether log level is at least info level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+// when the log level isn't at least debug.
+func (logger *Logger) IsInfo() bool {
+	return logger.Level >= InfoLevel
+}
+
+// Reports whether log level is at least warning level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+// when the log level isn't at least debug.
+func (logger *Logger) IsWarn() bool {
+	return logger.Level >= WarnLevel
+}
+
+// Reports whether log level is at least error level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+func (logger *Logger) IsError() bool {
+	return logger.Level >= ErrorLevel
+}
+
+// Reports whether log level is at least fatal level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+func (logger *Logger) IsFatal() bool {
+	return logger.Level >= FatalLevel
+}
+
+// Reports whether log level is at least panic level.
+//
+// This method can be used to prevent evaluation of arguments if
+// the log level isn't high enough:
+//
+//      if log.IsDebug() {
+//           log.Debugf("π = %v", calculatePi())
+//      }
+//
+// In this case the method `calculatePi` will not be evaluated
+func (logger *Logger) IsPanic() bool {
+	return logger.Level >= PanicLevel
+}
+
 // Adds a field to the log entry, note that you it doesn't log until you call
 // Debug, Print, Info, Warn, Fatal or Panic. It only creates a log entry.
 // Ff you want multiple fields, use `WithFields`.

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -208,6 +208,61 @@ func TestDefaultFieldsAreNotPrefixed(t *testing.T) {
 	})
 }
 
+func TestDebugLevel(t *testing.T) {
+	log := New()
+	log.Level = DebugLevel
+
+	assert.True(t, log.IsDebug())
+	assert.True(t, log.IsInfo())
+	assert.True(t, log.IsWarn())
+	assert.True(t, log.IsError())
+	assert.True(t, log.IsPanic())
+}
+
+func TestInfoLevel(t *testing.T) {
+	log := New()
+	log.Level = InfoLevel
+
+	assert.False(t, log.IsDebug())
+	assert.True(t, log.IsInfo())
+	assert.True(t, log.IsWarn())
+	assert.True(t, log.IsError())
+	assert.True(t, log.IsPanic())
+}
+
+func TestWarnLevel(t *testing.T) {
+	log := New()
+	log.Level = WarnLevel
+
+	assert.False(t, log.IsDebug())
+	assert.False(t, log.IsInfo())
+	assert.True(t, log.IsWarn())
+	assert.True(t, log.IsError())
+	assert.True(t, log.IsPanic())
+}
+
+func TestErrorLevel(t *testing.T) {
+	log := New()
+	log.Level = ErrorLevel
+
+	assert.False(t, log.IsDebug())
+	assert.False(t, log.IsInfo())
+	assert.False(t, log.IsWarn())
+	assert.True(t, log.IsError())
+	assert.True(t, log.IsPanic())
+}
+
+func TestPanicLevel(t *testing.T) {
+	log := New()
+	log.Level = PanicLevel
+
+	assert.False(t, log.IsDebug())
+	assert.False(t, log.IsInfo())
+	assert.False(t, log.IsWarn())
+	assert.False(t, log.IsError())
+	assert.True(t, log.IsPanic())
+}
+
 func TestDoubleLoggingDoesntPrefixPreviousFields(t *testing.T) {
 
 	var buffer bytes.Buffer


### PR DESCRIPTION
I always loved the idea of structured logging, and when I stumbled upon logrus last week I decided to improve some of our logging code. But while migrating from `glog` to `logrus` I discovered that it lacks an good API to check the current log level to prevent unnecessary argument evaluation.
## Current state

``` go
log.Debugf("π: %v", calculate_pi())
```

In this example if the current log level is above debug, the message will not be logged. That is great, but this decision is made inside the `Debug` function. This means that  arguments are evaluated and the `calculate_pi` method will be executed for no good reason.

This can easily be fixed with an `if` statement:

``` go
if log.GetLevel() >= log.DebugLevel {
    log.Debugf("π: %v", calculate_pi())
}
```

But too be honest, I don't really like that API for the following reasons:
1. Inconsistent: direct package api has `GetLevel()` while `logger` instance has `Level` member.
2. Doesn't hide the way log levels are compared.
## My API proposal

I added `IsDebug`, `IsInfo`, `IsWarn`, `IsFatal` and `IsPanic` as static functions in `exported.go` and as methods to the `Logger` type in `logger.go`.

Here is how code that uses my changes is looks like:

``` go
if log.IsDebug() {
    log.Debugf("π: %v", calculate_pi())
}
```
## Tests

I've added tests to proof the methods are returning the right answer depending on the current log level. These can be found in `logrus_test.go`.
