### PR TITLE
Text formatter: Do not quote 9

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -96,7 +96,7 @@ func needsQuoting(text string) bool {
 	for _, ch := range text {
 		if !((ch >= 'a' && ch <= 'z') ||
 			(ch >= 'A' && ch <= 'Z') ||
-			(ch >= '0' && ch < '9') ||
+			(ch >= '0' && ch <= '9') ||
 			ch == '-' || ch == '.') {
 			return false
 		}

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -25,6 +25,7 @@ func TestQuoting(t *testing.T) {
 
 	checkQuoting(false, "abcd")
 	checkQuoting(false, "v1.0")
+	checkQuoting(false, "1234567890")
 	checkQuoting(true, "/foobar")
 	checkQuoting(true, "x y")
 	checkQuoting(true, "x,y")


### PR DESCRIPTION
I noticed that some UUIDs in our logs were quoted and some weren't, and tracked that down to whether the number 9 was included or not. It seems this was a bug in the conversion from a regexp to an if-statement in 15b296befc8fa20d93c34f6ca2ba934444d27749, so I changed the code to not quote 9s.