### PR TITLE
Fix race condition in entry log method

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -100,7 +100,7 @@ func (entry Entry) log(level Level, msg string) {
 	// panic() to use in Entry#Panic(), we avoid the allocation by checking
 	// directly here.
 	if level <= PanicLevel {
-		panic(entry)
+		panic(&entry)
 	}
 }
 

--- a/entry.go
+++ b/entry.go
@@ -70,6 +70,8 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	return &Entry{Logger: entry.Logger, Data: data}
 }
 
+// This function is not declared with a pointer value because otherwise
+// race conditions will occur when using multiple goroutines
 func (entry Entry) log(level Level, msg string) {
 	entry.Time = time.Now()
 	entry.Level = level

--- a/entry.go
+++ b/entry.go
@@ -70,12 +70,12 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	return &Entry{Logger: entry.Logger, Data: data}
 }
 
-func (entry *Entry) log(level Level, msg string) {
+func (entry Entry) log(level Level, msg string) {
 	entry.Time = time.Now()
 	entry.Level = level
 	entry.Message = msg
 
-	if err := entry.Logger.Hooks.Fire(level, entry); err != nil {
+	if err := entry.Logger.Hooks.Fire(level, &entry); err != nil {
 		entry.Logger.mu.Lock()
 		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
 		entry.Logger.mu.Unlock()


### PR DESCRIPTION
Use a copy of the Entry structure to avoid possible race conditions.

Fixes #216

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>