### PR TITLE
Allow sentry hook to be created using an initialized raven client

### DIFF
--- a/hooks/sentry/README.md
+++ b/hooks/sentry/README.md
@@ -46,6 +46,39 @@ hook, err := logrus_sentry.NewWithTagsSentryHook(YOUR_DSN, tags, levels)
 
 ```
 
+If you wish to initialize a SentryHook with an already initialized raven client, you can use 
+the `NewWithClientSentryHook` constructor:
+
+```go
+import (
+  "github.com/Sirupsen/logrus"
+  "github.com/Sirupsen/logrus/hooks/sentry"
+  "github.com/getsentry/raven-go"
+)
+
+func main() {
+  log := logrus.New()
+
+  client, err := raven.New(YOUR_DSN)
+  if err != nil {
+      log.Fatal(err)
+  }
+
+  hook, err := logrus_sentry.NewWithClientSentryHook(client, []logrus.Level{
+    logrus.PanicLevel,
+    logrus.FatalLevel,
+    logrus.ErrorLevel,
+  })
+
+  if err == nil {
+    log.Hooks.Add(hook)
+  }
+}
+
+hook, err := NewWithClientSentryHook(client, []logrus.Level{
+	logrus.ErrorLevel,
+})
+```
 
 ## Special fields
 

--- a/hooks/sentry/sentry.go
+++ b/hooks/sentry/sentry.go
@@ -86,6 +86,12 @@ func NewWithTagsSentryHook(DSN string, tags map[string]string, levels []logrus.L
 	return &SentryHook{100 * time.Millisecond, client, levels}, nil
 }
 
+// NewWithClientSentryHook creates a hook using an initialized raven client.
+// This method sets the timeout to 100 milliseconds.
+func NewWithClientSentryHook(client *raven.Client, levels []logrus.Level) (*SentryHook, error) {
+	return &SentryHook{100 * time.Millisecond, client, levels}, nil
+}
+
 // Called when an event should be sent to sentry
 // Special fields that sentry uses to give more information to the server
 // are extracted from entry.Data (if they are found)

--- a/hooks/sentry/sentry_test.go
+++ b/hooks/sentry/sentry_test.go
@@ -100,6 +100,28 @@ func TestSentryHandler(t *testing.T) {
 	})
 }
 
+func TestSentryWithClient(t *testing.T) {
+	WithTestDSN(t, func(dsn string, pch <-chan *raven.Packet) {
+		logger := getTestLogger()
+
+		client, _ := raven.New(dsn)
+
+		hook, err := NewWithClientSentryHook(client, []logrus.Level{
+			logrus.ErrorLevel,
+		})
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		logger.Hooks.Add(hook)
+
+		logger.Error(message)
+		packet := <-pch
+		if packet.Message != message {
+			t.Errorf("message should have been %s, was %s", message, packet.Message)
+		}
+	})
+}
+
 func TestSentryTags(t *testing.T) {
 	WithTestDSN(t, func(dsn string, pch <-chan *raven.Packet) {
 		logger := getTestLogger()


### PR DESCRIPTION
Allows using a initialized raven client to create a logrus hook.  Avoids having to create an additional raven client when wanting to use raven directly (ex. raven.CapturePanic).