### PR TITLE
Improve references to Logstash formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,10 @@ The built-in logging formatters are:
     field to `true`.  To force no colored output even if there is a TTY  set the
     `DisableColors` field to `true`
 * `logrus.JSONFormatter`. Logs fields as JSON.
-* `logrus_logstash.LogstashFormatter`. Logs fields as Logstash Events (http://logstash.net).
+* `logrus/formatters/logstash.LogstashFormatter`. Logs fields as [Logstash](http://logstash.net) Events.
 
     ```go
-      logrus.SetFormatter(&logrus_logstash.LogstashFormatter{Type: “application_name"})
+      logrus.SetFormatter(&logstash.LogstashFormatter{Type: “application_name"})
     ```
 
 Third party logging formatters:


### PR DESCRIPTION
`logrus_logstash` was a bit cryptic, as there is no such package?!