### PR TITLE
[TextFormatter] Speed up (~40%). Fprintf is changed to buffer.Write*

### DIFF
--- a/formatter_bench_test.go
+++ b/formatter_bench_test.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -43,6 +44,15 @@ var largeFields = Fields{
 	"this":      "will",
 	"make":      "thirty",
 	"entries":   "yeah",
+}
+
+var errorFields = Fields{
+	"foo": fmt.Errorf("bar"),
+	"baz": fmt.Errorf("qux"),
+}
+
+func BenchmarkErrorTextFormatter(b *testing.B) {
+	doBenchmark(b, &TextFormatter{DisableColors: true}, errorFields)
 }
 
 func BenchmarkSmallTextFormatter(b *testing.B) {

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -131,21 +131,28 @@ func needsQuoting(text string) bool {
 	return true
 }
 
-func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key, value interface{}) {
-	switch value.(type) {
+func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
+
+	b.WriteString(key)
+	b.WriteByte('=')
+
+	switch value := value.(type) {
 	case string:
-		if needsQuoting(value.(string)) {
-			fmt.Fprintf(b, "%v=%s ", key, value)
+		if needsQuoting(value) {
+			b.WriteString(value)
 		} else {
-			fmt.Fprintf(b, "%v=%q ", key, value)
+			fmt.Fprintf(b, "%q", value)
 		}
 	case error:
-		if needsQuoting(value.(error).Error()) {
-			fmt.Fprintf(b, "%v=%s ", key, value)
+		errmsg := value.Error()
+		if needsQuoting(errmsg) {
+			b.WriteString(errmsg)
 		} else {
-			fmt.Fprintf(b, "%v=%q ", key, value)
+			fmt.Fprintf(b, "%q", value)
 		}
 	default:
-		fmt.Fprintf(b, "%v=%v ", key, value)
+		fmt.Fprint(b, value)
 	}
+
+	b.WriteByte(' ')
 }


### PR DESCRIPTION
As Fprintf is slower than buffer.WriteString, it's replaced to faster call.

Before:
```
BenchmarkSmallTextFormatter	  300000	      5841 ns/op	  14.89 MB/s
BenchmarkLargeTextFormatter	   50000	     24215 ns/op	  11.85 MB/s
BenchmarkSmallColoredTextFormatter	  300000	      5071 ns/op	  27.02 MB/s
BenchmarkLargeColoredTextFormatter	   50000	     27192 ns/op	  20.34 MB/s
```
Now:
```
BenchmarkSmallTextFormatter	  300000	      3883 ns/op	  22.40 MB/s
BenchmarkLargeTextFormatter	  100000	     14305 ns/op	  20.06 MB/s
BenchmarkSmallColoredTextFormatter	  300000	      5114 ns/op	  26.79 MB/s
BenchmarkLargeColoredTextFormatter	   50000	     26918 ns/op	  20.54 MB/s
```