### PR TITLE
Json disable timestamp

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -26,6 +26,9 @@ type JSONFormatter struct {
 	// TimestampFormat sets the format used for marshaling timestamps.
 	TimestampFormat string
 
+	// DisableTimestamp allows disabling automatic timestamps in output
+	DisableTimestamp bool
+
 	// FieldMap allows users to customize the names of keys for various fields.
 	// As an example:
 	// formatter := &JSONFormatter{
@@ -57,7 +60,9 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		timestampFormat = DefaultTimestampFormat
 	}
 
-	data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
+	if !f.DisableTimestamp {
+		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
+	}
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
 	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
 

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -180,7 +180,7 @@ func TestJSONDisableTimestamp(t *testing.T) {
 		t.Fatal("Unable to format entry: ", err)
 	}
 	s := string(b)
-	if strings.Contains(s, "time") {
+	if strings.Contains(s, FieldKeyTime) {
 		t.Error("Did not prevent timestamp", s)
 	}
 }
@@ -193,7 +193,7 @@ func TestJSONEnableTimestamp(t *testing.T) {
 		t.Fatal("Unable to format entry: ", err)
 	}
 	s := string(b)
-	if !strings.Contains(s, "time") {
+	if !strings.Contains(s, FieldKeyTime) {
 		t.Error("Timestamp not present", s)
 	}
 }

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -169,3 +169,31 @@ func TestJSONTimeKey(t *testing.T) {
 		t.Fatal("Expected JSON to format time key")
 	}
 }
+
+func TestJSONDisableTimestamp(t *testing.T) {
+	formatter := &JSONFormatter{
+		DisableTimestamp: true,
+	}
+
+	b, err := formatter.Format(WithField("level", "something"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if strings.Contains(s, "time") {
+		t.Error("Did not prevent timestamp", s)
+	}
+}
+
+func TestJSONEnableTimestamp(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(WithField("level", "something"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "time") {
+		t.Error("Timestamp not present", s)
+	}
+}


### PR DESCRIPTION
Quick option for disabling the timestamp field in the JSON formatter.