### PR TITLE
Remove misleading comment in Airbrake hook

### DIFF
--- a/hooks/airbrake/airbrake.go
+++ b/hooks/airbrake/airbrake.go
@@ -9,7 +9,7 @@ import (
 // with the Airbrake API. You must set:
 // * airbrake.Endpoint
 // * airbrake.ApiKey
-// * airbrake.Environment (only sends exceptions when set to "production")
+// * airbrake.Environment
 //
 // Before using this hook, to send an error. Entries that trigger an Error,
 // Fatal or Panic should now include an "error" field to send to Airbrake.


### PR DESCRIPTION
As far as I can tell, exceptions are always sent regardless of what
`airbrake.Environment` is set to.