### PR TITLE
Allow replacing Exit function

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -150,7 +150,7 @@ func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.log(FatalLevel, fmt.Sprint(args...))
 	}
-	os.Exit(1)
+	entry.Logger.Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
@@ -198,7 +198,7 @@ func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.Fatal(fmt.Sprintf(format, args...))
 	}
-	os.Exit(1)
+	entry.Logger.Exit(1)
 }
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
@@ -245,7 +245,7 @@ func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.Fatal(entry.sprintlnn(args...))
 	}
-	os.Exit(1)
+	entry.Logger.Exit(1)
 }
 
 func (entry *Entry) Panicln(args ...interface{}) {

--- a/entry_test.go
+++ b/entry_test.go
@@ -32,6 +32,48 @@ func TestEntryWithError(t *testing.T) {
 
 }
 
+func TestEntryFatal(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter
+	entry := NewEntry(logger)
+
+	entry.Fatal("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+func TestEntryFatalf(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter
+	entry := NewEntry(logger)
+
+	entry.Fatalf("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+func TestEntryFatalln(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter
+	entry := NewEntry(logger)
+
+	entry.Fatalln("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
 func TestEntryPanicln(t *testing.T) {
 	errBoom := fmt.Errorf("boom time")
 
@@ -74,4 +116,12 @@ func TestEntryPanicf(t *testing.T) {
 	logger.Out = &bytes.Buffer{}
 	entry := NewEntry(logger)
 	entry.WithField("err", errBoom).Panicf("kaboom %v", true)
+}
+
+type exiter struct {
+	exitCode int
+}
+
+func (e *exiter) Exit(exitCode int) {
+	e.exitCode = exitCode
 }

--- a/logger.go
+++ b/logger.go
@@ -26,6 +26,8 @@ type Logger struct {
 	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
 	// logged. `logrus.Debug` is useful in
 	Level Level
+	// The function invoked by the Fatal() family of functions. The default is `os.Exit`.
+	Exit func(int)
 	// Used to sync writing to the log.
 	mu sync.Mutex
 }
@@ -48,6 +50,7 @@ func New() *Logger {
 		Formatter: new(TextFormatter),
 		Hooks:     make(LevelHooks),
 		Level:     InfoLevel,
+		Exit:      os.Exit,
 	}
 }
 
@@ -108,7 +111,7 @@ func (logger *Logger) Fatalf(format string, args ...interface{}) {
 	if logger.Level >= FatalLevel {
 		NewEntry(logger).Fatalf(format, args...)
 	}
-	os.Exit(1)
+	logger.Exit(1)
 }
 
 func (logger *Logger) Panicf(format string, args ...interface{}) {
@@ -155,7 +158,7 @@ func (logger *Logger) Fatal(args ...interface{}) {
 	if logger.Level >= FatalLevel {
 		NewEntry(logger).Fatal(args...)
 	}
-	os.Exit(1)
+	logger.Exit(1)
 }
 
 func (logger *Logger) Panic(args ...interface{}) {
@@ -202,7 +205,7 @@ func (logger *Logger) Fatalln(args ...interface{}) {
 	if logger.Level >= FatalLevel {
 		NewEntry(logger).Fatalln(args...)
 	}
-	os.Exit(1)
+	logger.Exit(1)
 }
 
 func (logger *Logger) Panicln(args ...interface{}) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,61 @@
+package logrus
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that logger.Fatal() exits even if log level set to set Panic.
+func TestFatal(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatal("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+// Test that logger.Fatalf() exits even if log level set to set Panic.
+func TestFatalf(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatalf("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+// Test that logger.Fatalln() exits even if log level set to set Panic.
+func TestFatalln(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatalln("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+type exiter struct {
+	exitCode int
+}
+
+func (e *exiter) Exit(exitCode int) {
+	e.exitCode = exitCode
+}


### PR DESCRIPTION
Adds the ability to replace the exit function called by logrus's Fatal() family. Tests can use this to replace the function with a stub that panics or otherwise stores the exit call without killing the test run.

This does mean that libraries receiving a Logger will be able to circumvent the exit functionality of Fatal calls, but those libraries could already arbitrarily terminate the program, change the logger's output destination, and add hooks, so I don't think it's really a concern.

See Sirupsen#375 is another PR modifying exit behavior. However, that PR still ultimately results in the program terminating.