### PR TITLE
field values can be the result of a function call made at time of logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,26 @@ In general, with Logrus using any of the `printf`-family functions should be
 seen as a hint you should add a field, however, you can still use the
 `printf`-family functions with Logrus.
 
+Usually, you'll use simple types, like string, as the values of the the fields.
+If you need to calculate the value of the field at run time, but want to
+centralize the definition of the logger with a set of fields, a function can
+be specified as the value of the field:
+
+```go
+customLogger = log.WithFields(log.Fields{
+  "static":  100,
+  "dynamic": log.Fn(myFunc),
+})
+...
+customLogger.Fatal("failed to send event")
+```
+
+This will generate a field named `dynamic` with the string value that `myFunc`
+returns *at the time the log entry is generated*.  The function must take no
+arguments and return a string, and must be cast to `logrus.Fn`.  It can be
+defined inline (`logus.Fn(func() string { ... })`), be an interface method,
+or a plain function referenced by name.
+
 #### Hooks
 
 You can add hooks for logging levels. For example to send errors to an exception

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -18,6 +18,8 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 			// Otherwise errors are ignored by `encoding/json`
 			// https://github.com/Sirupsen/logrus/issues/137
 			data[k] = v.Error()
+		case Fn:
+			data[k] = v()
 		default:
 			data[k] = v
 		}

--- a/logrus.go
+++ b/logrus.go
@@ -12,6 +12,9 @@ type Fields map[string]interface{}
 // Level type
 type Level uint8
 
+// Wrapper type to identify when to call functions for field values
+type Fn func() string
+
 // Convert the Level to a string. E.g. PanicLevel becomes "panic".
 func (level Level) String() string {
 	switch level {

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -118,6 +118,10 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 	}
 	for _, k := range keys {
 		v := entry.Data[k]
+		switch vf := v.(type) {
+		case Fn:
+			v = vf()
+		}
 		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%+v", levelColor, k, v)
 	}
 }
@@ -140,6 +144,13 @@ func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interf
 	b.WriteByte('=')
 
 	switch value := value.(type) {
+	case Fn:
+		s := value()
+		if !needsQuoting(s) {
+			b.WriteString(s)
+		} else {
+			fmt.Fprintf(b, "%q", s)
+		}
 	case string:
 		if !needsQuoting(value) {
 			b.WriteString(value)


### PR DESCRIPTION
Looking for feedback on this, I'm not married to this implementation, but I've gotten use out it for the use case described below.

This change lets you specify a function to be called _at the time the log entry is generated_ to set the value of a field.  This way you can set up a `logrus.Entry` with a bunch of context that may not be known yet, but pass that `logrus.Entry` around to other routines that can use it directly without having to create a new one with a call to `.WithFields`.

The function must take no arguments and return a string, and must be cast to `logrus.Fn`.  I didn't want to use an interface for this because that would require creating a new type in the simple case just to define a function on it.  As it stands now, you can use a inline function definition/closure, a pointer-receiver method reference, or a function name reference, so it's pretty flexible.

My exact use case is that I create an object and set up a logrus instance on it, but it needs to finish building itself out at some point in the future, or I want to log the current state of the object whenever it might emit a log line.  

A simplified, contrived version of how I'm using this:

``` go
type obj struct {
   log *logrus.Entry
   id  string
   amt int
}

func (o *obj) logIdent() string { return o.id }
func (o *obj) logAmt() string { return strconv.Itoa(o.amt) }

o := &obj{}
o.log = logrus.WithFields(logrus.Fields{
   "id":  logrus.Fn(o.logIdent),
   "amt": logrus.Fn(o.logAmt),
})
… // do something with o that modifies id and amt and does logging
o.log.Info("event occurred") // log with amt=0
o.amt -= 100
if o.amt < 0 {
  o.log.Error("amt below threshold") // log with amt=-100
}
```

I couldn't find a way to do this with the current code, other than to create new `logrus.Entry` every time the value could change: I had originally achieved this functionality by assigning a new instance of `logrus.Entry` (by calling `logrus.WithFields`) to `o.log` whenever I might change the value of `id` or `amt`, but this was error prone and didn't feel clean because, in my case, I'm populating the instance from various sources (unmarshalling from database or network, or manually building, etc) or various business rules change `amt`, and it was easy to miss having to touch logging on every one.

Suggestions for tests that would be appropriate for this change are welcome.
