### PR TITLE
Added ProvidesLogMessageAndData interface

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -116,7 +116,9 @@ func (entry Entry) log(level Level, msg string) {
 
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
-		entry.log(DebugLevel, fmt.Sprint(args...))
+		if !entry.logMsgAndData(DebugLevel, args...) {
+			entry.log(DebugLevel, fmt.Sprint(args...))
+		}
 	}
 }
 
@@ -126,13 +128,17 @@ func (entry *Entry) Print(args ...interface{}) {
 
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.Level >= InfoLevel {
-		entry.log(InfoLevel, fmt.Sprint(args...))
+		if !entry.logMsgAndData(InfoLevel, args...) {
+			entry.log(InfoLevel, fmt.Sprint(args...))
+		}
 	}
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
 	if entry.Logger.Level >= WarnLevel {
-		entry.log(WarnLevel, fmt.Sprint(args...))
+		if !entry.logMsgAndData(WarnLevel, args...) {
+			entry.log(WarnLevel, fmt.Sprint(args...))
+		}
 	}
 }
 
@@ -142,20 +148,26 @@ func (entry *Entry) Warning(args ...interface{}) {
 
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.Level >= ErrorLevel {
-		entry.log(ErrorLevel, fmt.Sprint(args...))
+		if !entry.logMsgAndData(ErrorLevel, args...) {
+			entry.log(ErrorLevel, fmt.Sprint(args...))
+		}
 	}
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
-		entry.log(FatalLevel, fmt.Sprint(args...))
+		if !entry.logMsgAndData(FatalLevel, args...) {
+			entry.log(FatalLevel, fmt.Sprint(args...))
+		}
 	}
 	os.Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
-		entry.log(PanicLevel, fmt.Sprint(args...))
+		if !entry.logMsgAndData(PanicLevel, args...) {
+			entry.log(PanicLevel, fmt.Sprint(args...))
+		}
 	}
 	panic(fmt.Sprint(args...))
 }
@@ -211,13 +223,17 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 
 func (entry *Entry) Debugln(args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
-		entry.Debug(entry.sprintlnn(args...))
+		if !entry.logMsgAndDataNn(PanicLevel, args...) {
+			entry.Debug(entry.sprintlnn(args...))
+		}
 	}
 }
 
 func (entry *Entry) Infoln(args ...interface{}) {
 	if entry.Logger.Level >= InfoLevel {
-		entry.Info(entry.sprintlnn(args...))
+		if !entry.logMsgAndDataNn(InfoLevel, args...) {
+			entry.Info(entry.sprintlnn(args...))
+		}
 	}
 }
 
@@ -237,20 +253,26 @@ func (entry *Entry) Warningln(args ...interface{}) {
 
 func (entry *Entry) Errorln(args ...interface{}) {
 	if entry.Logger.Level >= ErrorLevel {
-		entry.Error(entry.sprintlnn(args...))
+		if !entry.logMsgAndDataNn(ErrorLevel, args...) {
+			entry.Error(entry.sprintlnn(args...))
+		}
 	}
 }
 
 func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
-		entry.Fatal(entry.sprintlnn(args...))
+		if !entry.logMsgAndDataNn(FatalLevel, args...) {
+			entry.Fatal(entry.sprintlnn(args...))
+		}
 	}
 	os.Exit(1)
 }
 
 func (entry *Entry) Panicln(args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
-		entry.Panic(entry.sprintlnn(args...))
+		if !entry.logMsgAndDataNn(PanicLevel, args...) {
+			entry.Panic(entry.sprintlnn(args...))
+		}
 	}
 }
 
@@ -261,4 +283,29 @@ func (entry *Entry) Panicln(args ...interface{}) {
 func (entry *Entry) sprintlnn(args ...interface{}) string {
 	msg := fmt.Sprintln(args...)
 	return msg[:len(msg)-1]
+}
+
+func (entry *Entry) logMsgAndData(lvl Level, args ...interface{}) bool {
+	if len(args) != 1 {
+		return false
+	}
+	switch ta := args[0].(type) {
+	case ProvidesLogMessageAndData:
+		entry.WithFields(ta.GetLogData()).log(lvl, ta.GetLogMessage())
+		return true
+	}
+	return false
+}
+
+func (entry *Entry) logMsgAndDataNn(lvl Level, args ...interface{}) bool {
+	if len(args) != 1 {
+		return false
+	}
+	switch ta := args[0].(type) {
+	case ProvidesLogMessageAndData:
+		msg := ta.GetLogMessage()
+		entry.WithFields(ta.GetLogData()).log(lvl, msg[:len(msg)-1])
+		return true
+	}
+	return false
 }

--- a/logrus.go
+++ b/logrus.go
@@ -107,3 +107,13 @@ type StdLogger interface {
 	Panicf(string, ...interface{})
 	Panicln(...interface{})
 }
+
+// ProvidesLogMessageAndData is what types implement that want to provide
+// specific messages and data to log entries.
+type ProvidesLogMessageAndData interface {
+	// GetLogMessage gets the message to use with a log entry.
+	GetLogMessage() string
+
+	// GetLogData gets the field data to use with a log entry.
+	GetLogData() map[string]interface{}
+}

--- a/provides_test.go
+++ b/provides_test.go
@@ -1,0 +1,103 @@
+package logrus
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type fubarMsgAndData struct {
+	msg  string
+	data map[string]interface{}
+}
+
+func (f *fubarMsgAndData) String() string {
+	return "FUBAR"
+}
+
+type notFubarMsgAndData fubarMsgAndData
+
+func (nf *notFubarMsgAndData) GetLogMessage() string {
+	return nf.msg
+}
+
+func (nf *notFubarMsgAndData) GetLogData() map[string]interface{} {
+	return nf.data
+}
+
+func TestProvidesLogMessageAndDataFubar(t *testing.T) {
+	f := &fubarMsgAndData{
+		msg: "NAY",
+		data: map[string]interface{}{
+			"hello": "world",
+			"good":  "bye",
+		},
+	}
+	assertProvidesLogMessageAndDataFubar(f, ErrorLevel, t)
+	assertProvidesLogMessageAndDataFubar(f, WarnLevel, t)
+	assertProvidesLogMessageAndDataFubar(f, InfoLevel, t)
+	assertProvidesLogMessageAndDataFubar(f, DebugLevel, t)
+}
+
+func TestProvidesLogMessageAndData(t *testing.T) {
+	f := &notFubarMsgAndData{
+		msg: "YAY",
+		data: map[string]interface{}{
+			"hello": "world",
+			"good":  "bye",
+		},
+	}
+	assertProvidesLogMessageAndData(f, ErrorLevel, t)
+	assertProvidesLogMessageAndData(f, WarnLevel, t)
+	assertProvidesLogMessageAndData(f, InfoLevel, t)
+	assertProvidesLogMessageAndData(f, DebugLevel, t)
+}
+
+func assertProvidesLogMessageAndDataFubar(
+	obj interface{}, lvl Level, t *testing.T) {
+	b := &bytes.Buffer{}
+	l := New()
+	l.Level = DebugLevel
+	l.Formatter = &TextFormatter{DisableColors: true}
+	l.Out = b
+	switch lvl {
+	case ErrorLevel:
+		l.Error(obj)
+	case WarnLevel:
+		l.Warn(obj)
+	case InfoLevel:
+		l.Info(obj)
+	case DebugLevel:
+		l.Debug(obj)
+	}
+	s := b.String()
+	exp := fmt.Sprintf("level=%s msg=FUBAR", lvl)
+	if !strings.Contains(s, exp) {
+		t.Fatalf("s is `%s`, expected `%s`", s, exp)
+	}
+}
+
+func assertProvidesLogMessageAndData(
+	obj interface{}, lvl Level, t *testing.T) {
+	b := &bytes.Buffer{}
+	l := New()
+	l.Level = DebugLevel
+	l.Formatter = &TextFormatter{DisableColors: true}
+	l.Out = b
+	switch lvl {
+	case ErrorLevel:
+		l.Error(obj)
+	case WarnLevel:
+		l.Warn(obj)
+	case InfoLevel:
+		l.Info(obj)
+	case DebugLevel:
+		l.Debug(obj)
+	}
+	s := b.String()
+	exp := fmt.Sprintf("level=%s msg=YAY good=bye hello=world", lvl)
+	if !strings.Contains(s, exp) {
+		t.Fatalf("s is `%s`, expected `%s`", s, exp)
+	}
+}


### PR DESCRIPTION
This patch introduces the `ProvidesLogMessageAndData` interface. This interfaces enables types to directly influence the log message and data provided to a log entry when a user simply invokes `log.Info(obj)`. This simplified syntax will make things like error handling and other log-aware types so much easier on the end-developer and result in cleaner code. 

@Sirupsen, I am specifically needing this functionality for the error handling package, [Goof](https://github.com/akutz/goof), I created. If you take a look at that package I think you'll be convinced of the value of this patch. It's more than I can do via a TextFormatter.

Please see the file `provides_test.go` for examples.