### PR TITLE
Fix Fatalf() and Fataln() to exit irrespective of log level

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -188,6 +188,7 @@ func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.Fatal(fmt.Sprintf(format, args...))
 	}
+	os.Exit(1)
 }
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
@@ -234,6 +235,7 @@ func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.Fatal(entry.sprintlnn(args...))
 	}
+	os.Exit(1)
 }
 
 func (entry *Entry) Panicln(args ...interface{}) {


### PR DESCRIPTION
Fixing Fatalf() and Fataln() to behave similar to Fatal() based on discussion in #186 