### PR TITLE
Add log.Logger's Output method to Logger&Entry

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -254,6 +254,11 @@ func (entry *Entry) Panicln(args ...interface{}) {
 	}
 }
 
+func (entry *Entry) Output(calldepth int, s string) error {
+	entry.Infoln(s)
+	return nil
+}
+
 // Sprintlnn => Sprint no newline. This is to get the behavior of how
 // fmt.Sprintln where spaces are always added between operands, regardless of
 // their type. Instead of vendoring the Sprintln implementation to spare a

--- a/logger.go
+++ b/logger.go
@@ -210,3 +210,8 @@ func (logger *Logger) Panicln(args ...interface{}) {
 		NewEntry(logger).Panicln(args...)
 	}
 }
+
+func (logger *Logger) Output(calldepth int, s string) error {
+	NewEntry(logger).Println(s)
+	return nil
+}

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -83,6 +83,15 @@ func TestWarn(t *testing.T) {
 	})
 }
 
+func TestOutput(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Output(2, "test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test")
+		assert.Equal(t, fields["level"], "info")
+	})
+}
+
 func TestInfolnShouldAddSpacesBetweenStrings(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Infoln("test", "test")


### PR DESCRIPTION
The standard library's *log.Logger type has the method

```
Output(calldepth int, s string) error
```

Because it is so minimal, many libraries chose to target
it as an interface, which users could implement to receive
additional log messages:

```
type Logger {
    Output(int, string) error
}
```

While it is not overwhelmingly used, it is out there. Implementing
this interface allows us to use logrus.Logger and logrus.Entry
types to receive log messages from such libraries. I chose to log
such messages at the "Info" level, copying the Print\* methods. The
"calldepth" argument is ignored.

Addresses issue #118 
