### PR TITLE
Add Writer and WriterLevel to Entry

### DIFF
--- a/logrus_test.go
+++ b/logrus_test.go
@@ -359,3 +359,28 @@ func TestLogrusInterface(t *testing.T) {
 	e := logger.WithField("another", "value")
 	fn(e)
 }
+
+// Implements io.Writer using channels for synchronization, so we can wait on
+// the Entry.Writer goroutine to write in a non-racey way. This does assume that
+// there is a single call to Logger.Out for each message.
+type channelWriter chan []byte
+
+func (cw channelWriter) Write(p []byte) (int, error) {
+	cw <- p
+	return len(p), nil
+}
+
+func TestEntryWriter(t *testing.T) {
+	cw := channelWriter(make(chan []byte, 1))
+	log := New()
+	log.Out = cw
+	log.Formatter = new(JSONFormatter)
+	log.WithField("foo", "bar").WriterLevel(WarnLevel).Write([]byte("hello\n"))
+
+	bs := <-cw
+	var fields Fields
+	err := json.Unmarshal(bs, &fields)
+	assert.Nil(t, err)
+	assert.Equal(t, fields["foo"], "bar")
+	assert.Equal(t, fields["level"], "warning")
+}


### PR DESCRIPTION
This lets you do things like:

```
cmd := exec.Command("command")
stdout := logrus.WithField("fd", "stdout").Writer()
defer stdout.Close()
stderr := logrus.WithField("fd", "stderr").Writer()
defer stderr.Close()
cmd.Stdout = stdout
cmd.Stderr = stderr
```
