### PR TITLE
Preserve Message, Time, Logger and Level fields for new entry when using WithFields

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -82,9 +82,13 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	for k, v := range fields {
 		data[k] = v
 	}
-	newEntry := *entry
-	newEntry.Data = data
-	return &newEntry
+	return &Entry{
+		Logger:  entry.Logger,
+		Data:    data,
+		Time:    entry.Time,
+		Level:   entry.Level,
+		Message: entry.Message,
+	}
 }
 
 // This function is not declared with a pointer value because otherwise

--- a/entry.go
+++ b/entry.go
@@ -82,7 +82,9 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	for k, v := range fields {
 		data[k] = v
 	}
-	return &Entry{Logger: entry.Logger, Data: data}
+	newEntry := *entry
+	newEntry.Data = data
+	return &newEntry
 }
 
 // This function is not declared with a pointer value because otherwise

--- a/entry_test.go
+++ b/entry_test.go
@@ -85,12 +85,14 @@ func TestEntryWithFields(t *testing.T) {
 		Level:   DebugLevel,
 		Data:    Fields{"foo": "bar"},
 		Logger:  logger,
+		Buffer:  bytes.NewBuffer([]byte{}),
 	}
 	newEntry := entry.WithFields(Fields{"baz": 42, "one": "more"})
 	assert.Equal(t, entry.Time, newEntry.Time)
 	assert.Equal(t, entry.Message, newEntry.Message)
 	assert.Equal(t, entry.Level, newEntry.Level)
 	assert.Equal(t, entry.Logger, newEntry.Logger)
+	assert.NotEqual(t, entry.Buffer, newEntry.Buffer)
 
 	value, ok := newEntry.Data["foo"]
 	assert.True(t, ok)

--- a/entry_test.go
+++ b/entry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -74,4 +75,32 @@ func TestEntryPanicf(t *testing.T) {
 	logger.Out = &bytes.Buffer{}
 	entry := NewEntry(logger)
 	entry.WithField("err", errBoom).Panicf("kaboom %v", true)
+}
+
+func TestEntryWithFields(t *testing.T) {
+	logger := New()
+	entry := &Entry{
+		Time:    time.Date(2001, 2, 3, 4, 5, 6, 7, time.UTC),
+		Message: "The message",
+		Level:   DebugLevel,
+		Data:    Fields{"foo": "bar"},
+		Logger:  logger,
+	}
+	newEntry := entry.WithFields(Fields{"baz": 42, "one": "more"})
+	assert.Equal(t, entry.Time, newEntry.Time)
+	assert.Equal(t, entry.Message, newEntry.Message)
+	assert.Equal(t, entry.Level, newEntry.Level)
+	assert.Equal(t, entry.Logger, newEntry.Logger)
+
+	value, ok := newEntry.Data["foo"]
+	assert.True(t, ok)
+	assert.Equal(t, "bar", value)
+
+	value, ok = newEntry.Data["baz"]
+	assert.True(t, ok)
+	assert.Equal(t, 42, value)
+
+	value, ok = newEntry.Data["one"]
+	assert.True(t, ok)
+	assert.Equal(t, "more", value)
 }


### PR DESCRIPTION
When using `WithFields` method on Entry instance the result doesn't keep `Level`, `Logger`, `Message` and `Time` fields from original entry instance.

**NOTE**: not sure if it's bug or it was done intentionally 🤔 