### PR TITLE
Add trace log level 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ With `log.Formatter = new(logrus.JSONFormatter)`, for easy parsing by logstash
 or Splunk:
 
 ```json
+{"level":"trace","msg":"The tiniest detail","planck_length":
+1.61619926e-35,"time":"2014-03-10 09:15:29.562264112 -0400 EDT"}
+
 {"animal":"walrus","level":"info","msg":"A group of walrus emerges from the
 ocean","size":10,"time":"2014-03-10 19:57:38.562264131 -0400 EDT"}
 
@@ -37,6 +40,7 @@ attached, the output is compatible with the
 [logfmt](http://godoc.org/github.com/kr/logfmt) format:
 
 ```text
+time="2015-03-26T01:27:38-04:00" level=trace msg="The tiniest detail" planck_length=1.61619926e-35
 time="2015-03-26T01:27:38-04:00" level=debug msg="Started observing beach" animal=walrus number=8
 time="2015-03-26T01:27:38-04:00" level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
 time="2015-03-26T01:27:38-04:00" level=warning msg="The group's number increased tremendously!" number=122 omg=true
@@ -218,9 +222,10 @@ func init() {
 
 #### Level logging
 
-Logrus has six logging levels: Debug, Info, Warning, Error, Fatal and Panic.
+Logrus has seven  logging levels: Trace, Debug, Info, Warning, Error, Fatal and Panic.
 
 ```go
+log.Trace("Potentially spammy, low-level debug information")
 log.Debug("Useful debugging information.")
 log.Info("Something noteworthy happened!")
 log.Warn("You should probably take a look at this.")

--- a/entry.go
+++ b/entry.go
@@ -104,6 +104,12 @@ func (entry *Entry) log(level Level, msg string) {
 	}
 }
 
+func (entry *Entry) Trace(args ...interface{}) {
+	if entry.Logger.Level >= TraceLevel {
+		entry.log(TraceLevel, fmt.Sprint(args...))
+	}
+}
+
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
 		entry.log(DebugLevel, fmt.Sprint(args...))
@@ -152,6 +158,12 @@ func (entry *Entry) Panic(args ...interface{}) {
 
 // Entry Printf family functions
 
+func (entry *Entry) Tracef(format string, args ...interface{}) {
+	if entry.Logger.Level >= TraceLevel {
+		entry.Trace(fmt.Sprintf(format, args...))
+	}
+}
+
 func (entry *Entry) Debugf(format string, args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
 		entry.Debug(fmt.Sprintf(format, args...))
@@ -198,6 +210,12 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 }
 
 // Entry Println family functions
+
+func (entry *Entry) Traceln(args ...interface{}) {
+	if entry.Logger.Level >= TraceLevel {
+		entry.Trace(entry.sprintlnn(args...))
+	}
+}
 
 func (entry *Entry) Debugln(args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -9,7 +9,7 @@ var log = logrus.New()
 func init() {
 	log.Formatter = new(logrus.JSONFormatter)
 	log.Formatter = new(logrus.TextFormatter) // default
-	log.Level = logrus.DebugLevel
+	log.Level = logrus.TraceLevel
 }
 
 func main() {
@@ -23,6 +23,10 @@ func main() {
 			}).Fatal("The ice breaks!")
 		}
 	}()
+
+	log.WithFields(logrus.Fields{
+		"planck_length": 1.61619926e-35,
+	}).Trace("The tiniest detail")
 
 	log.WithFields(logrus.Fields{
 		"animal": "walrus",

--- a/hook_test.go
+++ b/hook_test.go
@@ -17,6 +17,7 @@ func (hook *TestHook) Fire(entry *Entry) error {
 
 func (hook *TestHook) Levels() []Level {
 	return []Level{
+		TraceLevel,
 		DebugLevel,
 		InfoLevel,
 		WarnLevel,
@@ -49,6 +50,7 @@ func (hook *ModifyHook) Fire(entry *Entry) error {
 
 func (hook *ModifyHook) Levels() []Level {
 	return []Level{
+		TraceLevel,
 		DebugLevel,
 		InfoLevel,
 		WarnLevel,

--- a/hooks/papertrail/papertrail.go
+++ b/hooks/papertrail/papertrail.go
@@ -51,5 +51,6 @@ func (hook *PapertrailHook) Levels() []logrus.Level {
 		logrus.WarnLevel,
 		logrus.InfoLevel,
 		logrus.DebugLevel,
+		logrus.TraceLevel,
 	}
 }

--- a/hooks/sentry/sentry.go
+++ b/hooks/sentry/sentry.go
@@ -2,8 +2,8 @@ package logrus_sentry
 
 import (
 	"fmt"
-	"time"
 	"net/http"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/getsentry/raven-go"
@@ -11,6 +11,7 @@ import (
 
 var (
 	severityMap = map[logrus.Level]raven.Severity{
+		logrus.TraceLevel: raven.DEBUG,
 		logrus.DebugLevel: raven.DEBUG,
 		logrus.InfoLevel:  raven.INFO,
 		logrus.WarnLevel:  raven.WARNING,

--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -42,6 +42,8 @@ func (hook *SyslogHook) Fire(entry *logrus.Entry) error {
 		return hook.Writer.Info(line)
 	case logrus.DebugLevel:
 		return hook.Writer.Debug(line)
+	case logrus.TraceLevel:
+		return hook.Writer.Debug(line)
 	default:
 		return nil
 	}
@@ -55,5 +57,6 @@ func (hook *SyslogHook) Levels() []logrus.Level {
 		logrus.WarnLevel,
 		logrus.InfoLevel,
 		logrus.DebugLevel,
+		logrus.TraceLevel,
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -64,6 +64,12 @@ func (logger *Logger) WithFields(fields Fields) *Entry {
 	return NewEntry(logger).WithFields(fields)
 }
 
+func (logger *Logger) Tracef(format string, args ...interface{}) {
+	if logger.Level >= TraceLevel {
+		NewEntry(logger).Tracef(format, args...)
+	}
+}
+
 func (logger *Logger) Debugf(format string, args ...interface{}) {
 	if logger.Level >= DebugLevel {
 		NewEntry(logger).Debugf(format, args...)
@@ -111,6 +117,12 @@ func (logger *Logger) Panicf(format string, args ...interface{}) {
 	}
 }
 
+func (logger *Logger) Trace(args ...interface{}) {
+	if logger.Level >= TraceLevel {
+		NewEntry(logger).Trace(args...)
+	}
+}
+
 func (logger *Logger) Debug(args ...interface{}) {
 	if logger.Level >= DebugLevel {
 		NewEntry(logger).Debug(args...)
@@ -155,6 +167,12 @@ func (logger *Logger) Fatal(args ...interface{}) {
 func (logger *Logger) Panic(args ...interface{}) {
 	if logger.Level >= PanicLevel {
 		NewEntry(logger).Panic(args...)
+	}
+}
+
+func (logger *Logger) Traceln(args ...interface{}) {
+	if logger.Level >= TraceLevel {
+		NewEntry(logger).Traceln(args...)
 	}
 }
 

--- a/logrus.go
+++ b/logrus.go
@@ -14,6 +14,8 @@ type Level uint8
 // Convert the Level to a string. E.g. PanicLevel becomes "panic".
 func (level Level) String() string {
 	switch level {
+	case TraceLevel:
+		return "trace"
 	case DebugLevel:
 		return "debug"
 	case InfoLevel:
@@ -46,6 +48,8 @@ func ParseLevel(lvl string) (Level, error) {
 		return InfoLevel, nil
 	case "debug":
 		return DebugLevel, nil
+	case "trace":
+		return TraceLevel, nil
 	}
 
 	var l Level
@@ -71,6 +75,8 @@ const (
 	InfoLevel
 	// DebugLevel level. Usually only enabled when debugging. Very verbose logging.
 	DebugLevel
+	// TraceLevel level. Very low-level logging, for when DebugLevel isn't enough.
+	TraceLevel
 )
 
 // Won't compile if StdLogger can't be realized by a log.Logger

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -242,6 +242,7 @@ func TestDoubleLoggingDoesntPrefixPreviousFields(t *testing.T) {
 }
 
 func TestConvertLevelToString(t *testing.T) {
+	assert.Equal(t, "trace", TraceLevel.String())
 	assert.Equal(t, "debug", DebugLevel.String())
 	assert.Equal(t, "info", InfoLevel.String())
 	assert.Equal(t, "warning", WarnLevel.String())
@@ -278,6 +279,10 @@ func TestParseLevel(t *testing.T) {
 	l, err = ParseLevel("debug")
 	assert.Nil(t, err)
 	assert.Equal(t, DebugLevel, l)
+
+	l, err = ParseLevel("trace")
+	assert.Nil(t, err)
+	assert.Equal(t, TraceLevel, l)
 
 	l, err = ParseLevel("invalid")
 	assert.Equal(t, "not a valid logrus Level: \"invalid\"", err.Error())

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -15,6 +15,7 @@ const (
 	green   = 32
 	yellow  = 33
 	blue    = 34
+	magenta = 35
 	gray    = 37
 )
 
@@ -96,6 +97,8 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string) {
 	var levelColor int
 	switch entry.Level {
+	case TraceLevel:
+		levelColor = magenta
 	case DebugLevel:
 		levelColor = gray
 	case WarnLevel:


### PR DESCRIPTION
Hi,

I've added a 'trace' log level for when debug just isn't enough. When hooking into systems that don't support a trace level it'll push them out to debug instead (e.g. syslog, sentry).

Thanks