### PR TITLE
Add additional fields to logger that will be present on all new entries

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -26,6 +27,8 @@ type Logger struct {
 	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
 	// logged. `logrus.Debug` is useful in
 	Level Level
+	// Additional fields that will be attached to every new entry
+	AdditionalFields Fields
 	// Used to sync writing to the log. Locking is enabled by Default
 	mu MutexWrap
 	// Reusable empty entry
@@ -76,10 +79,14 @@ func New() *Logger {
 
 func (logger *Logger) newEntry() *Entry {
 	entry, ok := logger.entryPool.Get().(*Entry)
-	if ok {
-		return entry
+	if !ok {
+		entry = NewEntry(logger)
 	}
-	return NewEntry(logger)
+	if len(logger.AdditionalFields) > 0 {
+		fmt.Println("we have additional fields")
+		return entry.WithFields(logger.AdditionalFields)
+	}
+	return entry
 }
 
 func (logger *Logger) releaseEntry(entry *Entry) {

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -131,6 +131,25 @@ func TestInfoShouldNotAddSpacesBetweenStrings(t *testing.T) {
 	})
 }
 
+func TestAdditionalFieldsAreAddedToNewEntries(t *testing.T) {
+	var buffer bytes.Buffer
+	var fields Fields
+
+	addFields := Fields{"test": "testing", "moretest": "moretesting"}
+	logger := New()
+	logger.Out = &buffer
+	logger.Formatter = new(JSONFormatter)
+	logger.AdditionalFields = addFields
+
+	logger.Info("myTest")
+
+	err := json.Unmarshal(buffer.Bytes(), &fields)
+	assert.Nil(t, err)
+
+	assert.Equal(t, fields["test"], "testing")
+	assert.Equal(t, fields["moretest"], "moretesting")
+}
+
 func TestWithFieldsShouldAllowAssignments(t *testing.T) {
 	var buffer bytes.Buffer
 	var fields Fields


### PR DESCRIPTION
We have a bunch of things we want to go into every log line: App name, region app is running in, server name, etc. The existing solution is to Create an Entry and distribute that throughout your code in place of a logger. Howere, that requires all methods than previously took a Logger to take an Entry, which is non-intuitive (at least to me)