### PR TITLE
Add Logentrus to README.md (hook for Logentries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Logmatic.io](https://github.com/logmatic/logmatic-go) | Hook for logging to [Logmatic.io](http://logmatic.io/) |
 | [Pushover](https://github.com/toorop/logrus_pushover) | Send error via [Pushover](https://pushover.net) |
 | [PostgreSQL](https://github.com/gemnasium/logrus-postgresql-hook) | Send logs to [PostgreSQL](http://postgresql.org) |
+| [Logentrus](https://github.com/puddingfactory/logentrus) | Hook for logging to [Logentries](https://logentries.com/) |
 
 
 #### Level logging


### PR DESCRIPTION
Have tried to keep [Logentrus](https://github.com/puddingfactory/logentrus) clean and well documented. Let me know if you have any questions or recommendations.