### PR TITLE
race in logstashformatter.go

### DIFF
--- a/formatters/logstash/logstash.go
+++ b/formatters/logstash/logstash.go
@@ -24,11 +24,13 @@ func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	fields["@version"] = 1
 
-	if f.TimestampFormat == "" {
-		f.TimestampFormat = logrus.DefaultTimestampFormat
+	timeStampFormat := f.TimestampFormat
+
+	if timeStampFormat == "" {
+		timeStampFormat = logrus.DefaultTimestampFormat
 	}
 
-	fields["@timestamp"] = entry.Time.Format(f.TimestampFormat)
+	fields["@timestamp"] = entry.Time.Format(timeStampFormat)
 
 	// set message field
 	v, ok := entry.Data["message"]


### PR DESCRIPTION
I've got warning about date race logstashformat and fixed it. 

But there are another places which looks dangerous. For example  Entry.Data is public so there is a possibility that some code outside  will write in this map in the same moment as you read from it in Format method. 