### PR TITLE
assertify changed behavior and consider float64 != int

### DIFF
--- a/logrus_test.go
+++ b/logrus_test.go
@@ -191,7 +191,7 @@ func TestUserSuppliedLevelFieldHasPrefix(t *testing.T) {
 		log.WithField("level", 1).Info("test")
 	}, func(fields Fields) {
 		assert.Equal(t, fields["level"], "info")
-		assert.Equal(t, fields["fields.level"], 1)
+		assert.Equal(t, fields["fields.level"], 1.0) // JSON has floats only
 	})
 }
 


### PR DESCRIPTION
@Sirupsen all the tests and PRs are broken because of this. ima merge right away since it's just a fix to the tests