### PR TITLE
TextFormatter: brighten up the blue

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -14,7 +14,7 @@ const (
 	red     = 31
 	green   = 32
 	yellow  = 33
-	blue    = 34
+	blue    = 36
 	gray    = 37
 )
 


### PR DESCRIPTION
Logrus is amazing, but I find the current blue color used by the TextFormatter to be near impossible to read. I've updated it to a bit more of a cyan, but I think it can pass as a blue. See screenshots below.

Before:
![screen shot 2016-08-23 at 9 56 08 am](https://cloud.githubusercontent.com/assets/18831/17902334/f06d1c6e-6934-11e6-961d-0126b4f663ce.png)

After:
![screen shot 2016-08-23 at 9 56 29 am](https://cloud.githubusercontent.com/assets/18831/17902337/f2df0cc8-6934-11e6-8b4e-ae86552507ce.png)
