### PR TITLE
implemented IsTerminal() on Solaris

### DIFF
--- a/terminal_solaris.go
+++ b/terminal_solaris.go
@@ -1,15 +1,22 @@
+// Based on ssh/terminal/util_solaris.go:
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // +build solaris
 
 package logrus
 
 import (
-	"os"
-
 	"golang.org/x/sys/unix"
+	"syscall"
 )
 
 // IsTerminal returns true if the given file descriptor is a terminal.
+// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
 func IsTerminal() bool {
-	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETA)
+	fd := syscall.Stderr
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(fd, unix.TCGETA, &termio)
 	return err == nil
 }


### PR DESCRIPTION
This is a Solaris implementation of IsTerminal(), based on https://github.com/golang/go/issues/13085