### PR TITLE
Add WithError support to logstash

### DIFF
--- a/formatters/logstash/logstash.go
+++ b/formatters/logstash/logstash.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
-// Formatter generates json in logstash format.
+// LogstashFormatter generates json in logstash format.
 // Logstash site: http://logstash.net/
 type LogstashFormatter struct {
 	Type string // if not empty use for logstash type field.
@@ -16,6 +16,7 @@ type LogstashFormatter struct {
 	TimestampFormat string
 }
 
+// Format implements the logrus formatter.
 func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	entry.Data["@version"] = 1
 

--- a/formatters/logstash/logstash.go
+++ b/formatters/logstash/logstash.go
@@ -49,9 +49,10 @@ func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		entry.Data["type"] = f.Type
 	}
 
-	if v, ok := entry.Data[logrus.ErrorKey]; ok {
+	// convert all errors to string.
+	for k, v := range entry.Data {
 		if err, ok := v.(error); ok {
-			entry.Data[logrus.ErrorKey] = err.Error()
+			entry.Data[k] = err.Error()
 		}
 	}
 

--- a/formatters/logstash/logstash.go
+++ b/formatters/logstash/logstash.go
@@ -48,6 +48,12 @@ func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		entry.Data["type"] = f.Type
 	}
 
+	if v, ok := entry.Data[logrus.ErrorKey]; ok {
+		if err, ok := v.(error); ok {
+			entry.Data[logrus.ErrorKey] = err.Error()
+		}
+	}
+
 	serialized, err := json.Marshal(entry.Data)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)

--- a/formatters/logstash/logstash_test.go
+++ b/formatters/logstash/logstash_test.go
@@ -16,12 +16,13 @@ func TestLogstashFormatter(t *testing.T) {
 	lf := LogstashFormatter{Type: "abc"}
 
 	fields := logrus.Fields{
-		"message": "def",
-		"level":   "ijk",
-		"type":    "lmn",
-		"one":     1,
-		"pi":      3.14,
-		"bool":    true,
+		"message":      "def",
+		"level":        "ijk",
+		"type":         "lmn",
+		"one":          1,
+		"pi":           3.14,
+		"bool":         true,
+		"custom_error": errors.New("test custom error"),
 	}
 
 	entry := logrus.WithFields(fields).WithError(errors.New("test error"))
@@ -42,8 +43,9 @@ func TestLogstashFormatter(t *testing.T) {
 	assert.Equal("msg", data["message"])
 	assert.Equal("info", data["level"])
 
-	// error field
-	assert.Equal("test error", data["error"])
+	// error fields
+	assert.Equal("test error", data[logrus.ErrorKey])
+	assert.Equal("test custom error", data["custom_error"])
 
 	// substituted fields
 	assert.Equal("def", data["fields.message"])


### PR DESCRIPTION
Before this patch, when `WithError` is used, the value is empty.

EDIT: updated to convert all errors to string. If a field has an error type, it would not be marhsalled properly.