### PR TITLE
Update readme example for switching  output

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ func init() {
   // Log as JSON instead of the default ASCII formatter.
   log.SetFormatter(&log.JSONFormatter{})
 
-  // Output to stderr instead of stdout, could also be a file.
-  log.SetOutput(os.Stderr)
+  // Output to stdout instead of the default stderr, could also be a file.
+  log.SetOutput(os.Stdout)
 
   // Only log the warning severity or above.
   log.SetLevel(log.WarnLevel)


### PR DESCRIPTION
Clarifies that stderr is the default, not stdout.