### PR TITLE
Flip stdout and stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ func init() {
   // Log as JSON instead of the default ASCII formatter.
   log.SetFormatter(&log.JSONFormatter{})
 
-  // Output to stderr instead of stdout, could also be a file.
-  log.SetOutput(os.Stderr)
+  // Output to stdout instead of stderr, could also be a file.
+  log.SetOutput(os.Stdout)
 
   // Only log the warning severity or above.
   log.SetLevel(log.WarnLevel)


### PR DESCRIPTION
The default was changed to os.Stderr in f8f08842cce7ed05c296430852f60f287458c529
