### PR TITLE
Compile examples filtered in #439

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.6
+  - 1.7
   - tip
 install:
   - go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 go:
   - 1.6
-  - 1.7
   - tip
 install:
-  - go get -t $(go list ./... | grep -v /examples/)
-script:
-  - GOMAXPROCS=4 GORACE="halt_on_error=1" go test -race -v $(go list ./... | grep -v /examples/)
+  - go get -t ./...
+script: GOMAXPROCS=4 GORACE="halt_on_error=1" go test -race -v ./...


### PR DESCRIPTION
This partially reverts the changes in #439 that removed example compilation. Travis no longer builds before Go 1.6, so these examples should continue to build.

We may want to define a policy for how many Go versions are supported at any one time.

cc @Sirupsen 