### PR TITLE
text_formatter: detect tty based on fd

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ func init() {
   // Log as JSON instead of the default ASCII formatter.
   log.SetFormatter(&log.JSONFormatter{})
 
-  // Output to stdout instead of the default stderr, could also be a file.
+  // Output to stdout instead of the default stderr
+  // Can be any io.Writer, see below for File example
   log.SetOutput(os.Stdout)
 
   // Only log the warning severity or above.
@@ -138,7 +139,15 @@ var log = logrus.New()
 func main() {
   // The API for setting attributes is a little different than the package level
   // exported logger. See Godoc.
-  log.Out = os.Stderr
+  log.Out = os.Stdout
+
+  // You could set this to any `io.Writer` such as a file
+  // file, err := os.OpenFile("logrus.log", os.O_CREATE|os.O_WRONLY, 0666)
+  // if err == nil {
+  //  log.Out = file
+  // } else {
+  //  log.Info("Failed to log to file, using default stderr")
+  // }
 
   log.WithFields(logrus.Fields{
     "animal": "walrus",

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/Sirupsen/logrus"
+	"os"
 )
 
 var log = logrus.New()

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/Sirupsen/logrus"
-	"os"
+	// "os"
 )
 
 var log = logrus.New()
@@ -10,6 +10,14 @@ var log = logrus.New()
 func init() {
 	log.Formatter = new(logrus.JSONFormatter)
 	log.Formatter = new(logrus.TextFormatter) // default
+
+	// file, err := os.OpenFile("logrus.log", os.O_CREATE|os.O_WRONLY, 0666)
+	// if err == nil {
+	// 	log.Out = file
+	// } else {
+	// 	log.Info("Failed to log to file, using default stderr")
+	// }
+
 	log.Level = logrus.DebugLevel
 }
 

--- a/formatter_bench_test.go
+++ b/formatter_bench_test.go
@@ -80,11 +80,14 @@ func BenchmarkLargeJSONFormatter(b *testing.B) {
 }
 
 func doBenchmark(b *testing.B, formatter Formatter, fields Fields) {
+	logger := New()
+
 	entry := &Entry{
 		Time:    time.Time{},
 		Level:   InfoLevel,
 		Message: "message",
 		Data:    fields,
+		Logger:  logger,
 	}
 	var d []byte
 	var err error

--- a/terminal_appengine.go
+++ b/terminal_appengine.go
@@ -3,6 +3,6 @@
 package logrus
 
 // IsTerminal returns true if stderr's file descriptor is a terminal.
-func IsTerminal() bool {
+func IsTerminal(f io.Writer) bool {
 	return true
 }

--- a/terminal_notwindows.go
+++ b/terminal_notwindows.go
@@ -9,14 +9,20 @@
 package logrus
 
 import (
+	"io"
+	"os"
 	"syscall"
 	"unsafe"
 )
 
 // IsTerminal returns true if stderr's file descriptor is a terminal.
-func IsTerminal() bool {
-	fd := syscall.Stderr
+func IsTerminal(f io.Writer) bool {
 	var termios Termios
-	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
-	return err == 0
+	switch v := f.(type) {
+	case *os.File:
+		_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(v.Fd()), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+		return err == 0
+	default:
+		return false
+	}
 }

--- a/terminal_solaris.go
+++ b/terminal_solaris.go
@@ -9,7 +9,13 @@ import (
 )
 
 // IsTerminal returns true if the given file descriptor is a terminal.
-func IsTerminal() bool {
-	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETA)
-	return err == nil
+func IsTerminal(f io.Writer) bool {
+	var termios Termios
+	switch v := f.(type) {
+	case *os.File:
+		_, err := unix.IoctlGetTermios(int(f.Fd()), unix.TCGETA)
+		return err == nil
+	default:
+		return false
+	}
 }

--- a/terminal_solaris.go
+++ b/terminal_solaris.go
@@ -13,7 +13,7 @@ func IsTerminal(f io.Writer) bool {
 	var termios Termios
 	switch v := f.(type) {
 	case *os.File:
-		_, err := unix.IoctlGetTermios(int(f.Fd()), unix.TCGETA)
+		_, err := unix.IoctlGetTermios(int(v.Fd()), unix.TCGETA)
 		return err == nil
 	default:
 		return false

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -19,9 +19,13 @@ var (
 )
 
 // IsTerminal returns true if stderr's file descriptor is a terminal.
-func IsTerminal() bool {
-	fd := syscall.Stderr
-	var st uint32
-	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
-	return r != 0 && e == 0
+func IsTerminal(f io.Writer) bool {
+	switch v := f.(type) {
+	case *os.File:
+		var st uint32
+		r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(v.Fd()), uintptr(unsafe.Pointer(&st)), 0)
+		return r != 0 && e == 0
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
@stevvooe we have a lot of problems with Logrus' TTY detection. I think the root of this is that `log.Out` when set to not `stderr` the TTY detection logic will _still_ use `os.Stderr` to check for TTY... this doesn't make sense as many people will want the text formatter to a file. This PR changes this for all platforms.

The mutex here is ugly... but I'm afraid of the race here and CI will complain if I don't do it. Ideas, @stevvooe? It's simpler to piggy-back off of the lock in `Entry`, but that'd prevent being able to serialize with the formatters in parallel which is potentially a large performance hit. Alternatively we could check for TTY on every logging statement, but the context switch I'd assume is even more expensive.

This should resolve issues such as https://github.com/sirupsen/logrus/issues/466 https://github.com/sirupsen/logrus/issues/414 https://github.com/sirupsen/logrus/issues/379 https://github.com/sirupsen/logrus/issues/306