### PR TITLE
Avoid re-allocations

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -68,7 +68,7 @@ func (entry *Entry) WithField(key string, value interface{}) *Entry {
 
 // Add a map of fields to the Entry.
 func (entry *Entry) WithFields(fields Fields) *Entry {
-	data := Fields{}
+	data := make(Fields, len(entry.Data)+len(fields))
 	for k, v := range entry.Data {
 		data[k] = v
 	}


### PR DESCRIPTION
Minor optimisation, which makes quite a big difference in some high-performance environments