### PR TITLE
add link to mail hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ func init() {
 | [Raygun](https://github.com/squirkle/logrus-raygun-hook) | Hook for logging to [Raygun.io](http://raygun.io/) |
 | [LFShook](https://github.com/rifflock/lfshook) | Hook for logging to the local filesystem |
 | [Honeybadger](https://github.com/agonzalezro/logrus_honeybadger) | Hook for sending exceptions to Honeybadger |
+| [Mail](https://github.com/zbindenren/logrus_mail) | Hook for sending exceptions via mail |
 
 #### Level logging
 


### PR DESCRIPTION
As discussed in #123 I created a merge request to add the mail hook reference to the README. Will close #123 