### PR TITLE
Add Go 1.8 to the testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
-  - 1.6
-  - 1.7
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
   - tip
 install:
   - go get -t ./...


### PR DESCRIPTION
And use the .x versions, so the latest versions of each Go release is used.