### PR TITLE
Add Typetalk hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Redis-Hook](https://github.com/rogierlommers/logrus-redis-hook) | Hook for logging to a ELK stack (through Redis) |
 | [Amqp-Hook](https://github.com/vladoatanasov/logrus_amqp) | Hook for logging to Amqp broker (Like RabbitMQ) |
 | [KafkaLogrus](https://github.com/goibibo/KafkaLogrus) | Hook for logging to kafka |
+| [Typetalk](https://github.com/dragon3/logrus-typetalk-hook) | Hook for logging to [Typetalk](https://www.typetalk.in/) |
 
 #### Level logging
 


### PR DESCRIPTION
I wrote a Typetalk hook for logrus.
Typetalk is a chat app like Slack and Hipchat ( https://www.typetalk.in/ )

I'd just like to add the link in the description of hooks.
