### PR TITLE
Allow configuration of timestamp layout

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -1,5 +1,9 @@
 package logrus
 
+import "time"
+
+const DefaultTimestampFormat = time.RFC3339
+
 // The Formatter interface is used to implement a custom Formatter. It takes an
 // `Entry`. It exposes all the fields, including the default ones:
 //

--- a/formatters/logstash/logstash.go
+++ b/formatters/logstash/logstash.go
@@ -3,19 +3,27 @@ package logstash
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
-	"time"
 )
 
 // Formatter generates json in logstash format.
 // Logstash site: http://logstash.net/
 type LogstashFormatter struct {
 	Type string // if not empty use for logstash type field.
+
+	// TimestampFormat sets the format used for timestamps.
+	TimestampFormat string
 }
 
 func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	entry.Data["@version"] = 1
-	entry.Data["@timestamp"] = entry.Time.Format(time.RFC3339)
+
+	if f.TimestampFormat == "" {
+		f.TimestampFormat = logrus.DefaultTimestampFormat
+	}
+
+	entry.Data["@timestamp"] = entry.Time.Format(f.TimestampFormat)
 
 	// set message field
 	v, ok := entry.Data["message"]

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -3,10 +3,12 @@ package logrus
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 )
 
-type JSONFormatter struct{}
+type JSONFormatter struct {
+	// TimestampFormat sets the format used for marshaling timestamps.
+	TimestampFormat string
+}
 
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	data := make(Fields, len(entry.Data)+3)
@@ -21,7 +23,12 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		}
 	}
 	prefixFieldClashes(data)
-	data["time"] = entry.Time.Format(time.RFC3339)
+
+	if f.TimestampFormat == "" {
+		f.TimestampFormat = DefaultTimestampFormat
+	}
+
+	data["time"] = entry.Time.Format(f.TimestampFormat)
 	data["msg"] = entry.Message
 	data["level"] = entry.Level.String()
 

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -18,9 +18,8 @@ const (
 )
 
 var (
-	baseTimestamp          time.Time
-	isTerminal             bool
-	defaultTimestampFormat = time.RFC3339
+	baseTimestamp time.Time
+	isTerminal    bool
 )
 
 func init() {
@@ -47,7 +46,7 @@ type TextFormatter struct {
 	// the time passed since beginning of execution.
 	FullTimestamp bool
 
-	// Timestamp format to use for display, if a full timestamp is printed
+	// TimestampFormat to use for display when a full timestamp is printed
 	TimestampFormat string
 
 	// The fields are sorted by default for a consistent output. For applications
@@ -73,7 +72,7 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	isColored := (f.ForceColors || isTerminal) && !f.DisableColors
 
 	if f.TimestampFormat == "" {
-		f.TimestampFormat = defaultTimestampFormat
+		f.TimestampFormat = DefaultTimestampFormat
 	}
 	if isColored {
 		f.printColored(b, entry, keys)


### PR DESCRIPTION
This just allows one to configure the timestamp layout and defaults to using `time.RFC3339Nano` by default.

Closes #161.

Signed-off-by: Stephen J Day <stephen.day@docker.com>