### PR TITLE
Add new hook for Logmatic.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [ElasticSearch](https://github.com/sohlich/elogrus) | Hook for logging to ElasticSearch|
 | [Sumorus](https://github.com/doublefree/sumorus) | Hook for logging to [SumoLogic](https://www.sumologic.com/)|
 | [Logstash](https://github.com/bshuster-repo/logrus-logstash-hook) | Hook for logging to [Logstash](https://www.elastic.co/products/logstash) |
+| [Logmatic.io](https://github.com/logmatic/logmatic-go) | Hook for logging to [Logmatic.io](http://logmatic.io/) |
+
 
 #### Level logging
 


### PR DESCRIPTION
Logmatic.io is Saas-based log management solution.
We develop a simple hook in order to send your Logrus logs straight to Logmatic.io