### PR TITLE
[Race] Fix datarace in GetLevel

### DIFF
--- a/exported.go
+++ b/exported.go
@@ -36,6 +36,8 @@ func SetLevel(level Level) {
 
 // GetLevel returns the standard logger level.
 func GetLevel() Level {
+	std.mu.Lock()
+	defer std.mu.Unlock()
 	return std.Level
 }
 

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -280,4 +281,21 @@ func TestParseLevel(t *testing.T) {
 
 	l, err = ParseLevel("invalid")
 	assert.Equal(t, "not a valid logrus Level: \"invalid\"", err.Error())
+}
+
+func TestGetSetLevelRace(t *testing.T) {
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				SetLevel(InfoLevel)
+			} else {
+				GetLevel()
+			}
+		}(i)
+
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
`std.Level` is protected by mutex in setter (SetLevel), so it must be protected in geetter (GetLevel) too.

``` 
go test -v -race github.com/Sirupsen/logrus
=== RUN TestGetSetLevelRace
==================
WARNING: DATA RACE
Read by goroutine 32:
  github.com/Sirupsen/logrus.func·041()
      /Users/noxiouz/Go/src/github.com/Sirupsen/logrus/logrus_test.go:291 +0x7c

Previous write by goroutine 31:
  github.com/Sirupsen/logrus.SetLevel()
      /Users/noxiouz/Go/src/github.com/Sirupsen/logrus/exported.go:34 +0xba
  github.com/Sirupsen/logrus.func·041()
      /Users/noxiouz/Go/src/github.com/Sirupsen/logrus/logrus_test.go:289 +0x4c

Goroutine 32 (running) created at:
  github.com/Sirupsen/logrus.TestGetSetLevelRace()
      /Users/noxiouz/Go/src/github.com/Sirupsen/logrus/logrus_test.go:293 +0x48
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Goroutine 31 (finished) created at:
  github.com/Sirupsen/logrus.TestGetSetLevelRace()
      /Users/noxiouz/Go/src/github.com/Sirupsen/logrus/logrus_test.go:293 +0x48
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133
==================
```