### PR TITLE
Allow disabling timestamps with colored output

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -115,7 +115,9 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 
 	levelText := strings.ToUpper(entry.Level.String())[0:4]
 
-	if !f.FullTimestamp {
+	if f.DisableTimestamp {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %-44s ", levelColor, levelText, entry.Message)
+	} else if !f.FullTimestamp {
 		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, miniTS(), entry.Message)
 	} else {
 		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 	"time"
+	"strings"
 )
 
 func TestQuoting(t *testing.T) {
@@ -55,6 +56,15 @@ func TestTimestampFormat(t *testing.T) {
 	checkTimeStr("2006-01-02T15:04:05.000000000Z07:00")
 	checkTimeStr("Mon Jan _2 15:04:05 2006")
 	checkTimeStr("")
+}
+
+func TestDisableTimestampWithColoredOutput(t *testing.T) {
+	tf := &TextFormatter{DisableTimestamp: true, ForceColors: true}
+
+	b, _ := tf.Format(WithField("test", "test"))
+	if strings.Contains(string(b), "[0000]") {
+		t.Error("timestamp not expected when DisableTimestamp is true")
+	}
 }
 
 // TODO add tests for sorting etc., this requires a parser for the text


### PR DESCRIPTION
When using colored output, `DisableTimestamps` doesn't work.

**Sample Application**

```
package main

import "github.com/Sirupsen/logrus"

func main() {
    l := logrus.New()
    l.Formatter = &logrus.TextFormatter{
        DisableTimestamp: true,
        ForceColors:      true,
    }

    l.Info("I'm a little teapot")
}
```

**Expected Output**

```
INFO I'm a little teapot
```

**Actual Output**

```
INFO[0000] I'm a little teapot
```
