### PR TITLE
Add logger wide context field handling

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -29,10 +29,15 @@ type Entry struct {
 }
 
 func NewEntry(logger *Logger) *Entry {
+	// Default is three fields, give a little extra room
+	entry_data := make(Fields,len(logger.Data)+5)
+	for k, v := range logger.Data {
+		entry_data[k] = v
+	}
+
 	return &Entry{
 		Logger: logger,
-		// Default is three fields, give a little extra room
-		Data: make(Fields, 5),
+		Data: entry_data,
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -28,6 +28,8 @@ type Logger struct {
 	Level Level
 	// Used to sync writing to the log.
 	mu sync.Mutex
+	// Contains all the fields set by the user.
+	Data Fields
 }
 
 // Creates a new logger. Configuration should be set by changing `Formatter`,
@@ -48,6 +50,7 @@ func New() *Logger {
 		Formatter: new(TextFormatter),
 		Hooks:     make(LevelHooks),
 		Level:     InfoLevel,
+		Data: make(Fields, 5),
 	}
 }
 
@@ -203,4 +206,21 @@ func (logger *Logger) Panicln(args ...interface{}) {
 	if logger.Level >= PanicLevel {
 		NewEntry(logger).Panicln(args...)
 	}
+}
+
+// Add a single field to the global log context
+func (logger *Logger) SetContextField(key string, value interface{}) {
+	logger.SetContextFields(Fields{key: value})
+}
+
+// Add a map of fields to the global log context
+func (logger *Logger) SetContextFields(fields Fields) {
+	data := Fields{}
+	for k, v := range logger.Data {
+		data[k] = v
+	}
+	for k, v := range fields {
+		data[k] = v
+	}
+	logger.Data=data
 }


### PR DESCRIPTION
This small patch provides the ability to add "Fields" at the logger level which will be inherited by any Entry created by that logger. Essentially it just pre-populates the Entry's fields with the global ones. This is useful for things like overall context such as "environment":"dev" etc