### PR TITLE
Protect test hook entries with a mutex

### DIFF
--- a/hooks/test/test.go
+++ b/hooks/test/test.go
@@ -9,6 +9,9 @@ import (
 
 // Hook is a hook designed for dealing with logs in test scenarios.
 type Hook struct {
+	// Entries is an array of all entries that have been received by this hook.
+	// For safe access, use the AllEntries() method, rather than reading this
+	// value directly.
 	Entries []*logrus.Entry
 	mu      sync.RWMutex
 }

--- a/hooks/test/test.go
+++ b/hooks/test/test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
-// test.Hook is a hook designed for dealing with logs in test scenarios.
+// Hook is a hook designed for dealing with logs in test scenarios.
 type Hook struct {
 	Entries []*logrus.Entry
 }
 
-// Installs a test hook for the global logger.
+// NewGlobal installs a test hook for the global logger.
 func NewGlobal() *Hook {
 
 	hook := new(Hook)
@@ -21,7 +21,7 @@ func NewGlobal() *Hook {
 
 }
 
-// Installs a test hook for a given local logger.
+// NewLocal installs a test hook for a given local logger.
 func NewLocal(logger *logrus.Logger) *Hook {
 
 	hook := new(Hook)
@@ -31,7 +31,7 @@ func NewLocal(logger *logrus.Logger) *Hook {
 
 }
 
-// Creates a discarding logger and installs the test hook.
+// NewNullLogger creates a discarding logger and installs the test hook.
 func NewNullLogger() (*logrus.Logger, *Hook) {
 
 	logger := logrus.New()


### PR DESCRIPTION
This PR is the result of our code hitting race conditions in our logging tests.

It is unsafe to read [`Entries`](https://github.com/sirupsen/logrus/blob/master/hooks/test/test.go#L11) while it is being written to, and at present there is no way to enforce synchronization of this (to my knowledge).

So this PR protects `Entries` with an RWMutex.

This PR isn't perfect... ideally, `Entries` would not be exported, so that the only way to access it would be via `Fire()`, `Reset()`, `LastEntry()` or (the new) `AllEntries()` methods. But to prevent breaking existing users, I left it exported.
