### PR TITLE
core: add DisableHTMLEscape flag to json_formatter

### DIFF
--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -197,3 +197,29 @@ func TestJSONEnableTimestamp(t *testing.T) {
 		t.Error("Timestamp not present", s)
 	}
 }
+
+func TestJSONDisableHTMLEscape(t *testing.T) {
+	formatter := &JSONFormatter{DisableHTMLEscape: true}
+
+	b, err := formatter.Format(&Entry{Message: "& < >"})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "& < >") {
+		t.Error("Message should not be HTML escaped", s)
+	}
+}
+
+func TestJSONEnableHTMLEscape(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(&Entry{Message: "& < >"})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !(strings.Contains(s, "u0026") && strings.Contains(s, "u003e") && strings.Contains(s, "u003c")) {
+		t.Error("Message should be HTML escaped", s)
+	}
+}


### PR DESCRIPTION
This will enable logging URLs with special characters like "&" and "%". 

HTML escaping support was only however added in go 1.7, so it is not compatible with 1.6 :(