### PR TITLE
Fix dead url for alt_exit.go

### DIFF
--- a/alt_exit.go
+++ b/alt_exit.go
@@ -1,7 +1,7 @@
 package logrus
 
 // The following code was sourced and modified from the
-// https://bitbucket.org/tebeka/atexit package governed by the following license:
+// https://github.com/tebeka/atexit package governed by the following license:
 //
 // Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
 //


### PR DESCRIPTION
The project tebeka/atexit has moved to github and so I updated it.