### PR TITLE
Make Entry.log panic with the message rather than the opaque entry

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -102,7 +102,7 @@ func (entry Entry) log(level Level, msg string) {
 	// panic() to use in Entry#Panic(), we avoid the allocation by checking
 	// directly here.
 	if level <= PanicLevel {
-		panic(&entry)
+		panic(msg)
 	}
 }
 


### PR DESCRIPTION
Fixes #232 