### PR TITLE
[#76800642] Add a new Airbrake hook

### DIFF
--- a/hooks/airbrake2/airbrake.go
+++ b/hooks/airbrake2/airbrake.go
@@ -1,0 +1,46 @@
+package airbrake
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/tobi/airbrake-go"
+)
+
+// AirbrakeHook to send exceptions to an exception-tracking service compatible
+// with the Airbrake API.
+type airbrakeHook struct {
+	APIKey      string
+	Endpoint    string
+	Environment string
+}
+
+func NewHook(endpoint, apiKey, env string) *airbrakeHook {
+	return &airbrakeHook{
+		APIKey:      apiKey,
+		Endpoint:    endpoint,
+		Environment: env,
+	}
+}
+
+func (hook *airbrakeHook) Fire(entry *logrus.Entry) error {
+	airbrake.ApiKey = hook.APIKey
+	airbrake.Endpoint = hook.Endpoint
+	airbrake.Environment = hook.Environment
+
+	airErr := airbrake.Notify(errors.New(entry.Message))
+	if airErr != nil {
+		return fmt.Errorf("Failed to send error to Airbrake: %s", airErr)
+	}
+
+	return nil
+}
+
+func (hook *airbrakeHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
+}

--- a/hooks/airbrake2/airbrake_test.go
+++ b/hooks/airbrake2/airbrake_test.go
@@ -1,0 +1,48 @@
+package airbrake
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type notice struct {
+	Error struct {
+		Message string `xml:"message"`
+	} `xml:"error"`
+}
+
+func TestNoticeReceived(t *testing.T) {
+	msg := make(chan string, 1)
+	expectedMsg := "foo"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var notice notice
+		if err := xml.NewDecoder(r.Body).Decode(&notice); err != nil {
+			t.Error(err)
+		}
+		r.Body.Close()
+
+		msg <- notice.Error.Message
+	}))
+	defer ts.Close()
+
+	hook := NewHook(ts.URL, "foo", "production")
+
+	log := logrus.New()
+	log.Hooks.Add(hook)
+	log.Error(expectedMsg)
+
+	select {
+	case received := <-msg:
+		if received != expectedMsg {
+			t.Errorf("Unexpected message received: %s", received)
+		}
+	case <-time.After(time.Second):
+		t.Error("Timed out; no notice received by Airbrake API")
+	}
+}


### PR DESCRIPTION
Add a new Airbrake hook in `hooks/airbrake2` which addresses some
frustrations I had with the existing Airbrake hook, namely;

- log entries had to include an 'error' field containing an error type,
  which was redundant if you just want to send your log entry messages
  to Airbrake

- credentials and endpoint settings were not scoped to the hook; this
  new hook needs to be invoked using `NewAirbrakeHook`. For example:

        log.Hooks.Add(airbrake.NewHook("https//endpoint.example.com", "api-key-xyz", "production"))

I chose to write a new hook as I couldn't implement the desired
behaviour without making backwards-incompatible changes to the original
hook.

Limitations:

- This hook blocks when sending Airbrake notifications, like the
original.

- Logrus fields are not sent to Airbrake.

Includes a integration simple test to ensure that messages are being
received as part of an XML payload as expected at the specified
endpoint.