### PR TITLE
Fixed compilation for Solaris

### DIFF
--- a/terminal_solaris.go
+++ b/terminal_solaris.go
@@ -3,6 +3,7 @@
 package logrus
 
 import (
+	"io"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -10,7 +11,6 @@ import (
 
 // IsTerminal returns true if the given file descriptor is a terminal.
 func IsTerminal(f io.Writer) bool {
-	var termios Termios
 	switch v := f.(type) {
 	case *os.File:
 		_, err := unix.IoctlGetTermios(int(v.Fd()), unix.TCGETA)


### PR DESCRIPTION
After merging #471 compilation on Solaris was broken. Here's a fix for it.

There are missing "io" import and unused variable
Releated issues #471 #289