### PR TITLE
[Race] Fix datarace in GetLevel using atomics

### DIFF
--- a/exported.go
+++ b/exported.go
@@ -2,6 +2,7 @@ package logrus
 
 import (
 	"io"
+	"sync/atomic"
 )
 
 var (
@@ -29,14 +30,12 @@ func SetFormatter(formatter Formatter) {
 
 // SetLevel sets the standard logger level.
 func SetLevel(level Level) {
-	std.mu.Lock()
-	defer std.mu.Unlock()
-	std.Level = level
+	atomic.StoreUint32((*uint32)(&std.Level), uint32(level))
 }
 
 // GetLevel returns the standard logger level.
 func GetLevel() Level {
-	return std.Level
+	return Level(atomic.LoadUint32((*uint32)(&std.Level)))
 }
 
 // AddHook adds a hook to the standard logger hooks.

--- a/logrus.go
+++ b/logrus.go
@@ -9,7 +9,7 @@ import (
 type Fields map[string]interface{}
 
 // Level type
-type Level uint8
+type Level uint32
 
 // Convert the Level to a string. E.g. PanicLevel becomes "panic".
 func (level Level) String() string {


### PR DESCRIPTION
Use atomics to operate with `std.Level` to prevent datarace #127 and to speedup access. 
```
with mutex
BenchmarkGetlevelConcurrent	   50000	     33696 ns/op
BenchmarkGetlevel	10000000	       112 ns/op

with atomics
BenchmarkGetlevelConcurrent	  100000	     22216 ns/op
BenchmarkGetlevel	500000000	         3.58 ns/op
```

Signed-off-by: Anton Tiurin <noxiouz@yandex.ru>