### PR TITLE
Make LevelHooks goroutine safe.

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -1,5 +1,7 @@
 package logrus
 
+import "sync"
+
 // A hook to be fired when logging on the logging levels returned from
 // `Levels()` on your implementation of the interface. Note that this is not
 // fired in a goroutine or a channel with workers, you should handle such
@@ -11,20 +13,31 @@ type Hook interface {
 }
 
 // Internal type for storing the hooks on a logger instance.
-type LevelHooks map[Level][]Hook
+type LevelHooks struct {
+	hooks map[Level][]Hook
+	mu    sync.Mutex
+}
+
+func NewLevelHooks() *LevelHooks {
+	return &LevelHooks{hooks: make(map[Level][]Hook)}
+}
 
 // Add a hook to an instance of logger. This is called with
 // `log.Hooks.Add(new(MyHook))` where `MyHook` implements the `Hook` interface.
-func (hooks LevelHooks) Add(hook Hook) {
+func (hooks *LevelHooks) Add(hook Hook) {
+	hooks.mu.Lock()
+	defer hooks.mu.Unlock()
 	for _, level := range hook.Levels() {
-		hooks[level] = append(hooks[level], hook)
+		hooks.hooks[level] = append(hooks.hooks[level], hook)
 	}
 }
 
 // Fire all the hooks for the passed level. Used by `entry.log` to fire
 // appropriate hooks for a log entry.
-func (hooks LevelHooks) Fire(level Level, entry *Entry) error {
-	for _, hook := range hooks[level] {
+func (hooks *LevelHooks) Fire(level Level, entry *Entry) error {
+	hooks.mu.Lock()
+	defer hooks.mu.Unlock()
+	for _, hook := range hooks.hooks[level] {
 		if err := hook.Fire(entry); err != nil {
 			return err
 		}

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -1,0 +1,36 @@
+package logrus
+
+import (
+	"testing"
+)
+
+func TestLevelHooks_Add(t *testing.T) {
+	const hooksAddLength = 1000
+	hookList := make([]Hook, 0, hooksAddLength)
+	for i := 0; i < hooksAddLength; i++ {
+		hookList = append(hookList, new(TestHook))
+	}
+
+	hooks := NewLevelHooks()
+	for _, h := range hookList {
+		go func(hooks *LevelHooks, h Hook) { hooks.Add(h) }(hooks, h) // raise data race.
+	}
+
+	hooks2 := NewLevelHooks()
+	for _, h := range hookList {
+		hooks2.Add(h) // no data race.
+	}
+}
+
+func TestLevelHooks_Fire(t *testing.T) {
+	const hooksFireLength = 1000
+	entryList := make([]Entry, 0, hooksFireLength)
+	for i := 0; i < hooksFireLength; i++ {
+		entryList = append(entryList, Entry{})
+	}
+
+	hooks := NewLevelHooks()
+	for _, e := range entryList {
+		go func(hooks *LevelHooks, e Entry) { hooks.Fire(ErrorLevel, &e) }(hooks, e)
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -69,7 +69,7 @@ func New() *Logger {
 	return &Logger{
 		Out:       os.Stderr,
 		Formatter: new(TextFormatter),
-		Hooks:     make(LevelHooks),
+		Hooks:     *NewLevelHooks(),
 		Level:     InfoLevel,
 	}
 }


### PR DESCRIPTION
There is a concurrent write problem because LevelHooks has been alias of map.
I think it would be better to make LevelHooks struct with map and Mutex, and lock in Adding hooks.