### PR TITLE
Allow timestamp for included formatters to be in UTC

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -29,6 +29,8 @@ type JSONFormatter struct {
 	// DisableTimestamp allows disabling automatic timestamps in output
 	DisableTimestamp bool
 
+	TimestampInUTC bool
+
 	// FieldMap allows users to customize the names of keys for various fields.
 	// As an example:
 	// formatter := &JSONFormatter{
@@ -61,7 +63,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	}
 
 	if !f.DisableTimestamp {
-		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
+		data[f.FieldMap.resolve(FieldKeyTime)] = f.timestamp(entry, timestampFormat)
 	}
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
 	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
@@ -71,4 +73,12 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
 	}
 	return append(serialized, '\n'), nil
+}
+
+func (f *JSONFormatter) timestamp(entry *Entry, format string) string {
+	if f.TimestampInUTC {
+		return entry.Time.UTC().Format(format)
+	} else {
+		return entry.Time.Format(format)
+	}
 }

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestErrorNotLost(t *testing.T) {
@@ -65,6 +66,33 @@ func TestFieldClashWithTime(t *testing.T) {
 
 	if entry["time"] != "0001-01-01T00:00:00Z" {
 		t.Fatal("time field not set to current time, was: ", entry["time"])
+	}
+}
+
+func TestTimestampInUTC(t *testing.T) {
+	fiveHours := int(time.Hour/time.Second) * 5
+	est := time.FixedZone("EST", fiveHours)
+	time, err := time.ParseInLocation("2006-Jan-02", "2012-Jul-09", est)
+	if err != nil {
+		t.Fatal("Unable to Parse time/location", err)
+	}
+
+	entry := &Entry{}
+	entry.Time = time
+
+	formatter := &JSONFormatter{TimestampInUTC: true}
+	b, err := formatter.Format(entry)
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	entryWithJSON := make(map[string]interface{})
+	err = json.Unmarshal(b, &entryWithJSON)
+	if err != nil {
+		t.Fatal("Unable to unmarshal formatted entry: ", err)
+	}
+	if entryWithJSON["time"] != "2012-07-08T19:00:00Z" {
+		t.Fatal("Time was not converted to UTC")
 	}
 }
 

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -44,6 +44,8 @@ type TextFormatter struct {
 	// TimestampFormat to use for display when a full timestamp is printed
 	TimestampFormat string
 
+	TimestampInUTC bool
+
 	// The fields are sorted by default for a consistent output. For applications
 	// that log extremely frequently and don't use the JSON formatter this may not
 	// be desired.
@@ -101,7 +103,11 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		f.printColored(b, entry, keys, timestampFormat)
 	} else {
 		if !f.DisableTimestamp {
-			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+			if f.TimestampInUTC {
+				f.appendKeyValue(b, "time", entry.Time.UTC().Format(timestampFormat))
+			} else {
+				f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+			}
 		}
 		f.appendKeyValue(b, "level", entry.Level.String())
 		if entry.Message != "" {

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -103,11 +103,7 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		f.printColored(b, entry, keys, timestampFormat)
 	} else {
 		if !f.DisableTimestamp {
-			if f.TimestampInUTC {
-				f.appendKeyValue(b, "time", entry.Time.UTC().Format(timestampFormat))
-			} else {
-				f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
-			}
+			f.appendKeyValue(b, "time", f.timestamp(entry, timestampFormat))
 		}
 		f.appendKeyValue(b, "level", entry.Level.String())
 		if entry.Message != "" {
@@ -142,12 +138,20 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 	} else if !f.FullTimestamp {
 		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, int(entry.Time.Sub(baseTimestamp)/time.Second), entry.Message)
 	} else {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, f.timestamp(entry, timestampFormat), entry.Message)
 	}
 	for _, k := range keys {
 		v := entry.Data[k]
 		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=", levelColor, k)
 		f.appendValue(b, v)
+	}
+}
+
+func (f *TextFormatter) timestamp(entry *Entry, format string) string {
+	if f.TimestampInUTC {
+		return entry.Time.UTC().Format(format)
+	} else {
+		return entry.Time.Format(format)
 	}
 }
 

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -74,6 +74,36 @@ func TestTimestampFormat(t *testing.T) {
 	checkTimeStr("")
 }
 
+func getTime(textFormatted []byte, formatter *TextFormatter) []byte {
+	timeStart := bytes.Index(textFormatted, ([]byte)("time="))
+	timeEnd := bytes.Index(textFormatted, ([]byte)("level="))
+	return textFormatted[timeStart+5+len(formatter.QuoteCharacter) : timeEnd-1-len(formatter.QuoteCharacter)]
+
+}
+
+func TestTimestampInUTCTextFormatter(t *testing.T) {
+	fiveHours := int(time.Hour/time.Second) * 5
+	est := time.FixedZone("EST", fiveHours)
+	time, err := time.ParseInLocation("2006-Jan-02", "2012-Jul-09", est)
+	if err != nil {
+		t.Errorf("Unable to Parse time/location", err)
+	}
+	entry := &Entry{}
+	entry.Time = time
+
+	tf := &TextFormatter{TimestampInUTC: true}
+	b, err := tf.Format(entry)
+	if err != nil {
+		t.Errorf("Error when formatting", err)
+	}
+
+	timeVal := getTime(b, tf)
+	expectedTime := "2012-07-08T19:00:00Z"
+	if string(timeVal) != expectedTime {
+		t.Errorf("Expected \"%s\" to equal \"%s\"", timeVal, expectedTime)
+	}
+}
+
 func TestDisableTimestampWithColoredOutput(t *testing.T) {
 	tf := &TextFormatter{DisableTimestamp: true, ForceColors: true}
 


### PR DESCRIPTION
Hi @sirupsen and @stevvooe. This PR is closely related to https://github.com/sirupsen/logrus/pull/294 and https://github.com/sirupsen/logrus/pull/402.
I'd still like to put forward the idea of allowing formatted timestamps to be in UTC but without going as far as allowing specific timezones. I'd guess most people just want UTC all the time. As to any questions about why would the time on the server not be set to UTC, well it should be as far as I know but things happen and I'd rather specify in my app as well. As far as I can tell this doesn't break any backwards compatibility.