### PR TITLE
None formatter for basically disabling processing of logging messages.

### DIFF
--- a/none_formatter.go
+++ b/none_formatter.go
@@ -1,0 +1,9 @@
+package logrus
+
+// NoneFormatter has only the Format() member function, which returns a null formatter
+type NoneFormatter struct { }
+
+// Format for NoneFormatter returns nil,nil to ignore all by log.Fatal
+func (f *NoneFormatter) Format(entry *Entry) ([]byte, error) {
+	return nil, nil
+}

--- a/none_formatter_test.go
+++ b/none_formatter_test.go
@@ -1,0 +1,13 @@
+package logrus
+
+import "testing"
+
+// TestNoneFormat should return nil,nil for ignoring log output
+func TestNoneFormat(t *testing.T) {
+	nof := &NoneFormatter{}
+
+	b, _ := nof.Format(WithField("test", "anything"))
+	if b != nil {
+		t.Errorf("none formatter returned an actual formatter?")
+	}
+}


### PR DESCRIPTION
Effectively disable all processing of calls to logging, except for Fatal() which it cannot and should not disable. This is similar to the null logger in log4j and is like writing to /dev/null.