### PR TITLE
Do not add 'FieldKey*'  field when they are void.

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -60,12 +60,19 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		timestampFormat = DefaultTimestampFormat
 	}
 
-	if !f.DisableTimestamp {
+	if !f.DisableTimestamp && len(f.FieldMap[FieldKeyTime]) > 0 {
 		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
 	}
-	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
-	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
 
+	if len(f.FieldMap[FieldKeyMsg]) > 0 {
+		data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
+	}
+
+	if len(f.FieldMap[FieldKeyLevel]) > 0 {
+		data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
+	}
+
+	fmt.Println(data)
 	serialized, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)


### PR DESCRIPTION
Set the default field key to "", eg. :

        logrus.FieldKeyLevel:   ""

    it will create an error format JSON string
    as "":"info". So add FieldKEy length checking before do json.Marshal(data)

    It alse can using th default key-name that defined in previous:

    const (
        FieldKeyMsg   = "msg"
        FieldKeyLevel = "level"
        FieldKeyTime  = "time"
    )

    But I think developer who set these fields to "" wants to hide or conceal the key-value that definde in default JSONFormatter.

    Sorry for my poor English :D