### PR TITLE
Add option `ForceTTY` to override normal `SYS_IOCTL` detection

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -36,6 +36,10 @@ type TextFormatter struct {
 	// Set to true to bypass checking for a TTY before outputting colors.
 	ForceColors bool
 
+	// Set to true to bypass checking for a TTY. Formatting and colors will be
+	// overridden as if the session is taking place inside of one.
+	ForceTTY bool
+
 	// Force disabling colors.
 	DisableColors bool
 
@@ -70,7 +74,7 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 
 	prefixFieldClashes(entry.Data)
 
-	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
+	isColorTerminal := f.ForceTTY || isTerminal && (runtime.GOOS != "windows")
 	isColored := (f.ForceColors || isColorTerminal) && !f.DisableColors
 
 	if f.TimestampFormat == "" {


### PR DESCRIPTION
This adds an option to the `TextFormatter` called `ForceTTY` that
overrides the standard detection of a TTY.

The motivation for this is to be able to get logrus' pretty-printed text
output from within a tool like [Foreman][foreman] or [Forego][forego].
These tools did identify themselves as TTYs at some point during their
earlier stages, but have since stopped because it caused some side
effects that were undesirable. There is some more documentation on that
on the [Foreman wiki][foreman-wiki].

This obviously isn't a perfect solution, but does seem to accomplish
what I want. It also seems to fall in-line with some of the conventions
that are already established by other options within `TextFormatter`.
That said, I'd welcome alternatives if anyone has them.

@Sirupsen Love what you've done with this project. Thanks!

[forego]: https://github.com/ddollar/forego
[foreman]: https://github.com/ddollar/foreman
[foreman-wiki]: https://github.com/ddollar/foreman/wiki/Missing-Output