### PR TITLE
Fixed missing imports for windows terminal

### DIFF
--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -8,6 +8,8 @@
 package logrus
 
 import (
+	"io"	
+	"os"	
 	"syscall"
 	"unsafe"
 )


### PR DESCRIPTION
As reported here https://github.com/sirupsen/logrus/issues/475