### PR TITLE
Format full values for fields

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -184,6 +184,6 @@ func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
 			fmt.Fprintf(b, "%s%v%s", f.QuoteCharacter, errmsg, f.QuoteCharacter)
 		}
 	default:
-		fmt.Fprint(b, value)
+		fmt.Fprintf(b, "%+v", value)
 	}
 }

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -83,5 +83,18 @@ func TestDisableTimestampWithColoredOutput(t *testing.T) {
 	}
 }
 
+func TestDefaultValueFormatWithStruct(t *testing.T) {
+	tf := &TextFormatter{DisableColors: true}
+	type testStruct struct {
+		keyName string
+	}
+	ts := testStruct{keyName:"test"}
+	b, _ := tf.Format(WithField("structField", ts))
+
+	if !bytes.Contains(b, []byte("keyName")) {
+		t.Errorf("Failed to find struct key names in formatted output, struct: '%+v', formatted string: '%s'", ts, b)
+	}
+}
+
 // TODO add tests for sorting etc., this requires a parser for the text
 // formatter output.


### PR DESCRIPTION
Previously we would just use the equivelent of a
%s but this wouldn't show structs that were passed
in as key values very nicely. If we change to process
them as %+v the output is much more helpful, and
saves from having to implement stringers for every
single struct that might be logged.