### PR TITLE
customize message field with json formatter

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -2,7 +2,10 @@ package logrus
 
 import "time"
 
-const DefaultTimestampFormat = time.RFC3339
+const (
+	DefaultTimestampFormat = time.RFC3339
+	DefaultMessageField    = "msg"
+)
 
 // The Formatter interface is used to implement a custom Formatter. It takes an
 // `Entry`. It exposes all the fields, including the default ones:

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -6,6 +6,8 @@ import (
 )
 
 type JSONFormatter struct {
+	// MessageField sets the name of message field.
+	MessageField string
 	// TimestampFormat sets the format used for marshaling timestamps.
 	TimestampFormat string
 }
@@ -28,9 +30,13 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	if timestampFormat == "" {
 		timestampFormat = DefaultTimestampFormat
 	}
+	messageField := f.MessageField
+	if messageField == "" {
+		messageField = DefaultMessageField
+	}
 
 	data["time"] = entry.Time.Format(timestampFormat)
-	data["msg"] = entry.Message
+	data[messageField] = entry.Message
 	data["level"] = entry.Level.String()
 
 	serialized, err := json.Marshal(data)

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -118,3 +118,24 @@ func TestJSONEntryEndsWithNewline(t *testing.T) {
 		t.Fatal("Expected JSON log entry to end with a newline")
 	}
 }
+
+func TestCustomMessageField(t *testing.T) {
+	formatter := &JSONFormatter{MessageField: "message"}
+
+	data := NewEntry(std)
+	data.Message = "something"
+	b, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	entry := make(map[string]interface{})
+	err = json.Unmarshal(b, &entry)
+	if err != nil {
+		t.Fatal("Unable to unmarshal formatted entry: ", err)
+	}
+
+	if entry["message"] != "something" {
+		t.Fatalf("not find log data in custom message field, got %v", entry)
+	}
+}


### PR DESCRIPTION
This add `MessageField` option to JSONFormatter to customize the message field
name instead of the default `msg`.

For example, to change the message field to `message`

```
log.SetFormatter(&logrus.JSONFormatter{MessageField: "message"})
```

Fix #367 
