### PR TITLE
Sentry tags

### DIFF
--- a/hooks/sentry/README.md
+++ b/hooks/sentry/README.md
@@ -31,6 +31,22 @@ func main() {
 }
 ```
 
+If you wish to initialize a SentryHook with tags, you can use the `NewWithTagsSentryHook` constructor to provide default tags:
+
+```go
+tags := map[string]string{
+  "site": "example.com",
+}
+levels := []logrus.Level{
+  logrus.PanicLevel,
+  logrus.FatalLevel,
+  logrus.ErrorLevel,
+}
+hook, err := logrus_sentry.NewWithTagsSentryHook(YOUR_DSN, tags, levels)
+
+```
+
+
 ## Special fields
 
 Some logrus fields have a special meaning in this hook,

--- a/hooks/sentry/sentry.go
+++ b/hooks/sentry/sentry.go
@@ -2,8 +2,8 @@ package logrus_sentry
 
 import (
 	"fmt"
-	"time"
 	"net/http"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/getsentry/raven-go"
@@ -68,7 +68,18 @@ type SentryHook struct {
 // and initializes the raven client.
 // This method sets the timeout to 100 milliseconds.
 func NewSentryHook(DSN string, levels []logrus.Level) (*SentryHook, error) {
-	client, err := raven.NewClient(DSN, nil)
+	client, err := raven.New(DSN)
+	if err != nil {
+		return nil, err
+	}
+	return &SentryHook{100 * time.Millisecond, client, levels}, nil
+}
+
+// NewWithTagsSentryHook creates a hook with tags to be added to an instance
+// of logger and initializes the raven client. This method sets the timeout to
+// 100 milliseconds.
+func NewWithTagsSentryHook(DSN string, tags map[string]string, levels []logrus.Level) (*SentryHook, error) {
+	client, err := raven.NewWithTags(DSN, tags)
 	if err != nil {
 		return nil, err
 	}

--- a/hooks/sentry/sentry_test.go
+++ b/hooks/sentry/sentry_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -94,6 +95,37 @@ func TestSentryHandler(t *testing.T) {
 		logger.Error(message)
 		packet := <-pch
 		if packet.Message != message {
+			t.Errorf("message should have been %s, was %s", message, packet.Message)
+		}
+	})
+}
+
+func TestSentryTags(t *testing.T) {
+	WithTestDSN(t, func(dsn string, pch <-chan *raven.Packet) {
+		logger := getTestLogger()
+		tags := map[string]string{
+			"site": "test",
+		}
+		levels := []logrus.Level{
+			logrus.ErrorLevel,
+		}
+
+		hook, err := NewWithTagsSentryHook(dsn, tags, levels)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		logger.Hooks.Add(hook)
+
+		logger.Error(message)
+		packet := <-pch
+		expected := raven.Tags{
+			raven.Tag{
+				Key:   "site",
+				Value: "test",
+			},
+		}
+		if !reflect.DeepEqual(packet.Tags, expected) {
 			t.Errorf("message should have been %s, was %s", message, packet.Message)
 		}
 	})


### PR DESCRIPTION
The raven function for creating a new client, [NewClient](http://godoc.org/github.com/getsentry/raven-go#NewClient), is deprecated. I've updated the SentryHook to use the proper constructor as well as added a new function for creating a SentryHook with Tags. This is useful because there is currently no way to add Tags when initializing a SentryHook.