### PR TITLE
Hook for providing default fields to be added to all logged events

### DIFF
--- a/hooks/defaultfields/README.md
+++ b/hooks/defaultfields/README.md
@@ -1,0 +1,31 @@
+# Default Fields Hooks for Logrus
+
+Add default fields to be logged with every event. Useful when your logs are aggregated
+and you want to identify where a particular event originated.
+
+## Usage
+
+```go
+import (
+	"log/syslog"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus/hooks/defaultfields"
+)
+
+func main() {
+	log  := logrus.New()
+	hook := defaultfields.NewDefaultFields([]logrus.Level{
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+	})
+	hook.AddDefaultField("appId", "a1b4949a-0df9-11e5-8daa-5cf9dd6ef856")
+	hook.AddDefaultField("appName", "MyApp")
+
+    log.Hooks.Add(hook)
+}
+```

--- a/hooks/defaultfields/defaultfields.go
+++ b/hooks/defaultfields/defaultfields.go
@@ -1,0 +1,34 @@
+package defaultfields
+
+import (
+	"github.com/Sirupsen/logrus"
+)
+
+type DefaultFieldsHook struct {
+	defaultFields map[string]interface{}
+	levels        []logrus.Level
+}
+
+func (dfh DefaultFieldsHook) AddDefaultField(key string, val interface{}) {
+	dfh.defaultFields[key] = val
+}
+
+func (dfh DefaultFieldsHook) Levels() []logrus.Level {
+	return dfh.levels
+}
+
+func (dfh DefaultFieldsHook) Fire(entry *logrus.Entry) error {
+	for key, val := range dfh.defaultFields {
+		entry.Data[key] = val
+	}
+	return nil
+}
+
+func NewDefaultFieldsHook(levels []logrus.Level) *DefaultFieldsHook {
+	fields := map[string]interface{}{}
+	return &DefaultFieldsHook{
+		defaultFields: fields,
+		levels:        levels,
+	}
+
+}

--- a/hooks/defaultfields/defaultfields_test.go
+++ b/hooks/defaultfields/defaultfields_test.go
@@ -1,0 +1,49 @@
+package defaultfields
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func TestDefaultFieldLogged(t *testing.T) {
+
+	var buffer bytes.Buffer
+	var fields logrus.Fields
+
+	log := logrus.New()
+	log.Out = &buffer
+	log.Formatter = new(logrus.JSONFormatter)
+
+	hook := NewDefaultFieldsHook([]logrus.Level{
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+	})
+
+	defaultKey := "default"
+	expected := "Test Value"
+	hook.AddDefaultField(defaultKey, expected)
+	log.Hooks.Add(hook)
+
+	log.WithField("another", "value").Info("A message")
+
+	err := json.Unmarshal(buffer.Bytes(), &fields)
+	if err != nil {
+		t.Error("Cannot unmarshal JSON logged output")
+	}
+
+	actual, ok := fields[defaultKey]
+	if !ok {
+		t.Error("Default key not in logged output")
+	}
+
+	if expected != actual {
+		t.Error("Default value does not match expected:", expected, actual)
+	}
+}


### PR DESCRIPTION
This hook allows initializing default Fields that are added to every logged event. This is especially useful where you are aggregating logs from multiple applications (logstash).