### PR TITLE
Option to report caller info

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,9 +1,13 @@
 package logrus
 
 import (
+	"fmt"
 	"io"
+	"log"
 	"os"
+	"path"
 	"sync"
+	"runtime"
 )
 
 type Logger struct {
@@ -30,6 +34,8 @@ type Logger struct {
 	mu MutexWrap
 	// Reusable empty entry
 	entryPool sync.Pool
+	// Report caller options
+	ReportCallerOptions *ReportCallerOptions
 }
 
 type MutexWrap struct {
@@ -51,6 +57,19 @@ func (mw *MutexWrap) Unlock() {
 
 func (mw *MutexWrap) Disable() {
 	mw.disabled = true
+}
+
+// ReportCallerOptions stores state for reporting caller the source code and line numbers of
+// log entries
+type ReportCallerOptions struct {
+	// Field to display caller info in
+	Field string
+	// Stores the flags
+	Flags int
+}
+// HasFlag returns true if the report caller options contains the specified flag
+func (reportCaller *ReportCallerOptions) HasFlag(flag int) bool {
+	return reportCaller.Flags & flag != 0
 }
 
 // Creates a new logger. Configuration should be set by changing `Formatter`,
@@ -82,7 +101,40 @@ func (logger *Logger) newEntry() *Entry {
 	return NewEntry(logger)
 }
 
+// Checks the logger's report caller state, a flag indicating whether to display
+// the source file and line number of the log entry. Calls logger.newEntry for
+// backward compatibility with existing functionality. Source file and line number
+// are stored in a field called "src" in the format "file.go:22". By default, log.Llongfile
+// flag is set and takes precendence over log.Lshortfile to be consistent with default log
+// pkg
+func (logger *Logger) newEntryReportCaller(skipFrames int) *Entry {
+	entry := logger.newEntry()
+	if logger.ReportCallerOptions != nil {
+		// set default report caller field to "src"
+		if logger.ReportCallerOptions.Field == "" { logger.ReportCallerOptions.Field = "src" }
+		// Find caller info
+		_, file, line, ok := runtime.Caller(skipFrames)
+		if !ok {
+			file = "???"
+			line = 0
+		} else {
+			// check flags
+			if logger.ReportCallerOptions.HasFlag(log.Lshortfile) && !logger.ReportCallerOptions.HasFlag(log.Llongfile) {
+				file = path.Base(file)
+			}
+		}
+		entry.Data[logger.ReportCallerOptions.Field] = fmt.Sprintf("%s:%d", file, line)
+	}
+	return entry
+}
+
 func (logger *Logger) releaseEntry(entry *Entry) {
+	// Reset caller state
+	if logger.ReportCallerOptions != nil {
+		if _, ok := entry.Data[logger.ReportCallerOptions.Field]; ok {
+			delete(entry.Data, logger.ReportCallerOptions.Field)
+		}
+	}
 	logger.entryPool.Put(entry)
 }
 
@@ -90,7 +142,7 @@ func (logger *Logger) releaseEntry(entry *Entry) {
 // Debug, Print, Info, Warn, Fatal or Panic. It only creates a log entry.
 // If you want multiple fields, use `WithFields`.
 func (logger *Logger) WithField(key string, value interface{}) *Entry {
-	entry := logger.newEntry()
+	entry := logger.newEntryReportCaller(2)
 	defer logger.releaseEntry(entry)
 	return entry.WithField(key, value)
 }
@@ -98,7 +150,7 @@ func (logger *Logger) WithField(key string, value interface{}) *Entry {
 // Adds a struct of fields to the log entry. All it does is call `WithField` for
 // each `Field`.
 func (logger *Logger) WithFields(fields Fields) *Entry {
-	entry := logger.newEntry()
+	entry := logger.newEntryReportCaller(2)
 	defer logger.releaseEntry(entry)
 	return entry.WithFields(fields)
 }
@@ -106,14 +158,14 @@ func (logger *Logger) WithFields(fields Fields) *Entry {
 // Add an error as single field to the log entry.  All it does is call
 // `WithError` for the given `error`.
 func (logger *Logger) WithError(err error) *Entry {
-	entry := logger.newEntry()
+	entry := logger.newEntryReportCaller(2)
 	defer logger.releaseEntry(entry)
 	return entry.WithError(err)
 }
 
 func (logger *Logger) Debugf(format string, args ...interface{}) {
 	if logger.Level >= DebugLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Debugf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -121,21 +173,21 @@ func (logger *Logger) Debugf(format string, args ...interface{}) {
 
 func (logger *Logger) Infof(format string, args ...interface{}) {
 	if logger.Level >= InfoLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Infof(format, args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Printf(format string, args ...interface{}) {
-	entry := logger.newEntry()
+	entry := logger.newEntryReportCaller(2)
 	entry.Printf(format, args...)
 	logger.releaseEntry(entry)
 }
 
 func (logger *Logger) Warnf(format string, args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Warnf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -143,7 +195,7 @@ func (logger *Logger) Warnf(format string, args ...interface{}) {
 
 func (logger *Logger) Warningf(format string, args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Warnf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -151,7 +203,7 @@ func (logger *Logger) Warningf(format string, args ...interface{}) {
 
 func (logger *Logger) Errorf(format string, args ...interface{}) {
 	if logger.Level >= ErrorLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Errorf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -159,7 +211,7 @@ func (logger *Logger) Errorf(format string, args ...interface{}) {
 
 func (logger *Logger) Fatalf(format string, args ...interface{}) {
 	if logger.Level >= FatalLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Fatalf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -168,7 +220,7 @@ func (logger *Logger) Fatalf(format string, args ...interface{}) {
 
 func (logger *Logger) Panicf(format string, args ...interface{}) {
 	if logger.Level >= PanicLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Panicf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -176,7 +228,7 @@ func (logger *Logger) Panicf(format string, args ...interface{}) {
 
 func (logger *Logger) Debug(args ...interface{}) {
 	if logger.Level >= DebugLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Debug(args...)
 		logger.releaseEntry(entry)
 	}
@@ -184,21 +236,21 @@ func (logger *Logger) Debug(args ...interface{}) {
 
 func (logger *Logger) Info(args ...interface{}) {
 	if logger.Level >= InfoLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Info(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Print(args ...interface{}) {
-	entry := logger.newEntry()
+	entry := logger.newEntryReportCaller(2)
 	entry.Info(args...)
 	logger.releaseEntry(entry)
 }
 
 func (logger *Logger) Warn(args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Warn(args...)
 		logger.releaseEntry(entry)
 	}
@@ -206,7 +258,7 @@ func (logger *Logger) Warn(args ...interface{}) {
 
 func (logger *Logger) Warning(args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Warn(args...)
 		logger.releaseEntry(entry)
 	}
@@ -214,7 +266,7 @@ func (logger *Logger) Warning(args ...interface{}) {
 
 func (logger *Logger) Error(args ...interface{}) {
 	if logger.Level >= ErrorLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Error(args...)
 		logger.releaseEntry(entry)
 	}
@@ -222,7 +274,7 @@ func (logger *Logger) Error(args ...interface{}) {
 
 func (logger *Logger) Fatal(args ...interface{}) {
 	if logger.Level >= FatalLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Fatal(args...)
 		logger.releaseEntry(entry)
 	}
@@ -231,7 +283,7 @@ func (logger *Logger) Fatal(args ...interface{}) {
 
 func (logger *Logger) Panic(args ...interface{}) {
 	if logger.Level >= PanicLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Panic(args...)
 		logger.releaseEntry(entry)
 	}
@@ -239,7 +291,7 @@ func (logger *Logger) Panic(args ...interface{}) {
 
 func (logger *Logger) Debugln(args ...interface{}) {
 	if logger.Level >= DebugLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Debugln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -247,21 +299,21 @@ func (logger *Logger) Debugln(args ...interface{}) {
 
 func (logger *Logger) Infoln(args ...interface{}) {
 	if logger.Level >= InfoLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Infoln(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Println(args ...interface{}) {
-	entry := logger.newEntry()
+	entry := logger.newEntryReportCaller(2)
 	entry.Println(args...)
 	logger.releaseEntry(entry)
 }
 
 func (logger *Logger) Warnln(args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Warnln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -269,7 +321,7 @@ func (logger *Logger) Warnln(args ...interface{}) {
 
 func (logger *Logger) Warningln(args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Warnln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -277,7 +329,7 @@ func (logger *Logger) Warningln(args ...interface{}) {
 
 func (logger *Logger) Errorln(args ...interface{}) {
 	if logger.Level >= ErrorLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Errorln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -285,7 +337,7 @@ func (logger *Logger) Errorln(args ...interface{}) {
 
 func (logger *Logger) Fatalln(args ...interface{}) {
 	if logger.Level >= FatalLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Fatalln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -294,7 +346,7 @@ func (logger *Logger) Fatalln(args ...interface{}) {
 
 func (logger *Logger) Panicln(args ...interface{}) {
 	if logger.Level >= PanicLevel {
-		entry := logger.newEntry()
+		entry := logger.newEntryReportCaller(2)
 		entry.Panicln(args...)
 		logger.releaseEntry(entry)
 	}


### PR DESCRIPTION
Reference #63 Extends the functionality of logrus by providing the option to report caller info:
```
logr := &logrus.Logger{
	Out:       	os.Stdout,
	Formatter: 	new(logrus.TextFormatter),
	Hooks:     	make(logrus.LevelHooks),
	Level:		logrus.DebugLevel,
	ReportCallerOptions: &logrus.ReportCallerOptions{
		Field: "file", // default is "src"
		Flags: log.Lshortfile, // default is "log.Llongfile"
	},
}
logr.Println("Test log")
// time="2017-05-02T10:26:49-05:00" level=info msg="Test log" file="main.go:12" 
```