### PR TITLE
Added Build Rule

### DIFF
--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -1,3 +1,5 @@
+// +build !windows,!nacl,!plan9
+
 package logrus_syslog
 
 import (


### PR DESCRIPTION
Add build rule, to only build on Linux platform, reason for adding this: This allows the usage of the logrus package within a Windows based project. Current logrus project fails to import due to the fact the syslog is missing on Windows.

Important Note:
The additional empty newline between the // +build and the package declaration is mandatory for GoLang to detect the build command.

Current change is tested on Windows, It allows an import of Logrus without errors