### PR TITLE
[TextFormatter] Preallocate enough memory for keys to speedup

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -43,7 +43,7 @@ type TextFormatter struct {
 
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 
-	var keys []string
+	var keys []string = make([]string, 0, len(entry.Data))
 	for k := range entry.Data {
 		keys = append(keys, k)
 	}


### PR DESCRIPTION
Benchmarks:
 * BenchmarkSmallTextFormatter: 6140/5943 ~3%
 * BenchmarkLargeTextFormatter: 28050/24789 ~11%

Signed-off-by: Anton Tiurin <noxiouz@yandex.ru>