### PR TITLE
Add LogrusLogger interface for Entry and Logger

### DIFF
--- a/logrus.go
+++ b/logrus.go
@@ -96,3 +96,39 @@ type StdLogger interface {
 	Panicf(string, ...interface{})
 	Panicln(...interface{})
 }
+
+// Logrus logger interface generalizes Entry and Logger types, so you can take any of these
+type LogrusLogger interface {
+	// we can return LogrusLogger here, but this will require many changes and will
+	// possible break backward compatiblity
+	WithField(key string, value interface{}) *Entry
+	WithFields(fields Fields) *Entry
+	WithError(err error) *Entry
+
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Printf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Panicf(format string, args ...interface{})
+
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Print(args ...interface{})
+	Warn(args ...interface{})
+	Warning(args ...interface{})
+	Error(args ...interface{})
+	Fatal(args ...interface{})
+	Panic(args ...interface{})
+
+	Debugln(args ...interface{})
+	Infoln(args ...interface{})
+	Println(args ...interface{})
+	Warnln(args ...interface{})
+	Warningln(args ...interface{})
+	Errorln(args ...interface{})
+	Fatalln(args ...interface{})
+	Panicln(args ...interface{})
+}

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -314,3 +314,20 @@ func TestLoggingRace(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// Compile test
+func TestLogrusInterface(t *testing.T) {
+	var buffer bytes.Buffer
+	fn := func(l LogrusLogger) {
+		b := l.WithField("key", "value")
+		b.Debug("Test")
+	}
+	// test logger
+	logger := New()
+	logger.Out = &buffer
+	fn(logger)
+
+	// test Entry
+	e := logger.WithField("another", "value")
+	fn(e)
+}


### PR DESCRIPTION
This make it possible for client code to accept either Logger or Entry.
For example, utility function may accept logger object to inform fatal
errors and it is job of the calling code to provide either generic
top-level logger, or request-bound Entry created using .WithFields.

There are some tests for compilation stage check.

(fixes #308)