### PR TITLE
terminal: Include appengine tag to compile for GAE

### DIFF
--- a/terminal_appengine.go
+++ b/terminal_appengine.go
@@ -1,0 +1,8 @@
+// +build appengine
+
+package logrus
+
+// IsTerminal returns true if stderr's file descriptor is a terminal.
+func IsTerminal() bool {
+	return true
+}

--- a/terminal_bsd.go
+++ b/terminal_bsd.go
@@ -1,4 +1,5 @@
 // +build darwin freebsd openbsd netbsd dragonfly
+// +build !appengine
 
 package logrus
 

--- a/terminal_linux.go
+++ b/terminal_linux.go
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !appengine
+
 package logrus
 
 import "syscall"

--- a/terminal_notwindows.go
+++ b/terminal_notwindows.go
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 // +build linux darwin freebsd openbsd netbsd dragonfly
+// +build !appengine
 
 package logrus
 

--- a/terminal_solaris.go
+++ b/terminal_solaris.go
@@ -1,4 +1,4 @@
-// +build solaris
+// +build solaris,!appengine
 
 package logrus
 

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build windows
+// +build windows,!appengine
 
 package logrus
 


### PR DESCRIPTION
Hi!

I tried to deploy an application to PaaS, which is Google App Engine.
The application includes `github.com/Sirupsen/logrus` for logging, but I noticed logrus containes `syscall` package which is prohibited using on GAE. So I hacked `terminal_[arch].go` referencing 
https://github.com/Sirupsen/logrus/issues/310 issue.

If you are fine with the PR, please merge it!

Thank you.