### PR TITLE
Renaming upper-case 'Sirupsen' to 'sirupsen'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/Sirupsen/logrus.svg?branch=master)](https://travis-ci.org/Sirupsen/logrus)&nbsp;[![GoDoc](https://godoc.org/github.com/Sirupsen/logrus?status.svg)](https://godoc.org/github.com/Sirupsen/logrus)
+# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/sirupsen/logrus.svg?branch=master)](https://travis-ci.org/sirupsen/logrus)&nbsp;[![GoDoc](https://godoc.org/github.com/sirupsen/logrus?status.svg)](https://godoc.org/github.com/sirupsen/logrus)
 
 Logrus is a structured logger for Go (golang), completely API compatible with
 the standard library logger. [Godoc][godoc]. **Please note the Logrus API is not
@@ -54,7 +54,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
 package main
 
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -65,7 +65,7 @@ func main() {
 ```
 
 Note that it's completely api-compatible with the stdlib logger, so you can
-replace your `log` imports everywhere with `log "github.com/Sirupsen/logrus"`
+replace your `log` imports everywhere with `log "github.com/sirupsen/logrus"`
 and you'll now have the flexibility of Logrus. You can customize it all you
 want:
 
@@ -74,7 +74,7 @@ package main
 
 import (
   "os"
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -123,7 +123,7 @@ application, you can also create an instance of the `logrus` Logger:
 package main
 
 import (
-  "github.com/Sirupsen/logrus"
+  "github.com/sirupsen/logrus"
 )
 
 // Create a new instance of the logger. You can have any number of instances.
@@ -176,9 +176,9 @@ Logrus comes with [built-in hooks](hooks/). Add those, or your custom hook, in
 
 ```go
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
   "gopkg.in/gemnasium/logrus-airbrake-hook.v2" // the package is named "aibrake"
-  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
   "log/syslog"
 )
 
@@ -203,7 +203,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Airbrake](https://github.com/gemnasium/logrus-airbrake-hook) | Send errors to the Airbrake API V3. Uses the official [`gobrake`](https://github.com/airbrake/gobrake) behind the scenes. |
 | [Airbrake "legacy"](https://github.com/gemnasium/logrus-airbrake-legacy-hook) | Send errors to an exception tracking service compatible with the Airbrake API V2. Uses [`airbrake-go`](https://github.com/tobi/airbrake-go) behind the scenes. |
 | [Papertrail](https://github.com/polds/logrus-papertrail-hook) | Send errors to the [Papertrail](https://papertrailapp.com) hosted logging service via UDP. |
-| [Syslog](https://github.com/Sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | Send errors to remote syslog server. Uses standard library `log/syslog` behind the scenes. |
+| [Syslog](https://github.com/sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | Send errors to remote syslog server. Uses standard library `log/syslog` behind the scenes. |
 | [Bugsnag](https://github.com/Shopify/logrus-bugsnag/blob/master/bugsnag.go) | Send errors to the Bugsnag exception tracking service. |
 | [Sentry](https://github.com/evalphobia/logrus_sentry) | Send errors to the Sentry error logging and aggregation service. |
 | [Hiprus](https://github.com/nubo/hiprus) | Send errors to a channel in hipchat. |
@@ -277,7 +277,7 @@ could do:
 
 ```go
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 init() {

--- a/alt_exit_test.go
+++ b/alt_exit_test.go
@@ -44,7 +44,7 @@ var testprog = []byte(`
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"flag"
 	"fmt"
 	"io/ioutil"

--- a/doc.go
+++ b/doc.go
@@ -7,7 +7,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
   package main
 
   import (
-    log "github.com/Sirupsen/logrus"
+    log "github.com/sirupsen/logrus"
   )
 
   func main() {
@@ -21,6 +21,6 @@ The simplest way to use Logrus is simply the package-level exported logger:
 Output:
   time="2015-09-07T08:48:33Z" level=info msg="A walrus appears" animal=walrus number=1 size=10
 
-For a full guide visit https://github.com/Sirupsen/logrus
+For a full guide visit https://github.com/sirupsen/logrus
 */
 package logrus

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var log = logrus.New()

--- a/examples/hook/hook.go
+++ b/examples/hook/hook.go
@@ -1,7 +1,7 @@
 // +build ignore
-// Do NOT include the above line in your code. This is a build contrainst used
+// Do NOT include the above line in your code. This is a build constraint used
 // to prevent import loops in the code whilst go get'ting it.
-// Read more about build contrains in golang here:
+// Read more about build constraints in golang here:
 // https://golang.org/pkg/go/build/#hdr-Build_Constraints
 
 package main

--- a/examples/hook/hook.go
+++ b/examples/hook/hook.go
@@ -1,9 +1,6 @@
 package main
 
-import (
-	"github.com/Sirupsen/logrus"
-	"gopkg.in/gemnasium/logrus-airbrake-hook.v2"
-)
+import "github.com/sirupsen/logrus"
 
 var log = logrus.New()
 

--- a/examples/hook/hook.go
+++ b/examples/hook/hook.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/sirupsen/logrus"
+	airbrake "gopkg.in/gemnasium/logrus-airbrake-hook.v2"
+)
 
 var log = logrus.New()
 

--- a/examples/hook/hook.go
+++ b/examples/hook/hook.go
@@ -1,3 +1,9 @@
+// +build ignore
+// Do NOT include the above line in your code. This is a build contrainst used
+// to prevent import loops in the code whilst go get'ting it.
+// Read more about build contrains in golang here:
+// https://golang.org/pkg/go/build/#hdr-Build_Constraints
+
 package main
 
 import (

--- a/hooks/syslog/README.md
+++ b/hooks/syslog/README.md
@@ -5,8 +5,8 @@
 ```go
 import (
   "log/syslog"
-  "github.com/Sirupsen/logrus"
-  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  "github.com/sirupsen/logrus"
+  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func main() {
@@ -24,8 +24,8 @@ If you want to connect to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "
 ```go
 import (
   "log/syslog"
-  "github.com/Sirupsen/logrus"
-  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  "github.com/sirupsen/logrus"
+  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func main() {

--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -4,9 +4,10 @@ package logrus_syslog
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
 	"log/syslog"
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
 // SyslogHook to send logs via syslog.

--- a/hooks/syslog/syslog_test.go
+++ b/hooks/syslog/syslog_test.go
@@ -1,9 +1,10 @@
 package logrus_syslog
 
 import (
-	"github.com/Sirupsen/logrus"
 	"log/syslog"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestLocalhostAddAndPrint(t *testing.T) {

--- a/hooks/test/test.go
+++ b/hooks/test/test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"io/ioutil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // test.Hook is a hook designed for dealing with logs in test scenarios.

--- a/hooks/test/test_test.go
+++ b/hooks/test/test_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -16,7 +16,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		switch v := v.(type) {
 		case error:
 			// Otherwise errors are ignored by `encoding/json`
-			// https://github.com/Sirupsen/logrus/issues/137
+			// https://github.com/sirupsen/logrus/issues/137
 			data[k] = v.Error()
 		default:
 			data[k] = v


### PR DESCRIPTION
The reason for this is that most other packages use lower-case naming conventions.

The vendoring tool I use (GB) is case sensitive, and can become a massive pain in the :peach: when Logrus is the only package with an upper-case name (as most other packages are in lower case, following https://blog.golang.org/package-names) - this often leads to build failures.

> Why don't you just vendor it in lower case?

Because Logrus has itself as an internal dependency, it vendors two folders, `Sirupsen/logrus` and `sirupsen/logrus`.
