### PR TITLE
Add WriterLevel() function to the logger

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -7,18 +7,40 @@ import (
 )
 
 func (logger *Logger) Writer() *io.PipeWriter {
+	return logger.WriterLevel(255)
+}
+
+func (logger *Logger) WriterLevel(level Level) *io.PipeWriter {
 	reader, writer := io.Pipe()
 
-	go logger.writerScanner(reader)
+	var printFunc func(args ...interface{})
+	switch level {
+	case DebugLevel:
+		printFunc = logger.Debug
+	case InfoLevel:
+		printFunc = logger.Info
+	case WarnLevel:
+		printFunc = logger.Warn
+	case ErrorLevel:
+		printFunc = logger.Error
+	case FatalLevel:
+		printFunc = logger.Fatal
+	case PanicLevel:
+		printFunc = logger.Panic
+	default:
+		printFunc = logger.Print
+	}
+
+	go logger.writerScanner(reader, printFunc)
 	runtime.SetFinalizer(writer, writerFinalizer)
 
 	return writer
 }
 
-func (logger *Logger) writerScanner(reader *io.PipeReader) {
+func (logger *Logger) writerScanner(reader *io.PipeReader, printFunc func(args ...interface{})) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		logger.Print(scanner.Text())
+		printFunc(scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
 		logger.Errorf("Error while reading from Writer: %s", err)


### PR DESCRIPTION
This commit adds a variant of the logger's Writer() function that
accepts a log level. When the variant is used, any messages written to
the returned pipe will be written with the provided level. The original
Writer() function uses the logger's Print() method as it always has.

This makes the logger pluggable into e.g. Gorilla's [recovery handler](http://www.gorillatoolkit.org/pkg/handlers#RecoveryHandler) without adding confusion by reporting panic messages using the default log level used by `Print()`:

```go
r := mux.NewRouter()
r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
    panic("Unexpected error!")
})

http.ListenAndServe(":1123", handlers.RecoveryHandler(
    // Specify a custom output for the recovery handler.
    // In this case, we want it to utilize Logrus, and all messages should be printed as errors.
    handlers.RecoveryLogger(log.New(logrus.StandardLogger().WriterLevel(logrus.ErrorLevel), "", 0)),
)(r))
```

This change should be 100% backwards-compatible with existing code.