### PR TITLE
improved: move level check from entry to logger and bail out faster

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -65,11 +65,15 @@ func (logger *Logger) WithFields(fields Fields) *Entry {
 }
 
 func (logger *Logger) Debugf(format string, args ...interface{}) {
-	NewEntry(logger).Debugf(format, args...)
+	if logger.Level >= DebugLevel {
+		NewEntry(logger).Debugf(format, args...)
+	}
 }
 
 func (logger *Logger) Infof(format string, args ...interface{}) {
-	NewEntry(logger).Infof(format, args...)
+	if logger.Level >= InfoLevel {
+		NewEntry(logger).Infof(format, args...)
+	}
 }
 
 func (logger *Logger) Printf(format string, args ...interface{}) {
@@ -77,31 +81,45 @@ func (logger *Logger) Printf(format string, args ...interface{}) {
 }
 
 func (logger *Logger) Warnf(format string, args ...interface{}) {
-	NewEntry(logger).Warnf(format, args...)
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warnf(format, args...)
+	}
 }
 
 func (logger *Logger) Warningf(format string, args ...interface{}) {
-	NewEntry(logger).Warnf(format, args...)
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warnf(format, args...)
+	}
 }
 
 func (logger *Logger) Errorf(format string, args ...interface{}) {
-	NewEntry(logger).Errorf(format, args...)
+	if logger.Level >= ErrorLevel {
+		NewEntry(logger).Errorf(format, args...)
+	}
 }
 
 func (logger *Logger) Fatalf(format string, args ...interface{}) {
-	NewEntry(logger).Fatalf(format, args...)
+	if logger.Level >= FatalLevel {
+		NewEntry(logger).Fatalf(format, args...)
+	}
 }
 
 func (logger *Logger) Panicf(format string, args ...interface{}) {
-	NewEntry(logger).Panicf(format, args...)
+	if logger.Level >= PanicLevel {
+		NewEntry(logger).Panicf(format, args...)
+	}
 }
 
 func (logger *Logger) Debug(args ...interface{}) {
-	NewEntry(logger).Debug(args...)
+	if logger.Level >= DebugLevel {
+		NewEntry(logger).Debug(args...)
+	}
 }
 
 func (logger *Logger) Info(args ...interface{}) {
-	NewEntry(logger).Info(args...)
+	if logger.Level >= InfoLevel {
+		NewEntry(logger).Info(args...)
+	}
 }
 
 func (logger *Logger) Print(args ...interface{}) {
@@ -109,31 +127,45 @@ func (logger *Logger) Print(args ...interface{}) {
 }
 
 func (logger *Logger) Warn(args ...interface{}) {
-	NewEntry(logger).Warn(args...)
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warn(args...)
+	}
 }
 
 func (logger *Logger) Warning(args ...interface{}) {
-	NewEntry(logger).Warn(args...)
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warn(args...)
+	}
 }
 
 func (logger *Logger) Error(args ...interface{}) {
-	NewEntry(logger).Error(args...)
+	if logger.Level >= ErrorLevel {
+		NewEntry(logger).Error(args...)
+	}
 }
 
 func (logger *Logger) Fatal(args ...interface{}) {
-	NewEntry(logger).Fatal(args...)
+	if logger.Level >= FatalLevel {
+		NewEntry(logger).Fatal(args...)
+	}
 }
 
 func (logger *Logger) Panic(args ...interface{}) {
-	NewEntry(logger).Panic(args...)
+	if logger.Level >= PanicLevel {
+		NewEntry(logger).Panic(args...)
+	}
 }
 
 func (logger *Logger) Debugln(args ...interface{}) {
-	NewEntry(logger).Debugln(args...)
+	if logger.Level >= DebugLevel {
+		NewEntry(logger).Debugln(args...)
+	}
 }
 
 func (logger *Logger) Infoln(args ...interface{}) {
-	NewEntry(logger).Infoln(args...)
+	if logger.Level >= InfoLevel {
+		NewEntry(logger).Infoln(args...)
+	}
 }
 
 func (logger *Logger) Println(args ...interface{}) {
@@ -141,21 +173,31 @@ func (logger *Logger) Println(args ...interface{}) {
 }
 
 func (logger *Logger) Warnln(args ...interface{}) {
-	NewEntry(logger).Warnln(args...)
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warnln(args...)
+	}
 }
 
 func (logger *Logger) Warningln(args ...interface{}) {
-	NewEntry(logger).Warnln(args...)
+	if logger.Level >= WarnLevel {
+		NewEntry(logger).Warnln(args...)
+	}
 }
 
 func (logger *Logger) Errorln(args ...interface{}) {
-	NewEntry(logger).Errorln(args...)
+	if logger.Level >= ErrorLevel {
+		NewEntry(logger).Errorln(args...)
+	}
 }
 
 func (logger *Logger) Fatalln(args ...interface{}) {
-	NewEntry(logger).Fatalln(args...)
+	if logger.Level >= FatalLevel {
+		NewEntry(logger).Fatalln(args...)
+	}
 }
 
 func (logger *Logger) Panicln(args ...interface{}) {
-	NewEntry(logger).Panicln(args...)
+	if logger.Level >= PanicLevel {
+		NewEntry(logger).Panicln(args...)
+	}
 }


### PR DESCRIPTION
Hi there.

Thank you for logrus, it's a wonderful logger.
I was benchmarking loggers, as mentioned in https://github.com/imkira/go-loggers-bench
and I found I could make logrus bail-out faster (but more importantly, lesser allocations) when the baseline log-level is higher than the level being logged.
This is a modest attempt to improve it.

I didn't do it in this PR, but I also tried to do the same with WithFields, but given the current API it is very difficult to do it.
My idea was to invert

log.WithFields(...).Info(...)

and allow something like:

log.Info(...).WithFields(...)

or alternatively something like

log.WithLevel(Info).WithFields(...).Log(...)

Using this kind of API it would be possible to return "blackhole" entries/loggers when the level does not satisfy the level condition.
What do you think of it?