### PR TITLE
Allow replacing Exit function

### DIFF
--- a/alt_exit.go
+++ b/alt_exit.go
@@ -51,6 +51,16 @@ func Exit(code int) {
 	os.Exit(code)
 }
 
+// handleExit runs all the Logrus atexit handlers and then terminates the program using the logger's Exit function (or os.Exit() if no exit function is set).
+func (logger *Logger) handleExit(code int) {
+	runHandlers()
+	if logger.Exit != nil {
+		logger.Exit(code)
+	} else {
+		os.Exit(code)
+	}
+}
+
 // RegisterExitHandler adds a Logrus Exit handler, call logrus.Exit to invoke
 // all handlers. The handlers will also be invoked when any Fatal log entry is
 // made.

--- a/entry.go
+++ b/entry.go
@@ -161,7 +161,7 @@ func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.log(FatalLevel, fmt.Sprint(args...))
 	}
-	Exit(1)
+	entry.Logger.handleExit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
@@ -209,7 +209,7 @@ func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.Fatal(fmt.Sprintf(format, args...))
 	}
-	Exit(1)
+	entry.Logger.handleExit(1)
 }
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
@@ -256,7 +256,7 @@ func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.Fatal(entry.sprintlnn(args...))
 	}
-	Exit(1)
+	entry.Logger.handleExit(1)
 }
 
 func (entry *Entry) Panicln(args ...interface{}) {

--- a/entry_test.go
+++ b/entry_test.go
@@ -32,6 +32,48 @@ func TestEntryWithError(t *testing.T) {
 
 }
 
+func TestEntryFatal(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter.Exit
+	entry := NewEntry(logger)
+
+	entry.Fatal("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+func TestEntryFatalf(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter.Exit
+	entry := NewEntry(logger)
+
+	entry.Fatalf("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+func TestEntryFatalln(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter.Exit
+	entry := NewEntry(logger)
+
+	entry.Fatalln("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
 func TestEntryPanicln(t *testing.T) {
 	errBoom := fmt.Errorf("boom time")
 

--- a/logger.go
+++ b/logger.go
@@ -26,6 +26,11 @@ type Logger struct {
 	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
 	// logged. `logrus.Debug` is useful in
 	Level Level
+	// The function invoked by the Fatal() family of functions. The default is `os.Exit`.
+	// Keep in mind that invocation of any Fatal() function is expected to
+	// terminate execution. Replacing this with a function that does not terminate
+	// execution may lead to surprising results.
+	Exit func(int)
 	// Used to sync writing to the log. Locking is enabled by Default
 	mu MutexWrap
 	// Reusable empty entry
@@ -163,7 +168,7 @@ func (logger *Logger) Fatalf(format string, args ...interface{}) {
 		entry.Fatalf(format, args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
+	logger.handleExit(1)
 }
 
 func (logger *Logger) Panicf(format string, args ...interface{}) {
@@ -226,7 +231,7 @@ func (logger *Logger) Fatal(args ...interface{}) {
 		entry.Fatal(args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
+	logger.handleExit(1)
 }
 
 func (logger *Logger) Panic(args ...interface{}) {
@@ -289,7 +294,7 @@ func (logger *Logger) Fatalln(args ...interface{}) {
 		entry.Fatalln(args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
+	logger.handleExit(1)
 }
 
 func (logger *Logger) Panicln(args ...interface{}) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,53 @@
+package logrus
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that logger.Fatal() exits even if log level set to set Panic.
+func TestFatal(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatal("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+// Test that logger.Fatalf() exits even if log level set to set Panic.
+func TestFatalf(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatalf("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+// Test that logger.Fatalln() exits even if log level set to set Panic.
+func TestFatalln(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatalln("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -359,3 +359,11 @@ func TestLogrusInterface(t *testing.T) {
 	e := logger.WithField("another", "value")
 	fn(e)
 }
+
+type exiter struct {
+	exitCode int
+}
+
+func (e *exiter) Exit(exitCode int) {
+	e.exitCode = exitCode
+}


### PR DESCRIPTION
Adds the ability to replace the exit function called by logrus's Fatal() family. Tests can use this to replace the function with a stub that panics or otherwise stores the exit call without killing the test run.

This does mean that libraries receiving a Logger will be able to circumvent the exit functionality of Fatal calls, but those libraries could already arbitrarily terminate the program, change the logger's output destination, and add hooks, so I don't think it's really a concern.
