### PR TITLE
remote caller (another take)

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -1,8 +1,16 @@
 package logrus
 
-import "time"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
 
 const DefaultTimestampFormat = time.RFC3339
+
+// To be used for triming base path of remote caller
+var gosrcpath = filepath.Join(os.Getenv("GOPATH"), "src")
 
 // The Formatter interface is used to implement a custom Formatter. It takes an
 // `Entry`. It exposes all the fields, including the default ones:
@@ -30,7 +38,7 @@ type Formatter interface {
 //
 // It's not exported because it's still using Data in an opinionated way. It's to
 // avoid code duplication between the two default formatters.
-func prefixFieldClashes(data Fields) {
+func prefixFieldClashes(data Fields, hasRemoteCaller bool) {
 	if t, ok := data["time"]; ok {
 		data["fields.time"] = t
 	}
@@ -42,4 +50,15 @@ func prefixFieldClashes(data Fields) {
 	if l, ok := data["level"]; ok {
 		data["fields.level"] = l
 	}
+
+	if hasRemoteCaller {
+		if c, ok := data["caller"]; ok {
+			data["fields.caller"] = c
+		}
+	}
+}
+
+// chop of GOPATH + src from the full path of the file, keeping the package path
+func formatRemoteCaller(caller string) string {
+	return strings.TrimPrefix(caller, gosrcpath)
 }

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -22,7 +22,8 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 			data[k] = v
 		}
 	}
-	prefixFieldClashes(data)
+	hasRemoteCaller := entry.RemoteCaller != ""
+	prefixFieldClashes(data, hasRemoteCaller)
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {
@@ -32,6 +33,10 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	data["time"] = entry.Time.Format(timestampFormat)
 	data["msg"] = entry.Message
 	data["level"] = entry.Level.String()
+
+	if hasRemoteCaller {
+		data["caller"] = formatRemoteCaller(entry.RemoteCaller)
+	}
 
 	serialized, err := json.Marshal(data)
 	if err != nil {

--- a/logger.go
+++ b/logger.go
@@ -26,6 +26,8 @@ type Logger struct {
 	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
 	// logged. `logrus.Debug` is useful in
 	Level Level
+	// Whether the caller should be logged or not
+	ShowCaller bool
 	// Used to sync writing to the log.
 	mu sync.Mutex
 }
@@ -44,10 +46,11 @@ type Logger struct {
 // It's recommended to make this a global instance called `log`.
 func New() *Logger {
 	return &Logger{
-		Out:       os.Stderr,
-		Formatter: new(TextFormatter),
-		Hooks:     make(LevelHooks),
-		Level:     InfoLevel,
+		Out:        os.Stderr,
+		Formatter:  new(TextFormatter),
+		Hooks:      make(LevelHooks),
+		Level:      InfoLevel,
+		ShowCaller: true,
 	}
 }
 

--- a/remote_caller_test/dummy.go
+++ b/remote_caller_test/dummy.go
@@ -1,0 +1,6 @@
+// mitigate go get "no buildable Go source files in"
+package main
+
+func main() {
+	// pointless main
+}

--- a/remote_caller_test/remote_caller_test.go
+++ b/remote_caller_test/remote_caller_test.go
@@ -1,0 +1,172 @@
+// test remote caller from an external packages point of view
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var expectedFilePattern = regexp.MustCompile(`remote_caller_test\.go:\d+$`)
+
+func TestVanilla(t *testing.T) {
+	var buff bytes.Buffer
+	var fields log.Fields
+
+	log.SetOutput(&buff)
+	log.SetFormatter(&log.JSONFormatter{})
+
+	log.Info("dummy")
+
+	err := json.Unmarshal(buff.Bytes(), &fields)
+	if err != nil {
+		t.Errorf("should have decoded message, got: %s", err)
+	}
+
+	caller := fields["caller"].(string)
+	t.Logf("got caller: %s", caller)
+	if !expectedFilePattern.MatchString(caller) {
+		t.Errorf("found unexpected caller: %s", caller)
+	}
+}
+
+func TestChainedField(t *testing.T) {
+	var buff bytes.Buffer
+	var fields log.Fields
+
+	log.SetOutput(&buff)
+	log.SetFormatter(&log.JSONFormatter{})
+
+	log.WithField("foo", "bar").Info("baz")
+
+	err := json.Unmarshal(buff.Bytes(), &fields)
+	if err != nil {
+		t.Errorf("should have decoded message, got: %s", err)
+	}
+
+	caller := fields["caller"].(string)
+	t.Logf("got caller: %s", caller)
+	if !expectedFilePattern.MatchString(caller) {
+		t.Errorf("found unexpected caller: %s", caller)
+	}
+}
+
+func TestReusedField(t *testing.T) {
+	var buff bytes.Buffer
+	var fields log.Fields
+
+	log.SetOutput(&buff)
+	log.SetFormatter(&log.JSONFormatter{})
+
+	foolog := log.WithField("foo", "bar")
+	foolog.Info("baz")
+	buff.Reset()
+	foolog.Info("baz2")
+
+	err := json.Unmarshal(buff.Bytes(), &fields)
+	if err != nil {
+		t.Errorf("should have decoded message, got: %s", err)
+	}
+
+	caller := fields["caller"].(string)
+	t.Logf("got caller: %s", caller)
+	if !expectedFilePattern.MatchString(caller) {
+		t.Errorf("found unexpected caller: %s", caller)
+	}
+}
+
+func TestReusedMultipleField(t *testing.T) {
+	var buff bytes.Buffer
+	var fields log.Fields
+
+	log.SetOutput(&buff)
+	log.SetFormatter(&log.JSONFormatter{})
+
+	foolog := log.WithFields(log.Fields{"foo": "bar", "q": 42})
+	foolog.Info("baz")
+	buff.Reset()
+	foolog.Info("baz2")
+
+	err := json.Unmarshal(buff.Bytes(), &fields)
+	if err != nil {
+		t.Errorf("should have decoded message, got: %s", err)
+	}
+
+	caller := fields["caller"].(string)
+	t.Logf("got caller: %s", caller)
+	if !expectedFilePattern.MatchString(caller) {
+		t.Errorf("found unexpected caller: %s", caller)
+	}
+}
+
+func TestMultipleChanins(t *testing.T) {
+	var buff bytes.Buffer
+	var fields log.Fields
+
+	log.SetOutput(&buff)
+	log.SetFormatter(&log.JSONFormatter{})
+
+	foolog := log.WithFields(log.Fields{"foo": "bar", "q": 42}).WithField("such", "field")
+	foolog.Info("baz")
+	buff.Reset()
+	foolog.Info("baz2")
+
+	err := json.Unmarshal(buff.Bytes(), &fields)
+	if err != nil {
+		t.Errorf("should have decoded message, got: %s", err)
+	}
+
+	caller := fields["caller"].(string)
+	t.Logf("got caller: %s", caller)
+	if !expectedFilePattern.MatchString(caller) {
+		t.Errorf("found unexpected caller: %s", caller)
+	}
+}
+
+func TestErrorField(t *testing.T) {
+	var buff bytes.Buffer
+	var fields log.Fields
+
+	log.SetOutput(&buff)
+	log.SetFormatter(&log.JSONFormatter{})
+
+	foolog := log.WithError(errors.New("wow, much error"))
+	foolog.Info("baz")
+
+	err := json.Unmarshal(buff.Bytes(), &fields)
+	if err != nil {
+		t.Errorf("should have decoded message, got: %s", err)
+	}
+
+	caller := fields["caller"].(string)
+	t.Logf("got caller: %s", caller)
+	if !expectedFilePattern.MatchString(caller) {
+		t.Errorf("found unexpected caller: %s", caller)
+	}
+}
+
+func TestNoCaller(t *testing.T) {
+	var buff bytes.Buffer
+	var fields log.Fields
+
+	l := log.New()
+	l.ShowCaller = false
+	l.Out = &buff
+	l.Formatter = &log.JSONFormatter{}
+
+	l.Info("baz")
+
+	err := json.Unmarshal(buff.Bytes(), &fields)
+	if err != nil {
+		t.Errorf("should have decoded message, got: %s", err)
+	}
+
+	if caller, exists := fields["caller"]; exists {
+		t.Errorf("caller not expected, but found one: %s", caller)
+	}
+
+}

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -57,6 +57,14 @@ type TextFormatter struct {
 }
 
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
+	b := &bytes.Buffer{}
+
+	hasRemoteCaller := entry.RemoteCaller != ""
+	prefixFieldClashes(entry.Data, hasRemoteCaller)
+	if hasRemoteCaller {
+		entry.Data["caller"] = formatRemoteCaller(entry.RemoteCaller)
+	}
+
 	var keys []string = make([]string, 0, len(entry.Data))
 	for k := range entry.Data {
 		keys = append(keys, k)
@@ -65,10 +73,6 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	if !f.DisableSorting {
 		sort.Strings(keys)
 	}
-
-	b := &bytes.Buffer{}
-
-	prefixFieldClashes(entry.Data)
 
 	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
 	isColored := (f.ForceColors || isColorTerminal) && !f.DisableColors


### PR DESCRIPTION
So, since #349 have not been merged yet, I thought I make another go at implementing remote caller support, addressing #63  (This patch is not based on any prior work)

There are a few differences in this patch compared to #349.
Mainly that here the actual remote caller look up is done in the "core" of logrus if you will, and then stored in the `Entry` as `RemoteCaller`. `RemoteCaller` will then contain some thing like `/full/path/to/file.go:42` after a successful lookup.

It is then up to the formatter if it likes to make use of the info. I have added remote caller as `caller` in both the text and json formatter.

I believe this is closer to how it should be done if logrus should be able to claim that it has support for remote caller. Since this actually add info about the caller, not just a the option that the user would like to show caller which is how it is done in #349 then basically leaving it up to the formatter to actually find the caller.

About compatibility, `ShowCaller` is on by default. Which means that any one that uses logrus out of the box with no additional config will have caller now appear with out any config change. To disable this one can set `logger.ShowCaller = false` on the logger. Any custom formatters output won't be affected, since they now should make use of `entry.RemoteCaller` if they want to show the caller. (Thought if one use a custom formatter not making use of `RemoteCaller` one should probably set `ShowCaller = false` to avoid doing the lookup).
