### PR TITLE
Cross compiling for Solaris-like OS

### DIFF
--- a/terminal_solaris.go
+++ b/terminal_solaris.go
@@ -1,0 +1,15 @@
+// +build solaris
+
+package logrus
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal() bool {
+	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETA)
+	return err == nil
+}


### PR DESCRIPTION
As described in issue #112 not all OS could be built. I've added support for Solaris OS (illumos kernel and SmartOs as well).

Since golang doesn't define SYS_IOCTL for Solaris, I've found nice extension "golang.org/x/sys" which has built-in IoctlGetTermios function.

I've seen projects who solve issue with absence of SYS_IOCTL by adding it manually, but for me using golang.org/x/sys seem more portable way.