### PR TITLE
Fix race condition in hooks that modify entry.Data by guarding access

### DIFF
--- a/formatter_bench_test.go
+++ b/formatter_bench_test.go
@@ -2,6 +2,7 @@ package logrus
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -85,6 +86,7 @@ func doBenchmark(b *testing.B, formatter Formatter, fields Fields) {
 		Level:   InfoLevel,
 		Message: "message",
 		Data:    fields,
+		mu:      &sync.RWMutex{},
 	}
 	var d []byte
 	var err error

--- a/hooks.go
+++ b/hooks.go
@@ -29,6 +29,5 @@ func (hooks LevelHooks) Fire(level Level, entry *Entry) error {
 			return err
 		}
 	}
-
 	return nil
 }

--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -4,9 +4,10 @@ package logrus_syslog
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
 	"log/syslog"
 	"os"
+
+	"github.com/Sirupsen/logrus"
 )
 
 // SyslogHook to send logs via syslog.

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -11,6 +11,7 @@ type JSONFormatter struct {
 }
 
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
+	entry.mu.RLock()
 	data := make(Fields, len(entry.Data)+3)
 	for k, v := range entry.Data {
 		switch v := v.(type) {
@@ -22,7 +23,11 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 			data[k] = v
 		}
 	}
+	entry.mu.RUnlock()
+
+	entry.mu.Lock()
 	prefixFieldClashes(data)
+	entry.mu.Unlock()
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {


### PR DESCRIPTION
Fixes Sirupsen/logrus#364
I'm not sold on the aesthetics of the implementation, but it's the only way I can think of doing it without breaking existing hooks.
