### PR TITLE
Entry.WithFields(): copy the original entry

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -82,7 +82,10 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	for k, v := range fields {
 		data[k] = v
 	}
-	return &Entry{Logger: entry.Logger, Data: data}
+	// shallow copy
+	newentry := *entry
+	newentry.Data = data
+	return &newentry
 }
 
 // This function is not declared with a pointer value because otherwise

--- a/entry_test.go
+++ b/entry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -74,4 +75,36 @@ func TestEntryPanicf(t *testing.T) {
 	logger.Out = &bytes.Buffer{}
 	entry := NewEntry(logger)
 	entry.WithField("err", errBoom).Panicf("kaboom %v", true)
+}
+
+func TestEntryWithFields(t *testing.T) {
+	entry1 := &Entry{
+		Logger: StandardLogger(),
+		Time:   time.Now(),
+		Level:  InfoLevel,
+	}
+
+	entry2 := entry1.WithFields(Fields{
+		"key1": "value1",
+		"key2": "value2",
+	})
+
+	// Check everything but Data is still the same
+	assert.Equal(t, entry1.Logger, entry2.Logger)
+	assert.Equal(t, entry1.Time, entry2.Time)
+	assert.Equal(t, entry1.Level, entry2.Level)
+	assert.Equal(t, entry1.Message, entry2.Message)
+	assert.Equal(t, entry1.Buffer, entry2.Buffer)
+
+	entry3 := entry2.WithFields(Fields{
+		"key3": "value4",
+		"key4": "value4",
+	})
+	// Check everything but Data is still the same
+	assert.Equal(t, entry1.Logger, entry3.Logger)
+	assert.Equal(t, entry1.Time, entry3.Time)
+	assert.Equal(t, entry1.Level, entry3.Level)
+	assert.Equal(t, entry1.Message, entry3.Message)
+	assert.Equal(t, entry1.Buffer, entry3.Buffer)
+
 }


### PR DESCRIPTION
`Entry.WithFields()` currently creates a new `Entry` and partially copies it. Calling several times `WithFields()` on an already logged entry (e.g. in a formatter) thus leads to an incorrectly initialized `Entry` structure.

The patch makes the method copy the original entry and only modify the `Data` member with the new set of fields. So that calling several times `WithFields()` on an already logged entry
(e.g. in a formatter `Format()` method) avoids this problem.