### PR TITLE
Update Sentry hook to allow capture of stacktraces at set Logrus Level

### DIFF
--- a/hooks/sentry/README.md
+++ b/hooks/sentry/README.md
@@ -68,7 +68,14 @@ with:
 
 ```go
 hook, _ := logrus_sentry.NewSentryHook(...)
-hook.SetStacktraceLevel(logrus.ErrorLevel)
+hook.StacktraceConfiguration.Enable = true
 ```
 
 Subsequent calls to `logger.Error` and above will create a stacktrace.
+
+Other configuration options are:
+- `StacktraceConfiguration.Level` the logrus level at which to start capturing stacktraces.
+- `StacktraceConfiguration.Skip` how many stack frames to skip before stacktrace starts recording.
+- `StacktraceConfiguration.Context` the number of lines to include around a stack frame for context.
+- `StacktraceConfiguration.InAppPrefixes` the prefixes that will be matched against the stack frame to identify it as in_app
+

--- a/hooks/sentry/README.md
+++ b/hooks/sentry/README.md
@@ -60,3 +60,15 @@ with a call to `NewSentryHook`. This can be changed by assigning a value to the 
 hook, _ := logrus_sentry.NewSentryHook(...)
 hook.Timeout = 20*time.Second
 ```
+
+## Enabling Stacktraces
+
+By default the hook will not send any stacktraces. However, this can be enabled
+with:
+
+```go
+hook, _ := logrus_sentry.NewSentryHook(...)
+hook.SetStacktraceLevel(logrus.ErrorLevel)
+```
+
+Subsequent calls to `logger.Error` and above will create a stacktrace.

--- a/hooks/sentry/sentry.go
+++ b/hooks/sentry/sentry.go
@@ -58,11 +58,27 @@ type SentryHook struct {
 	// Timeout sets the time to wait for a delivery error from the sentry server.
 	// If this is set to zero the server will not wait for any response and will
 	// consider the message correctly sent
-	Timeout time.Duration
+	Timeout                 time.Duration
+	StacktraceConfiguration stacktraceConfiguration
 
-	client          *raven.Client
-	levels          []logrus.Level
-	stacktraceLevel *logrus.Level
+	client *raven.Client
+	levels []logrus.Level
+}
+
+// stacktraceConfiguration allows for configuring stacktraces
+type stacktraceConfiguration struct {
+	// whether stacktraces should be enabled
+	Enable bool
+	// the level at which to start capturing stacktraces
+	Level logrus.Level
+	// how many stack frames to skip before stacktrace starts recording
+	Skip int
+	// the number of lines to include around a stack frame for context
+	Context int
+	// the prefixes that will be matched against the stack frame.
+	// if the stack frame's package matches one of these prefixes
+	// sentry will identify the stack frame as "in_app"
+	InAppPrefixes []string
 }
 
 // NewSentryHook creates a hook to be added to an instance of logger
@@ -73,12 +89,18 @@ func NewSentryHook(DSN string, levels []logrus.Level) (*SentryHook, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SentryHook{100 * time.Millisecond, client, levels, nil}, nil
-}
-
-// SetStacktraceLevel sets logging level at which to capture stacktrace.
-func (hook *SentryHook) SetStacktraceLevel(stacktraceLevel logrus.Level) {
-	hook.stacktraceLevel = &stacktraceLevel
+	return &SentryHook{
+		Timeout: 100 * time.Millisecond,
+		StacktraceConfiguration: stacktraceConfiguration{
+			Enable:        false,
+			Level:         logrus.ErrorLevel,
+			Skip:          5,
+			Context:       0,
+			InAppPrefixes: nil,
+		},
+		client: client,
+		levels: levels,
+	}, nil
 }
 
 // Called when an event should be sent to sentry
@@ -104,8 +126,10 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 	if req, ok := getAndDelRequest(d, "http_request"); ok {
 		packet.Interfaces = append(packet.Interfaces, raven.NewHttp(req))
 	}
-	if hook.stacktraceLevel != nil && entry.Level <= *hook.stacktraceLevel {
-		packet.Interfaces = append(packet.Interfaces, raven.NewStacktrace(5, 0, nil))
+	stConfig := &hook.StacktraceConfiguration
+	if stConfig.Enable && entry.Level <= stConfig.Level {
+		currentStacktrace := raven.NewStacktrace(stConfig.Skip, stConfig.Context, stConfig.InAppPrefixes)
+		packet.Interfaces = append(packet.Interfaces, currentStacktrace)
 	}
 	packet.Extra = map[string]interface{}(d)
 

--- a/hooks/sentry/sentry_test.go
+++ b/hooks/sentry/sentry_test.go
@@ -1,8 +1,11 @@
 package logrus_sentry
 
 import (
+	"compress/zlib"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -25,12 +28,23 @@ func getTestLogger() *logrus.Logger {
 	return l
 }
 
-func WithTestDSN(t *testing.T, tf func(string, <-chan *raven.Packet)) {
-	pch := make(chan *raven.Packet, 1)
+type resultPacket struct {
+	raven.Packet
+	Stacktrace raven.Stacktrace `json:"sentry.interfaces.Stacktrace"`
+}
+
+func WithTestDSN(t *testing.T, tf func(string, <-chan *resultPacket)) {
+	pch := make(chan *resultPacket, 1)
 	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
-		d := json.NewDecoder(req.Body)
-		p := &raven.Packet{}
+		contentType := req.Header.Get("Content-Type")
+		var bodyReader io.Reader = req.Body
+		if contentType == "application/octet-stream" {
+			bodyReader = base64.NewDecoder(base64.StdEncoding, bodyReader)
+			bodyReader, _ = zlib.NewReader(bodyReader)
+		}
+		d := json.NewDecoder(bodyReader)
+		p := &resultPacket{}
 		err := d.Decode(p)
 		if err != nil {
 			t.Fatal(err.Error())
@@ -50,7 +64,7 @@ func WithTestDSN(t *testing.T, tf func(string, <-chan *raven.Packet)) {
 }
 
 func TestSpecialFields(t *testing.T) {
-	WithTestDSN(t, func(dsn string, pch <-chan *raven.Packet) {
+	WithTestDSN(t, func(dsn string, pch <-chan *resultPacket) {
 		logger := getTestLogger()
 
 		hook, err := NewSentryHook(dsn, []logrus.Level{
@@ -81,7 +95,7 @@ func TestSpecialFields(t *testing.T) {
 }
 
 func TestSentryHandler(t *testing.T) {
-	WithTestDSN(t, func(dsn string, pch <-chan *raven.Packet) {
+	WithTestDSN(t, func(dsn string, pch <-chan *resultPacket) {
 		logger := getTestLogger()
 		hook, err := NewSentryHook(dsn, []logrus.Level{
 			logrus.ErrorLevel,
@@ -95,6 +109,50 @@ func TestSentryHandler(t *testing.T) {
 		packet := <-pch
 		if packet.Message != message {
 			t.Errorf("message should have been %s, was %s", message, packet.Message)
+		}
+	})
+}
+
+func TestSentryStacktrace(t *testing.T) {
+	WithTestDSN(t, func(dsn string, pch <-chan *resultPacket) {
+		logger := getTestLogger()
+		hook, err := NewSentryHook(dsn, []logrus.Level{
+			logrus.ErrorLevel,
+			logrus.InfoLevel,
+		})
+		hook.SetStacktraceLevel(logrus.ErrorLevel)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		logger.Hooks.Add(hook)
+
+		logger.Error(message) // this is the call that the last frame of stacktrace should capture
+		packet := <-pch
+		if packet.Message != message {
+			t.Errorf("message should have been %s, was %s", message, packet.Message)
+		}
+		stacktraceSize := len(packet.Stacktrace.Frames)
+		if stacktraceSize == 0 {
+			t.Error("Stacktrace should not be empty")
+		}
+		lastFrame := packet.Stacktrace.Frames[stacktraceSize-1]
+		expectedFilename := "github.com/Sirupsen/logrus/hooks/sentry/sentry_test.go"
+		if lastFrame.Filename != expectedFilename {
+			t.Errorf("File name should have been %s, was %s", expectedFilename, lastFrame.Filename)
+		}
+		expectedLineno := 129
+		if lastFrame.Lineno != expectedLineno {
+			t.Errorf("Line number should have been %s, was %s", expectedLineno, lastFrame.Lineno)
+		}
+
+		logger.Info(message)
+		packet = <-pch
+		if packet.Message != message {
+			t.Errorf("message should have been %s, was %s", message, packet.Message)
+		}
+		stacktraceSize = len(packet.Stacktrace.Frames)
+		if stacktraceSize > 0 {
+			t.Error("Stacktrace should be empty")
 		}
 	})
 }


### PR DESCRIPTION
This change would allow users of the Sentry hook to selectively enable stacktraces for a given logging level.
- Update hook to allow optional stacktrace capture
- Update hook test to handle response when raven client compresses / base64 encode the payload
- Implement packet object in hook test to allow for json deserialization of stacktrace