### PR TITLE
Remove os.Exit from entry.go

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -161,7 +161,6 @@ func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.log(FatalLevel, fmt.Sprint(args...))
 	}
-	Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {


### PR DESCRIPTION
This removes os.Exit from entry.go, because we already exit at
logger.go:166. Internal usage of entries in other libraries
ends up causing unexpected failures.