### PR TITLE
Detect TTY based on stderr, not stdout

### DIFF
--- a/terminal_notwindows.go
+++ b/terminal_notwindows.go
@@ -12,9 +12,9 @@ import (
 	"unsafe"
 )
 
-// IsTerminal returns true if the given file descriptor is a terminal.
+// IsTerminal returns true if stderr's file descriptor is a terminal.
 func IsTerminal() bool {
-	fd := syscall.Stdout
+	fd := syscall.Stderr
 	var termios Termios
 	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
 	return err == 0

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -18,9 +18,9 @@ var (
 	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
 )
 
-// IsTerminal returns true if the given file descriptor is a terminal.
+// IsTerminal returns true if stderr's file descriptor is a terminal.
 func IsTerminal() bool {
-	fd := syscall.Stdout
+	fd := syscall.Stderr
 	var st uint32
 	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
 	return r != 0 && e == 0


### PR DESCRIPTION
We actually write to stderr by default, so:

bin >/dev/null

currently weirdly prints non-colorized output, whereas:

bin 2>log

weirdly prints colorized output to a file.