### PR TITLE
Added special field for *http.Request to Sentry hook

### DIFF
--- a/hooks/sentry/README.md
+++ b/hooks/sentry/README.md
@@ -34,12 +34,13 @@ func main() {
 ## Special fields
 
 Some logrus fields have a special meaning in this hook,
-these are server_name and logger.
+these are `server_name`, `logger` and `http_request`.
 When logs are sent to sentry these fields are treated differently.
-- server_name (also known as hostname) is the name of the server which
+- `server_name` (also known as hostname) is the name of the server which
 is logging the event (hostname.example.com)
-- logger is the part of the application which is logging the event.
+- `logger` is the part of the application which is logging the event.
 In go this usually means setting it to the name of the package.
+- `http_request` is the in-coming request(*http.Request). The detailed request data are sent to Sentry.
 
 ## Timeout
 

--- a/hooks/sentry/sentry_test.go
+++ b/hooks/sentry/sentry_test.go
@@ -61,9 +61,12 @@ func TestSpecialFields(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 		logger.Hooks.Add(hook)
+
+		req, _ := http.NewRequest("GET", "url", nil)
 		logger.WithFields(logrus.Fields{
-			"server_name": server_name,
-			"logger":      logger_name,
+			"server_name":  server_name,
+			"logger":       logger_name,
+			"http_request": req,
 		}).Error(message)
 
 		packet := <-pch


### PR DESCRIPTION
This PR will attempt to add a special field for http.Request, and send detailed request information.
(see: http://sentry.readthedocs.org/en/latest/developer/interfaces/index.html#sentry.interfaces.http.Http)

When add *http.Request to `http_request` field of logrus data, request information is set to the data.
