### PR TITLE
formatter.go: simplify prefixFieldClashes(Fields)

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -31,18 +31,15 @@ type Formatter interface {
 // It's not exported because it's still using Data in an opinionated way. It's to
 // avoid code duplication between the two default formatters.
 func prefixFieldClashes(data Fields) {
-	_, ok := data["time"]
-	if ok {
-		data["fields.time"] = data["time"]
+	if t, ok := data["time"]; ok {
+		data["fields.time"] = t
 	}
 
-	_, ok = data["msg"]
-	if ok {
-		data["fields.msg"] = data["msg"]
+	if m, ok := data["msg"]; ok {
+		data["fields.msg"] = m
 	}
 
-	_, ok = data["level"]
-	if ok {
-		data["fields.level"] = data["level"]
+	if l, ok := data["level"]; ok {
+		data["fields.level"] = l
 	}
 }


### PR DESCRIPTION
Minor refactoring: simplify the implementation of `prefixFieldClashes(Fields)` in formatter.go