### PR TITLE
Add Discordrus, a hook for Discord, to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Amqp-Hook](https://github.com/vladoatanasov/logrus_amqp) | Hook for logging to Amqp broker (Like RabbitMQ) |
 | [Bugsnag](https://github.com/Shopify/logrus-bugsnag/blob/master/bugsnag.go) | Send errors to the Bugsnag exception tracking service. |
 | [DeferPanic](https://github.com/deferpanic/dp-logrus) | Hook for logging to DeferPanic |
+| [Discordrus](https://github.com/kz/discordrus) | Hook for logging to [Discord](https://discordapp.com/) |
 | [ElasticSearch](https://github.com/sohlich/elogrus) | Hook for logging to ElasticSearch|
 | [Fluentd](https://github.com/evalphobia/logrus_fluent) | Hook for logging to fluentd |
 | [Go-Slack](https://github.com/multiplay/go-slack) | Hook for logging to [Slack](https://slack.com) |


### PR DESCRIPTION
I would like to add my hook for Discord, [kz/discordrus](https://github.com/kz/discordrus), to your README.

I've made sure to keep code well-commented and have written tests where appropriate. Tests are run weekly on Travis CI to look out for Discord and logrus API changes. This is my first Go-based contribution, so please let me know if you have any recommendations!