### PR TITLE
Print struct keys for struct log fields

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -115,7 +115,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 	}
 	for _, k := range keys {
 		v := entry.Data[k]
-		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%v", levelColor, k, v)
+		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%+v", levelColor, k, v)
 	}
 }
 


### PR DESCRIPTION
Can be useful for debugging, saves a lot of referring to source code