### PR TITLE
Remove TTY checking from text formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ ocean","size":10,"time":"2014-03-10 19:57:38.562264131 -0400 EDT"}
 "time":"2014-03-10 19:57:38.562543128 -0400 EDT"}
 ```
 
-With the default `log.SetFormatter(&log.TextFormatter{})` when a TTY is not
-attached, the output is compatible with the
+With `log.SetFormatter(&log.TextFormatter{Colors: false})`, the output is compatible with the
 [logfmt](http://godoc.org/github.com/kr/logfmt) format:
 
 ```text
@@ -304,9 +303,6 @@ The built-in logging formatters are:
 
 * `logrus.TextFormatter`. Logs the event in colors if stdout is a tty, otherwise
   without colors.
-  * *Note:* to force colored output when there is no TTY, set the `ForceColors`
-    field to `true`.  To force no colored output even if there is a TTY  set the
-    `DisableColors` field to `true`
 * `logrus.JSONFormatter`. Logs fields as JSON.
 
 Third party logging formatters:

--- a/formatter_bench_test.go
+++ b/formatter_bench_test.go
@@ -52,23 +52,23 @@ var errorFields = Fields{
 }
 
 func BenchmarkErrorTextFormatter(b *testing.B) {
-	doBenchmark(b, &TextFormatter{DisableColors: true}, errorFields)
+	doBenchmark(b, &TextFormatter{}, errorFields)
 }
 
 func BenchmarkSmallTextFormatter(b *testing.B) {
-	doBenchmark(b, &TextFormatter{DisableColors: true}, smallFields)
+	doBenchmark(b, &TextFormatter{}, smallFields)
 }
 
 func BenchmarkLargeTextFormatter(b *testing.B) {
-	doBenchmark(b, &TextFormatter{DisableColors: true}, largeFields)
+	doBenchmark(b, &TextFormatter{}, largeFields)
 }
 
 func BenchmarkSmallColoredTextFormatter(b *testing.B) {
-	doBenchmark(b, &TextFormatter{ForceColors: true}, smallFields)
+	doBenchmark(b, &TextFormatter{}, smallFields)
 }
 
 func BenchmarkLargeColoredTextFormatter(b *testing.B) {
-	doBenchmark(b, &TextFormatter{ForceColors: true}, largeFields)
+	doBenchmark(b, &TextFormatter{}, largeFields)
 }
 
 func BenchmarkSmallJSONFormatter(b *testing.B) {

--- a/logger.go
+++ b/logger.go
@@ -68,7 +68,7 @@ func (mw *MutexWrap) Disable() {
 func New() *Logger {
 	return &Logger{
 		Out:       os.Stderr,
-		Formatter: new(TextFormatter),
+		Formatter: NewTextFormatter(),
 		Hooks:     make(LevelHooks),
 		Level:     InfoLevel,
 	}

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkDummyLogger(b *testing.B) {
 		b.Fatalf("%v", err)
 	}
 	defer nullf.Close()
-	doLoggerBenchmark(b, nullf, &TextFormatter{DisableColors: true}, smallFields)
+	doLoggerBenchmark(b, nullf, &TextFormatter{}, smallFields)
 }
 
 func BenchmarkDummyLoggerNoLock(b *testing.B) {
@@ -28,7 +28,7 @@ func BenchmarkDummyLoggerNoLock(b *testing.B) {
 		b.Fatalf("%v", err)
 	}
 	defer nullf.Close()
-	doLoggerBenchmarkNoLock(b, nullf, &TextFormatter{DisableColors: true}, smallFields)
+	doLoggerBenchmarkNoLock(b, nullf, &TextFormatter{}, smallFields)
 }
 
 func doLoggerBenchmark(b *testing.B, out *os.File, formatter Formatter, fields Fields) {

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -32,9 +32,7 @@ func LogAndAssertText(t *testing.T, log func(*Logger), assertions func(fields ma
 
 	logger := New()
 	logger.Out = &buffer
-	logger.Formatter = &TextFormatter{
-		DisableColors: true,
-	}
+	logger.Formatter = NewTextFormatter()
 
 	log(logger)
 

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -33,27 +33,43 @@ func miniTS() int {
 }
 
 type TextFormatter struct {
-	// Set to true to bypass checking for a TTY before outputting colors.
-	ForceColors bool
 
-	// Force disabling colors.
-	DisableColors bool
+	// Enable colors
+	Colors bool
 
-	// Disable timestamp logging. useful when output is redirected to logging
-	// system that already adds timestamps.
-	DisableTimestamp bool
+	// Enable timestamp logging. It's useful to disable timestamps when output
+	// is redirected to logging system that already adds timestamps.  When
+	// disabled, a delta is used for each log line from the start of the
+	// process.  Enabling will apply a timestamp derived from TimestampFormat.
+	Timestamp bool
 
-	// Enable logging the full timestamp when a TTY is attached instead of just
-	// the time passed since beginning of execution.
-	FullTimestamp bool
-
-	// TimestampFormat to use for display when a full timestamp is printed
+	// TimestampFormat is the format used to print the timestamp.  By default
+	// an RFC3339 timestamp is used.
 	TimestampFormat string
 
 	// The fields are sorted by default for a consistent output. For applications
 	// that log extremely frequently and don't use the JSON formatter this may not
 	// be desired.
 	DisableSorting bool
+
+	// Escape noncharacter ascii strings.
+	EscapeNonCharacters bool
+}
+
+// NewTextFormatter returns a text formatter with defaults appropriate for the
+// TTY or file being written to.
+func NewTextFormatter() *TextFormatter {
+
+	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
+
+	formatter := &TextFormatter{
+		Colors:          isColorTerminal,
+		Timestamp:       false,
+		TimestampFormat: DefaultTimestampFormat,
+		DisableSorting:  false,
+	}
+
+	return formatter
 }
 
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
@@ -66,6 +82,7 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	if !f.DisableSorting {
 		sort.Strings(keys)
 	}
+
 	if entry.Buffer != nil {
 		b = entry.Buffer
 	} else {
@@ -74,23 +91,21 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 
 	prefixFieldClashes(entry.Data)
 
-	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
-	isColored := (f.ForceColors || isColorTerminal) && !f.DisableColors
+	// get the time string
+	ts := f.timeStamp(entry)
 
-	timestampFormat := f.TimestampFormat
-	if timestampFormat == "" {
-		timestampFormat = DefaultTimestampFormat
-	}
-	if isColored {
-		f.printColored(b, entry, keys, timestampFormat)
+	if f.Colors {
+		f.printColored(b, entry, keys, ts)
 	} else {
-		if !f.DisableTimestamp {
-			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+		if f.Timestamp {
+			f.appendKeyValue(b, "time", ts)
 		}
+
 		f.appendKeyValue(b, "level", entry.Level.String())
 		if entry.Message != "" {
 			f.appendKeyValue(b, "msg", entry.Message)
 		}
+
 		for _, key := range keys {
 			f.appendKeyValue(b, key, entry.Data[key])
 		}
@@ -100,7 +115,21 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string, timestampFormat string) {
+func (f *TextFormatter) timeStamp(entry *Entry) string {
+	if !f.Timestamp {
+		return fmt.Sprintf("%04d", miniTS())
+	}
+
+	timestampFormat := f.TimestampFormat
+
+	if timestampFormat == "" {
+		timestampFormat = DefaultTimestampFormat
+	}
+
+	return entry.Time.Format(timestampFormat)
+}
+
+func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string, timestamp string) {
 	var levelColor int
 	switch entry.Level {
 	case DebugLevel:
@@ -115,18 +144,19 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 
 	levelText := strings.ToUpper(entry.Level.String())[0:4]
 
-	if !f.FullTimestamp {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, miniTS(), entry.Message)
-	} else {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
-	}
+	fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, timestamp, entry.Message)
+
 	for _, k := range keys {
 		v := entry.Data[k]
 		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%+v", levelColor, k, v)
 	}
 }
 
-func needsQuoting(text string) bool {
+func (f *TextFormatter) needsQuoting(text string) bool {
+	if !f.EscapeNonCharacters {
+		return false
+	}
+
 	for _, ch := range text {
 		if !((ch >= 'a' && ch <= 'z') ||
 			(ch >= 'A' && ch <= 'Z') ||
@@ -145,14 +175,14 @@ func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interf
 
 	switch value := value.(type) {
 	case string:
-		if !needsQuoting(value) {
+		if !f.needsQuoting(value) {
 			b.WriteString(value)
 		} else {
 			fmt.Fprintf(b, "%q", value)
 		}
 	case error:
 		errmsg := value.Error()
-		if !needsQuoting(errmsg) {
+		if !f.needsQuoting(errmsg) {
 			b.WriteString(errmsg)
 		} else {
 			fmt.Fprintf(b, "%q", value)

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestQuoting(t *testing.T) {
-	tf := &TextFormatter{DisableColors: true}
+	tf := &TextFormatter{EscapeNonCharacters: true}
 
 	checkQuoting := func(q bool, value interface{}) {
 		b, _ := tf.Format(WithField("test", value))
@@ -35,7 +35,10 @@ func TestQuoting(t *testing.T) {
 
 func TestTimestampFormat(t *testing.T) {
 	checkTimeStr := func(format string) {
-		customFormatter := &TextFormatter{DisableColors: true, TimestampFormat: format}
+		customFormatter := &TextFormatter{
+			Timestamp:       true,
+			TimestampFormat: format,
+		}
 		customStr, _ := customFormatter.Format(WithField("test", "test"))
 		timeStart := bytes.Index(customStr, ([]byte)("time="))
 		timeEnd := bytes.Index(customStr, ([]byte)("level="))


### PR DESCRIPTION
Moved TTY checking and default setting for the TextFormatter to the
NewTextFormatter() method.  This will set the `Color` bool in the
formatter to emit colors.  Likewise all bools can now be toggled from
the TextFormatter struct directy regardless of Out being
a TTY or not.

Fixes #431 
