### PR TITLE
Add file and line number

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -296,6 +296,6 @@ func (entry *Entry) caller() {
 			str = fmt.Sprint(filepath.Base(file), ":", line)
 		}
 
-		entry.Data["File@Line"] = str
+		entry.Data["caller"] = str
 	}
 }

--- a/exported.go
+++ b/exported.go
@@ -41,6 +41,13 @@ func GetLevel() Level {
 	return std.Level
 }
 
+// SetFileLineEnabled sets the standard logger level.
+func ShowFileLine(b bool) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	std.showFileLine = b
+}
+
 // AddHook adds a hook to the standard logger hooks.
 func AddHook(hook Hook) {
 	std.mu.Lock()

--- a/exported.go
+++ b/exported.go
@@ -42,7 +42,7 @@ func GetLevel() Level {
 }
 
 // SetFileLineEnabled sets the standard logger level.
-func ShowFileLine(b bool) {
+func ShowCaller(b bool) {
 	std.mu.Lock()
 	defer std.mu.Unlock()
 	std.showFileLine = b

--- a/logger.go
+++ b/logger.go
@@ -28,6 +28,8 @@ type Logger struct {
 	Level Level
 	// Used to sync writing to the log.
 	mu sync.Mutex
+
+	showFileLine bool
 }
 
 // Creates a new logger. Configuration should be set by changing `Formatter`,
@@ -44,10 +46,11 @@ type Logger struct {
 // It's recommended to make this a global instance called `log`.
 func New() *Logger {
 	return &Logger{
-		Out:       os.Stderr,
-		Formatter: new(TextFormatter),
-		Hooks:     make(LevelHooks),
-		Level:     InfoLevel,
+		Out:          os.Stderr,
+		Formatter:    new(TextFormatter),
+		Hooks:        make(LevelHooks),
+		Level:        InfoLevel,
+		showFileLine: true,
 	}
 }
 


### PR DESCRIPTION
This is the way I propose to add File-Line number capability. The function
ShowFileLine(bool) will set the appearance of the file and line number of the source file in logs. If you set 
ShowFileLine(false)
it only contains a function call and a boolean comparison, so performance is not an issue in it.