### PR TITLE
Golf Support

### DIFF
--- a/golfs_test.go
+++ b/golfs_test.go
@@ -1,0 +1,16 @@
+package logrus
+
+type Person struct {
+	Name    string   `golf:"name"`
+	Alias   string   `golf:"alias"`
+	Hideout *Hideout `golf:"hideout"`
+}
+
+func (p *Person) PlayGolf() bool {
+	return true
+}
+
+type Hideout struct {
+	Name        string `golf:"name"`
+	DimensionId int    `golf:"dimensionId"`
+}

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -3,6 +3,8 @@ package logrus
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/akutz/golf"
 )
 
 type JSONFormatter struct {
@@ -14,6 +16,10 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	data := make(Fields, len(entry.Data)+3)
 	for k, v := range entry.Data {
 		switch v := v.(type) {
+		case golf.Golfs:
+			for ck, cv := range golf.Fore(k, v) {
+				data[ck] = cv
+			}
 		case error:
 			// Otherwise errors are ignored by `encoding/json`
 			// https://github.com/Sirupsen/logrus/issues/137

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 
@@ -116,5 +117,58 @@ func TestJSONEntryEndsWithNewline(t *testing.T) {
 
 	if b[len(b)-1] != '\n' {
 		t.Fatal("Expected JSON log entry to end with a newline")
+	}
+}
+
+func TestGolfsWithJsonFormatter(t *testing.T) {
+	p := &Person{
+		Name:  "Bruce",
+		Alias: "Batman",
+		Hideout: &Hideout{
+			Name:        "JLU Tower",
+			DimensionId: 52,
+		},
+	}
+
+	jf := &JSONFormatter{}
+	b, err := jf.Format(&Entry{
+		Message: "the dark knight", Data: Fields{"hero": p}})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	if bytes.Index(b, ([]byte)(`"hero.name":"Bruce"`)) < 0 {
+		t.Fatalf(`missing "hero.name":"Bruce"`)
+	}
+
+	if bytes.Index(b, ([]byte)(`"hero.alias":"Batman"`)) < 0 {
+		t.Fatalf(`missing "hero.alias":"Batman"`)
+	}
+
+	if bytes.Index(b, ([]byte)(`"hero.hideout.name":"JLU Tower"`)) < 0 {
+		t.Fatalf(`missing "hero.hideout.name":"JLU Tower"`)
+	}
+
+	if bytes.Index(b, ([]byte)(`"hero.hideout.dimensionId":52`)) < 0 {
+		t.Fatalf(`missing "hero.hideout.dimensionId":52`)
+	}
+}
+
+func TestGolfsWithJsonFormatterAndNonGolfer(t *testing.T) {
+	h := &Hideout{
+		Name:        "JLU Tower",
+		DimensionId: 52,
+	}
+
+	jf := &JSONFormatter{}
+	b, err := jf.Format(&Entry{
+		Message: "secret base", Data: Fields{"hideout": h}})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	t.Log(string(b))
+
+	if bytes.Index(b, ([]byte)(`"hideout":{"Name":"JLU Tower","DimensionId":52}`)) < 0 {
+		t.Fatalf(`missing "hideout":{"Name":"JLU Tower","DimensionId":52}`)
 	}
 }

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -57,5 +57,52 @@ func TestTimestampFormat(t *testing.T) {
 	checkTimeStr("")
 }
 
+func TestGolfsWithTextFormatter(t *testing.T) {
+	p := &Person{
+		Name:  "Bruce",
+		Alias: "Batman",
+		Hideout: &Hideout{
+			Name:        "JLU Tower",
+			DimensionId: 52,
+		},
+	}
+
+	tf := &TextFormatter{DisableColors: true}
+	b, _ := tf.Format(&Entry{
+		Message: "the dark knight", Data: Fields{"hero": p}})
+
+	if bytes.Index(b, ([]byte)("hero.name=Bruce")) < 0 {
+		t.Fatalf("missing hero.name=Bruce")
+	}
+
+	if bytes.Index(b, ([]byte)("hero.alias=Batman")) < 0 {
+		t.Fatalf("missing hero.alias=Batman")
+	}
+
+	if bytes.Index(b, ([]byte)(`hero.hideout.name="JLU Tower"`)) < 0 {
+		t.Fatalf(`missing hero.hideout.name="JLU Tower"`)
+	}
+
+	if bytes.Index(b, ([]byte)("hero.hideout.dimensionId=52")) < 0 {
+		t.Fatalf("missing hero.hideout.dimensionId=52")
+	}
+}
+
+func TestGolfsWithTextFormatterAndNonGolfer(t *testing.T) {
+	h := &Hideout{
+		Name:        "JLU Tower",
+		DimensionId: 52,
+	}
+
+	tf := &TextFormatter{DisableColors: true}
+	b, _ := tf.Format(&Entry{
+		Message: "secret base", Data: Fields{"hideout": h}})
+	t.Log(string(b))
+
+	if bytes.Index(b, ([]byte)("hideout=&{JLU Tower 52}")) < 0 {
+		t.Fatalf("missing hideout={JLU Tower 52}")
+	}
+}
+
 // TODO add tests for sorting etc., this requires a parser for the text
 // formatter output.


### PR DESCRIPTION
This patch adds support for the Golf package, a library that enables
types to define the fields they want returned about themselves or by way
of reflection.

For example, take the following type:

    type Person struct {
        Name  string
        Alias string
    }

    p := &Person{"Bruce", "Batman"}

If p were given to Logrus as a field value with an associated key of
"hero" then it would be formatted as such (given a text formatter):

    hero="&{Bruce Batman}"

However, the Person type may know how it wants to be formatted when it
comes to be logged as a field value, and this interface will provide
that advantage.

    func (p *Person) PlayGolf() bool {
        return true
    }

Now when a Person instance is provided to Logrus as a field value with
an associated key of hero it would be formatted as such (given a text
formatter):

    hero.Name=Bruce hero.Alias=Batman...

For more information on how the Golf package works, please see
https://github.com/akutz/golf. Thank you!