### PR TITLE
Rename logstash formatter to comply with golint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,10 @@ The built-in logging formatters are:
     field to `true`.  To force no colored output even if there is a TTY  set the
     `DisableColors` field to `true`
 * `logrus.JSONFormatter`. Logs fields as JSON.
-* `logrus_logstash.LogstashFormatter`. Logs fields as Logstash Events (http://logstash.net).
+* `logstash.Formatter`. Logs fields as Logstash Events (http://logstash.net).
 
     ```go
-      logrus.SetFormatter(&logrus_logstash.LogstashFormatter{Type: “application_name"})
+      logrus.SetFormatter(&logstash.Formatter{Type: "application_name"})
     ```
 
 Third party logging formatters:

--- a/formatters/logstash/logstash.go
+++ b/formatters/logstash/logstash.go
@@ -9,14 +9,14 @@ import (
 
 // Formatter generates json in logstash format.
 // Logstash site: http://logstash.net/
-type LogstashFormatter struct {
+type Formatter struct {
 	Type string // if not empty use for logstash type field.
 
 	// TimestampFormat sets the format used for timestamps.
 	TimestampFormat string
 }
 
-func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	entry.Data["@version"] = 1
 
 	if f.TimestampFormat == "" {

--- a/formatters/logstash/logstash_test.go
+++ b/formatters/logstash/logstash_test.go
@@ -11,7 +11,7 @@ import (
 func TestLogstashFormatter(t *testing.T) {
 	assert := assert.New(t)
 
-	lf := LogstashFormatter{Type: "abc"}
+	lf := Formatter{Type: "abc"}
 
 	fields := logrus.Fields{
 		"message": "def",


### PR DESCRIPTION
Before: `logstash.LogstashFormatter`, after: `logstash.Formatter`.

Complies with Golint which complains for now and makes it more readable.