### PR TITLE
Make Fields an implementable interface with a ToFields() method, issue

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -67,12 +67,12 @@ func (entry *Entry) WithField(key string, value interface{}) *Entry {
 }
 
 // Add a map of fields to the Entry.
-func (entry *Entry) WithFields(fields Fields) *Entry {
+func (entry *Entry) WithFields(fields FieldsConverter) *Entry {
 	data := Fields{}
 	for k, v := range entry.Data {
 		data[k] = v
 	}
-	for k, v := range fields {
+	for k, v := range fields.ToFields() {
 		data[k] = v
 	}
 	return &Entry{Logger: entry.Logger, Data: data}

--- a/exported.go
+++ b/exported.go
@@ -68,7 +68,7 @@ func WithField(key string, value interface{}) *Entry {
 //
 // Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
 // or Panic on the Entry it returns.
-func WithFields(fields Fields) *Entry {
+func WithFields(fields FieldsConverter) *Entry {
 	return std.WithFields(fields)
 }
 

--- a/logger.go
+++ b/logger.go
@@ -60,7 +60,7 @@ func (logger *Logger) WithField(key string, value interface{}) *Entry {
 
 // Adds a struct of fields to the log entry. All it does is call `WithField` for
 // each `Field`.
-func (logger *Logger) WithFields(fields Fields) *Entry {
+func (logger *Logger) WithFields(fields FieldsConverter) *Entry {
 	return NewEntry(logger).WithFields(fields)
 }
 

--- a/logrus.go
+++ b/logrus.go
@@ -8,6 +8,16 @@ import (
 // Fields type, used to pass to `WithFields`.
 type Fields map[string]interface{}
 
+//FieldsConverter has a ToFields method that returns the map representation of the struct
+type FieldsConverter interface {
+	ToFields() Fields
+}
+
+//ToFields returns the map representation of the struct
+func (f Fields) ToFields() Fields {
+	return f
+}
+
 // Level type
 type Level uint8
 


### PR DESCRIPTION
Following the discussion started for issue #207, I’ve created a simple way to have the Fields type as implementable interface with a ToFields method.