### PR TITLE
Entry times as UTC with new TimestampInUTC formatting option

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -21,7 +21,7 @@ type Entry struct {
 	// Contains all the fields set by the user.
 	Data Fields
 
-	// Time at which the log entry was created
+	// Time, in UTC, at which the log entry was created
 	Time time.Time
 
 	// Level the log entry was logged at: Debug, Info, Warn, Error, Fatal or Panic
@@ -81,7 +81,7 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 // This function is not declared with a pointer value because otherwise
 // race conditions will occur when using multiple goroutines
 func (entry Entry) log(level Level, msg string) {
-	entry.Time = time.Now()
+	entry.Time = time.Now().UTC()
 	entry.Level = level
 	entry.Message = msg
 

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -8,6 +8,9 @@ import (
 type JSONFormatter struct {
 	// TimestampFormat sets the format used for marshaling timestamps.
 	TimestampFormat string
+
+	// Record time using UTC instead of local time
+	TimestampInUTC bool
 }
 
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
@@ -28,8 +31,12 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	if timestampFormat == "" {
 		timestampFormat = DefaultTimestampFormat
 	}
-
-	data["time"] = entry.Time.Format(timestampFormat)
+    
+	if f.TimestampInUTC {
+		data["time"] = entry.Time.Format(timestampFormat)
+	} else {
+		data["time"] = entry.Time.Local().Format(timestampFormat)
+	}
 	data["msg"] = entry.Message
 	data["level"] = entry.Level.String()
 

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -46,7 +46,7 @@ func TestErrorNotLostOnFieldNotNamedError(t *testing.T) {
 }
 
 func TestFieldClashWithTime(t *testing.T) {
-	formatter := &JSONFormatter{}
+	formatter := &JSONFormatter{TimestampInUTC: true}
 
 	b, err := formatter.Format(WithField("time", "right now!"))
 	if err != nil {


### PR DESCRIPTION
To ensure consistency across systems, use UTC for all Entry times.

Add a new formatting option, the boolean TimestampInUTC, in both the TextFormatter and the JSONFormatter. This boolean defaults to false, giving the existing behavior using local times.

One JSONFormatter unit test had to be changed slightly by setting TimestampInUTC: true.

It would be good to add unit testing of the TimestampInUTC setting, but I'm not sure the best way to do this.

