### PR TITLE
Added customizable keys to JSON formatter

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 )
+
 type fieldKey string
 type FieldMap map[fieldKey]string
 
@@ -24,7 +25,17 @@ func (f FieldMap) resolve(key fieldKey) string {
 type JSONFormatter struct {
 	// TimestampFormat sets the format used for marshaling timestamps.
 	TimestampFormat string
-	FieldMap        FieldMap
+
+	// FieldMap allows users to customize the names of keys for various fields.
+	// As an example:
+	// formatter := &JSONFormatter{
+	//   	FieldMap: FieldMap{
+	// 		 FieldKeyTime: "@timestamp",
+	// 		 FieldKeyLevel: "@level",
+	// 		 FieldKeyLevel: "@message",
+	//    },
+	// }
+	FieldMap FieldMap
 }
 
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -8,6 +8,9 @@ import (
 type JSONFormatter struct {
 	// TimestampFormat sets the format used for marshaling timestamps.
 	TimestampFormat string
+	MessageKey      string
+	LevelKey        string
+	TimeKey         string
 }
 
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
@@ -29,9 +32,24 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		timestampFormat = DefaultTimestampFormat
 	}
 
-	data["time"] = entry.Time.Format(timestampFormat)
-	data["msg"] = entry.Message
-	data["level"] = entry.Level.String()
+	timeKey := f.TimeKey
+	if timeKey == "" {
+		timeKey = "time"
+	}
+
+	messageKey := f.MessageKey
+	if messageKey == "" {
+		messageKey = "msg"
+	}
+
+	levelKey := f.LevelKey
+	if levelKey == "" {
+		levelKey = "level"
+	}
+
+	data[timeKey] = entry.Time.Format(timestampFormat)
+	data[messageKey] = entry.Message
+	data[levelKey] = entry.Level.String()
 
 	serialized, err := json.Marshal(data)
 	if err != nil {

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -5,6 +5,14 @@ import (
 	"fmt"
 )
 
+type fieldKey string
+
+const (
+	DefaultKeyMsg   = "msg"
+	DefaultKeyLevel = "level"
+	DefaultKeyTime  = "time"
+)
+
 type JSONFormatter struct {
 	// TimestampFormat sets the format used for marshaling timestamps.
 	TimestampFormat string
@@ -32,28 +40,20 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		timestampFormat = DefaultTimestampFormat
 	}
 
-	timeKey := f.TimeKey
-	if timeKey == "" {
-		timeKey = "time"
-	}
-
-	messageKey := f.MessageKey
-	if messageKey == "" {
-		messageKey = "msg"
-	}
-
-	levelKey := f.LevelKey
-	if levelKey == "" {
-		levelKey = "level"
-	}
-
-	data[timeKey] = entry.Time.Format(timestampFormat)
-	data[messageKey] = entry.Message
-	data[levelKey] = entry.Level.String()
+	data[f.resolveKey(f.TimeKey, DefaultKeyTime)] = entry.Time.Format(timestampFormat)
+	data[f.resolveKey(f.MessageKey, DefaultKeyMsg)] = entry.Message
+	data[f.resolveKey(f.LevelKey, DefaultKeyLevel)] = entry.Level.String()
 
 	serialized, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
 	}
 	return append(serialized, '\n'), nil
+}
+
+func (f *JSONFormatter) resolveKey(key, defaultKey string) string {
+	if len(key) > 0 {
+		return key
+	}
+	return defaultKey
 }

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -3,7 +3,7 @@ package logrus
 import (
 	"encoding/json"
 	"errors"
-
+	"strings"
 	"testing"
 )
 
@@ -116,5 +116,44 @@ func TestJSONEntryEndsWithNewline(t *testing.T) {
 
 	if b[len(b)-1] != '\n' {
 		t.Fatal("Expected JSON log entry to end with a newline")
+	}
+}
+
+func TestJSONMessageKey(t *testing.T) {
+	formatter := &JSONFormatter{MessageKey: "message"}
+
+	b, err := formatter.Format(&Entry{Message: "oh hai"})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !(strings.Contains(s, "message") && strings.Contains(s, "oh hai")) {
+		t.Fatal("Expected JSON to format message key")
+	}
+}
+
+func TestJSONLevelKey(t *testing.T) {
+	formatter := &JSONFormatter{LevelKey: "somelevel"}
+
+	b, err := formatter.Format(WithField("level", "something"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "somelevel") {
+		t.Fatal("Expected JSON to format level key")
+	}
+}
+
+func TestJSONTimeKey(t *testing.T) {
+	formatter := &JSONFormatter{TimeKey: "timeywimey"}
+
+	b, err := formatter.Format(WithField("level", "something"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "timeywimey") {
+		t.Fatal("Expected JSON to format time key")
 	}
 }

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -120,7 +120,11 @@ func TestJSONEntryEndsWithNewline(t *testing.T) {
 }
 
 func TestJSONMessageKey(t *testing.T) {
-	formatter := &JSONFormatter{MessageKey: "message"}
+	formatter := &JSONFormatter{
+		FieldMap: FieldMap{
+			FieldKeyMsg: "message",
+		},
+	}
 
 	b, err := formatter.Format(&Entry{Message: "oh hai"})
 	if err != nil {
@@ -133,7 +137,11 @@ func TestJSONMessageKey(t *testing.T) {
 }
 
 func TestJSONLevelKey(t *testing.T) {
-	formatter := &JSONFormatter{LevelKey: "somelevel"}
+	formatter := &JSONFormatter{
+		FieldMap: FieldMap{
+			FieldKeyLevel: "somelevel",
+		},
+	}
 
 	b, err := formatter.Format(WithField("level", "something"))
 	if err != nil {
@@ -146,7 +154,11 @@ func TestJSONLevelKey(t *testing.T) {
 }
 
 func TestJSONTimeKey(t *testing.T) {
-	formatter := &JSONFormatter{TimeKey: "timeywimey"}
+	formatter := &JSONFormatter{
+		FieldMap: FieldMap{
+			FieldKeyTime: "timeywimey",
+		},
+	}
 
 	b, err := formatter.Format(WithField("level", "something"))
 	if err != nil {


### PR DESCRIPTION
I have found a need for this and I'm sure it would be useful to others as well. If a user needs to customize the keys of the JSON message to fit a particular parsing scheme, they are currently disallowed from changing the key `msg` to `message` for example or `level`, or `time` as they are all hard-coded. This fix allows simple customizability of the keys in the JSON formatter.
