### PR TITLE
Change DebugLevel color to gray

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -15,6 +15,7 @@ const (
 	green   = 32
 	yellow  = 33
 	blue    = 34
+	gray    = 37
 )
 
 var (
@@ -75,6 +76,8 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 func printColored(b *bytes.Buffer, entry *Entry, keys []string) {
 	var levelColor int
 	switch entry.Level {
+	case DebugLevel:
+		levelColor = gray
 	case WarnLevel:
 		levelColor = yellow
 	case ErrorLevel, FatalLevel, PanicLevel:


### PR DESCRIPTION
This is highly subjective but we have an application that spits lots and lots of debug output and demoting it to be nearly "colorless" helps us to visually distinguish it from interesting output.