### PR TITLE
add caller offset to fix caller's problem.

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -42,6 +42,10 @@ type Entry struct {
 
 	// When formatter is called in entry.log(), an Buffer may be set to entry
 	Buffer *bytes.Buffer
+	// Record the caller's depth
+	CallerOffset int
+	// Init caller's depth
+	InitCallerOffset int
 }
 
 func NewEntry(logger *Logger) *Entry {
@@ -49,6 +53,8 @@ func NewEntry(logger *Logger) *Entry {
 		Logger: logger,
 		// Default is three fields, give a little extra room
 		Data: make(Fields, 5),
+		CallerOffset: 6,
+		InitCallerOffset: 6,
 	}
 }
 
@@ -82,7 +88,7 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	for k, v := range fields {
 		data[k] = v
 	}
-	return &Entry{Logger: entry.Logger, Data: data}
+	return &Entry{Logger: entry.Logger, Data: data, CallerOffset:4, InitCallerOffset:4}
 }
 
 // This function is not declared with a pointer value because otherwise
@@ -98,6 +104,7 @@ func (entry Entry) log(level Level, msg string) {
 		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
 		entry.Logger.mu.Unlock()
 	}
+	
 	buffer = bufferPool.Get().(*bytes.Buffer)
 	buffer.Reset()
 	defer bufferPool.Put(buffer)
@@ -125,40 +132,60 @@ func (entry Entry) log(level Level, msg string) {
 	}
 }
 
+func (entry *Entry) increaseCaller(){
+	entry.CallerOffset += 1
+}
+
+func (entry *Entry) clearCaller(){
+	entry.CallerOffset = entry.InitCallerOffset
+}
+
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
+		entry.increaseCaller()
+		defer entry.clearCaller()
 		entry.log(DebugLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Print(args ...interface{}) {
+	entry.increaseCaller()
 	entry.Info(args...)
 }
 
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.Level >= InfoLevel {
+		entry.increaseCaller()
+		defer entry.clearCaller()
 		entry.log(InfoLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
 	if entry.Logger.Level >= WarnLevel {
+		entry.increaseCaller()
+		defer entry.clearCaller()
 		entry.log(WarnLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Warning(args ...interface{}) {
+	entry.increaseCaller()
 	entry.Warn(args...)
 }
 
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.Level >= ErrorLevel {
+		entry.increaseCaller()
+		defer entry.clearCaller()
 		entry.log(ErrorLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
+		entry.increaseCaller()
+		defer entry.clearCaller()
 		entry.log(FatalLevel, fmt.Sprint(args...))
 	}
 	Exit(1)
@@ -166,6 +193,8 @@ func (entry *Entry) Fatal(args ...interface{}) {
 
 func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
+		entry.increaseCaller()
+		defer entry.clearCaller()
 		entry.log(PanicLevel, fmt.Sprint(args...))
 	}
 	panic(fmt.Sprint(args...))
@@ -175,12 +204,14 @@ func (entry *Entry) Panic(args ...interface{}) {
 
 func (entry *Entry) Debugf(format string, args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
+		entry.increaseCaller()
 		entry.Debug(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Infof(format string, args ...interface{}) {
 	if entry.Logger.Level >= InfoLevel {
+		entry.increaseCaller()
 		entry.Info(fmt.Sprintf(format, args...))
 	}
 }
@@ -191,22 +222,26 @@ func (entry *Entry) Printf(format string, args ...interface{}) {
 
 func (entry *Entry) Warnf(format string, args ...interface{}) {
 	if entry.Logger.Level >= WarnLevel {
+		entry.increaseCaller()
 		entry.Warn(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Warningf(format string, args ...interface{}) {
+	entry.increaseCaller()
 	entry.Warnf(format, args...)
 }
 
 func (entry *Entry) Errorf(format string, args ...interface{}) {
 	if entry.Logger.Level >= ErrorLevel {
+		entry.increaseCaller()
 		entry.Error(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
+		entry.increaseCaller()
 		entry.Fatal(fmt.Sprintf(format, args...))
 	}
 	Exit(1)
@@ -214,6 +249,7 @@ func (entry *Entry) Fatalf(format string, args ...interface{}) {
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
+		entry.increaseCaller()
 		entry.Panic(fmt.Sprintf(format, args...))
 	}
 }
@@ -222,38 +258,45 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 
 func (entry *Entry) Debugln(args ...interface{}) {
 	if entry.Logger.Level >= DebugLevel {
+		entry.increaseCaller()
 		entry.Debug(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Infoln(args ...interface{}) {
 	if entry.Logger.Level >= InfoLevel {
+		entry.increaseCaller()
 		entry.Info(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Println(args ...interface{}) {
+	entry.increaseCaller()
 	entry.Infoln(args...)
 }
 
 func (entry *Entry) Warnln(args ...interface{}) {
 	if entry.Logger.Level >= WarnLevel {
+		entry.increaseCaller()
 		entry.Warn(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Warningln(args ...interface{}) {
+	entry.increaseCaller()
 	entry.Warnln(args...)
 }
 
 func (entry *Entry) Errorln(args ...interface{}) {
 	if entry.Logger.Level >= ErrorLevel {
+		entry.increaseCaller()
 		entry.Error(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
+		entry.increaseCaller()
 		entry.Fatal(entry.sprintlnn(args...))
 	}
 	Exit(1)
@@ -261,6 +304,7 @@ func (entry *Entry) Fatalln(args ...interface{}) {
 
 func (entry *Entry) Panicln(args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
+		entry.increaseCaller()
 		entry.Panic(entry.sprintlnn(args...))
 	}
 }


### PR DESCRIPTION
After read the zap, I think add caller offset to entry is a good idea to solve #63.

Then we can use a hook like this 

```

import (
	"path/filepath"
	"runtime"
	"strconv"
	"strings"
	
	"github.com/bobcyw/logrus"
)

type CallerHook struct {
}

func (hook *CallerHook) Fire(entry *logrus.Entry) error {
	entry.Data["caller"] = hook.caller(entry)
	return nil
}

func (hook *CallerHook) Levels() []logrus.Level {
	return []logrus.Level{
		logrus.PanicLevel,
		logrus.FatalLevel,
		logrus.ErrorLevel,
		logrus.WarnLevel,
		logrus.InfoLevel,
		logrus.DebugLevel,
	}
}

func (hook *CallerHook) caller(entry *logrus.Entry) string {
	if _, file, line, ok := runtime.Caller(entry.CallerOffset); ok {
		return strings.Join([]string{filepath.Base(file), strconv.Itoa(line)}, ":")
	}
	// not sure what the convention should be here
	return ""
}
```