### PR TITLE
Updated .travis.yml to ignore /examples/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ go:
   - 1.4
   - 1.5
   - 1.6
+  - 1.7
   - tip
 install:
-  - go get -t ./...
-script: GOMAXPROCS=4 GORACE="halt_on_error=1" go test -race -v ./...
+  - go get -t $(go list ./... | grep -v /examples/)
+script:
+  - GOMAXPROCS=4 GORACE="halt_on_error=1" go test -race -v $(go list ./... | grep -v /examples/)


### PR DESCRIPTION
`/examples/hook/hook.go` with it's child dependency on `airbrake/gobrake` is
not backwards compatible pre-go1.6 due to use of the following:
  - `os.LookupEnv` (introduced in go1.5)
  - `http.StatusTooManyRequests` (introduced in go1.6)
ignoring the fetch and explicit test of `/examples/` fixes failing go1.3,
go1.4, go1.5 builds.