### PR TITLE
Ignore example hook to avoid failing test when Go1.5 or lower

### DIFF
--- a/examples/hook/hook.go
+++ b/examples/hook/hook.go
@@ -1,3 +1,5 @@
+// +build go1.6
+
 package main
 
 import (


### PR DESCRIPTION
Since `gopkg.in/airbrake/gobrake.v2` updated to use new Go version's feature, tests is failing  in Go1.5 or lower.
So skip `go get` in old go version to add build tags.
