### PR TITLE
Update to stop printing timestamp if disabled and in color

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -115,10 +115,14 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 
 	levelText := strings.ToUpper(entry.Level.String())[0:4]
 
-	if !f.FullTimestamp {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, miniTS(), entry.Message)
+	if f.DisableTimestamp {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %-44s ", levelColor, levelText, entry.Message)
 	} else {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
+		if !f.FullTimestamp {
+			fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, miniTS(), entry.Message)
+		} else {
+			fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
+		}
 	}
 	for _, k := range keys {
 		v := entry.Data[k]


### PR DESCRIPTION
## Goal

I don't want the timestamp to be printed, but do want to keep the excellent color/formatting.
## Problem

While there is an option for `DisableTimestamp` in `logrus.TextFormatter` struct, I found that this will **only** exclude the timestamp if printing **without color**. 
## Solution

Add one other check for `DisableTimestamp` within `TextFormatter.printColored` method.
