### PR TITLE
Fixes #63 add caller info in safe manner

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -42,6 +42,9 @@ type Entry struct {
 
 	// When formatter is called in entry.log(), an Buffer may be set to entry
 	Buffer *bytes.Buffer
+
+	// Caller frames is the number of frames to skip to obtain the details of the original caller
+	callerFrames int
 }
 
 func NewEntry(logger *Logger) *Entry {
@@ -50,6 +53,21 @@ func NewEntry(logger *Logger) *Entry {
 		// Default is three fields, give a little extra room
 		Data: make(Fields, 5),
 	}
+}
+
+// CallerFrames returns the number of frames to skip to obtain the caller info
+func (entry *Entry) CallerFrames() int {
+	return entry.callerFrames
+}
+
+// Resets caller frames state to 0
+func (entry *Entry) resetCallerFrames() {
+	entry.callerFrames = 0
+}
+
+// Adds the specified frames to existing caller frames count
+func (entry *Entry) addCallerFrames(frames int) {
+	entry.callerFrames += frames
 }
 
 // Returns the string representation from the reader and ultimately the
@@ -92,6 +110,7 @@ func (entry Entry) log(level Level, msg string) {
 	entry.Time = time.Now()
 	entry.Level = level
 	entry.Message = msg
+	entry.addCallerFrames(3) // add 1 for this frame, 1 for Hooks.Fire below, and 1 for the Hook.Fire method
 
 	if err := entry.Logger.Hooks.Fire(level, &entry); err != nil {
 		entry.Logger.mu.Lock()
@@ -127,38 +146,52 @@ func (entry Entry) log(level Level, msg string) {
 
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.log(DebugLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Print(args ...interface{}) {
+	entry.addCallerFrames(1) // add 1 for this frame
+	defer entry.resetCallerFrames()
 	entry.Info(args...)
 }
 
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.level() >= InfoLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.log(InfoLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
 	if entry.Logger.level() >= WarnLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.log(WarnLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Warning(args ...interface{}) {
+	entry.addCallerFrames(1) // add 1 for this frame
+	defer entry.resetCallerFrames()
 	entry.Warn(args...)
 }
 
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.level() >= ErrorLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.log(ErrorLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.level() >= FatalLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.log(FatalLevel, fmt.Sprint(args...))
 	}
 	Exit(1)
@@ -166,6 +199,8 @@ func (entry *Entry) Fatal(args ...interface{}) {
 
 func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.level() >= PanicLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.log(PanicLevel, fmt.Sprint(args...))
 	}
 	panic(fmt.Sprint(args...))
@@ -175,38 +210,52 @@ func (entry *Entry) Panic(args ...interface{}) {
 
 func (entry *Entry) Debugf(format string, args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Debug(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Infof(format string, args ...interface{}) {
 	if entry.Logger.level() >= InfoLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Info(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Printf(format string, args ...interface{}) {
+	entry.addCallerFrames(1) // add 1 for this frame
+	defer entry.resetCallerFrames()
 	entry.Infof(format, args...)
 }
 
 func (entry *Entry) Warnf(format string, args ...interface{}) {
 	if entry.Logger.level() >= WarnLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Warn(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Warningf(format string, args ...interface{}) {
+	entry.addCallerFrames(1) // add 1 for this frame
+	defer entry.resetCallerFrames()
 	entry.Warnf(format, args...)
 }
 
 func (entry *Entry) Errorf(format string, args ...interface{}) {
 	if entry.Logger.level() >= ErrorLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Error(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.level() >= FatalLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Fatal(fmt.Sprintf(format, args...))
 	}
 	Exit(1)
@@ -214,6 +263,8 @@ func (entry *Entry) Fatalf(format string, args ...interface{}) {
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
 	if entry.Logger.level() >= PanicLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Panic(fmt.Sprintf(format, args...))
 	}
 }
@@ -222,38 +273,52 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 
 func (entry *Entry) Debugln(args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Debug(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Infoln(args ...interface{}) {
 	if entry.Logger.level() >= InfoLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Info(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Println(args ...interface{}) {
+	entry.addCallerFrames(1) // add 1 for this frame
+	defer entry.resetCallerFrames()
 	entry.Infoln(args...)
 }
 
 func (entry *Entry) Warnln(args ...interface{}) {
 	if entry.Logger.level() >= WarnLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Warn(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Warningln(args ...interface{}) {
+	entry.addCallerFrames(1) // add 1 for this frame
+	defer entry.resetCallerFrames()
 	entry.Warnln(args...)
 }
 
 func (entry *Entry) Errorln(args ...interface{}) {
 	if entry.Logger.level() >= ErrorLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Error(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.level() >= FatalLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Fatal(entry.sprintlnn(args...))
 	}
 	Exit(1)
@@ -261,6 +326,8 @@ func (entry *Entry) Fatalln(args ...interface{}) {
 
 func (entry *Entry) Panicln(args ...interface{}) {
 	if entry.Logger.level() >= PanicLevel {
+		entry.addCallerFrames(1) // add 1 for this frame
+		defer entry.resetCallerFrames()
 		entry.Panic(entry.sprintlnn(args...))
 	}
 }

--- a/exported.go
+++ b/exported.go
@@ -74,120 +74,120 @@ func WithFields(fields Fields) *Entry {
 
 // Debug logs a message at level Debug on the standard logger.
 func Debug(args ...interface{}) {
-	std.Debug(args...)
+	std.fDebug(1, args...)
 }
 
 // Print logs a message at level Info on the standard logger.
 func Print(args ...interface{}) {
-	std.Print(args...)
+	std.fPrint(1, args...)
 }
 
 // Info logs a message at level Info on the standard logger.
 func Info(args ...interface{}) {
-	std.Info(args...)
+	std.fInfo(1, args...)
 }
 
 // Warn logs a message at level Warn on the standard logger.
 func Warn(args ...interface{}) {
-	std.Warn(args...)
+	std.fWarn(1, args...)
 }
 
 // Warning logs a message at level Warn on the standard logger.
 func Warning(args ...interface{}) {
-	std.Warning(args...)
+	std.fWarning(1, args...)
 }
 
 // Error logs a message at level Error on the standard logger.
 func Error(args ...interface{}) {
-	std.Error(args...)
+	std.fError(1, args...)
 }
 
 // Panic logs a message at level Panic on the standard logger.
 func Panic(args ...interface{}) {
-	std.Panic(args...)
+	std.fPanic(1, args...)
 }
 
 // Fatal logs a message at level Fatal on the standard logger.
 func Fatal(args ...interface{}) {
-	std.Fatal(args...)
+	std.fFatal(1, args...)
 }
 
 // Debugf logs a message at level Debug on the standard logger.
 func Debugf(format string, args ...interface{}) {
-	std.Debugf(format, args...)
+	std.fDebugf(1, format, args...)
 }
 
 // Printf logs a message at level Info on the standard logger.
 func Printf(format string, args ...interface{}) {
-	std.Printf(format, args...)
+	std.fPrintf(1, format, args...)
 }
 
 // Infof logs a message at level Info on the standard logger.
 func Infof(format string, args ...interface{}) {
-	std.Infof(format, args...)
+	std.fInfof(1, format, args...)
 }
 
 // Warnf logs a message at level Warn on the standard logger.
 func Warnf(format string, args ...interface{}) {
-	std.Warnf(format, args...)
+	std.fWarnf(1, format, args...)
 }
 
 // Warningf logs a message at level Warn on the standard logger.
 func Warningf(format string, args ...interface{}) {
-	std.Warningf(format, args...)
+	std.fWarningf(1, format, args...)
 }
 
 // Errorf logs a message at level Error on the standard logger.
 func Errorf(format string, args ...interface{}) {
-	std.Errorf(format, args...)
+	std.fErrorf(1, format, args...)
 }
 
 // Panicf logs a message at level Panic on the standard logger.
 func Panicf(format string, args ...interface{}) {
-	std.Panicf(format, args...)
+	std.fPanicf(1, format, args...)
 }
 
 // Fatalf logs a message at level Fatal on the standard logger.
 func Fatalf(format string, args ...interface{}) {
-	std.Fatalf(format, args...)
+	std.fFatalf(1, format, args...)
 }
 
 // Debugln logs a message at level Debug on the standard logger.
 func Debugln(args ...interface{}) {
-	std.Debugln(args...)
+	std.fDebugln(1, args...)
 }
 
 // Println logs a message at level Info on the standard logger.
 func Println(args ...interface{}) {
-	std.Println(args...)
+	std.fPrintln(1, args...)
 }
 
 // Infoln logs a message at level Info on the standard logger.
 func Infoln(args ...interface{}) {
-	std.Infoln(args...)
+	std.fInfoln(1, args...)
 }
 
 // Warnln logs a message at level Warn on the standard logger.
 func Warnln(args ...interface{}) {
-	std.Warnln(args...)
+	std.fWarnln(1, args...)
 }
 
 // Warningln logs a message at level Warn on the standard logger.
 func Warningln(args ...interface{}) {
-	std.Warningln(args...)
+	std.fWarningln(1, args...)
 }
 
 // Errorln logs a message at level Error on the standard logger.
 func Errorln(args ...interface{}) {
-	std.Errorln(args...)
+	std.fErrorln(1, args...)
 }
 
 // Panicln logs a message at level Panic on the standard logger.
 func Panicln(args ...interface{}) {
-	std.Panicln(args...)
+	std.fPanicln(1, args...)
 }
 
 // Fatalln logs a message at level Fatal on the standard logger.
 func Fatalln(args ...interface{}) {
-	std.Fatalln(args...)
+	std.fFatalln(1, args...)
 }

--- a/hooks/caller/caller.go
+++ b/hooks/caller/caller.go
@@ -1,0 +1,83 @@
+package caller
+
+import (
+	"fmt"
+	"log"
+	"path"
+	"runtime"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// CallerHook adds caller information to log entries.
+//
+// Sample usage:
+// logrus.AddHook(caller.NewHook(&caller.CallerHookOptions{
+// 	Field: "src",
+// 	Flags: log.Lshortfile,
+// }))
+// logrus.SetFormatter(&logrus.JSONFormatter{})
+// logrus.Info("Test log")
+// // time="2017-05-02T10:26:49-05:00" level=info msg="Test log" file="main.go:12"
+
+type CallerHook struct {
+	CallerHookOptions *CallerHookOptions
+}
+
+// NewHook creates a new caller hook with options. If options are nil or unspecified, options.Field defaults to "src"
+// and options.Flags defaults to log.Llongfile
+func NewHook(options *CallerHookOptions) *CallerHook {
+	// Set default caller field to "src"
+	if options.Field == "" {
+		options.Field = "src"
+	}
+	// Set default caller flag to Std logger log.Llongfile
+	if options.Flags == 0 {
+		options.Flags = log.Llongfile
+	}
+	return &CallerHook{options}
+}
+
+// CallerHookOptions stores caller hook options
+type CallerHookOptions struct {
+	// Field to display caller info in
+	Field string
+	// Stores the flags
+	Flags int
+}
+
+// HasFlag returns true if the report caller options contains the specified flag
+func (options *CallerHookOptions) HasFlag(flag int) bool {
+	return options.Flags&flag != 0
+}
+
+func (hook *CallerHook) Fire(entry *logrus.Entry) error {
+	entry.Data[hook.CallerHookOptions.Field] = hook.callerInfo(entry.CallerFrames() + 1) // add 1 for this frame
+	return nil
+}
+
+func (hook *CallerHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+		logrus.InfoLevel,
+		logrus.DebugLevel,
+	}
+}
+
+func (hook *CallerHook) callerInfo(skipFrames int) string {
+	// Follows output of Std logger
+	_, file, line, ok := runtime.Caller(skipFrames)
+	if !ok {
+		file = "???"
+		line = 0
+	} else {
+		// check flags
+		if hook.CallerHookOptions.HasFlag(log.Lshortfile) && !hook.CallerHookOptions.HasFlag(log.Llongfile) {
+			file = path.Base(file)
+		}
+	}
+	return fmt.Sprintf("%s:%d", file, line)
+}

--- a/hooks/caller/caller_test.go
+++ b/hooks/caller/caller_test.go
@@ -1,0 +1,178 @@
+package caller
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type logJson struct {
+	Level string
+	Msg   string
+	Time  time.Time
+	Src   string
+}
+
+func TestCallerHook_ExportedInfo(t *testing.T) {
+	var buffer bytes.Buffer
+	// Caller hook
+	logrus.AddHook(NewHook(&CallerHookOptions{
+		Field: "src",
+		Flags: log.Lshortfile,
+	}))
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetOutput(&buffer)
+
+	testCallerHookExportedInfo(t, &buffer, "Testing")
+	testCallerHookExportedInfo(t, &buffer, "Testing 2")
+	testCallerHookExportedInfo(t, &buffer, "Testing 3")
+
+	// Test in goroutines
+	count := 50
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(t *testing.T, wg *sync.WaitGroup, i int) {
+			defer wg.Done()
+			logrus.Info(fmt.Sprintf("Testing for race conditions %d", i))
+		}(t, &wg, i)
+	}
+	// Wait for goroutines
+	wg.Wait()
+}
+
+func testCallerHookExportedInfo(t *testing.T, buffer *bytes.Buffer, msg string) {
+	var j logJson
+	logrus.Info(msg)
+	scanner := bufio.NewScanner(buffer)
+	scanner.Scan()
+	line := scanner.Text()
+	assert.NoError(t, scanner.Err(), "Scanner error")
+	json.Unmarshal([]byte(line), &j)
+	assert.Equal(t, "caller_test.go:54", j.Src, "%v", j)
+	assert.Equal(t, msg, j.Msg, "%v", j)
+	assert.Equal(t, "info", j.Level, "%v", j)
+}
+
+func TestCallerHook_ExportedEntryInfo(t *testing.T) {
+	var buffer bytes.Buffer
+	// Caller hook
+	logrus.AddHook(NewHook(&CallerHookOptions{
+		Field: "src",
+		Flags: log.Lshortfile,
+	}))
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetOutput(&buffer)
+
+	testCallerHookExportedEntryInfo(t, &buffer, "Testing")
+	testCallerHookExportedEntryInfo(t, &buffer, "Testing 2")
+	testCallerHookExportedEntryInfo(t, &buffer, "Testing 3")
+
+	// Test in goroutines
+	count := 50
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(t *testing.T, wg *sync.WaitGroup, i int) {
+			defer wg.Done()
+			logrus.Info(fmt.Sprintf("Testing for race conditions %d", i))
+		}(t, &wg, i)
+	}
+	// Wait for goroutines
+	wg.Wait()
+}
+
+func testCallerHookExportedEntryInfo(t *testing.T, buffer *bytes.Buffer, msg string) {
+	var j logJson
+	logrus.WithField("testcaller", "testcaller value").Info(msg)
+	scanner := bufio.NewScanner(buffer)
+	scanner.Scan()
+	line := scanner.Text()
+	assert.NoError(t, scanner.Err(), "Scanner error")
+	json.Unmarshal([]byte(line), &j)
+	assert.Equal(t, "caller_test.go:95", j.Src, "%v", j)
+	assert.Equal(t, msg, j.Msg, "%v", j)
+	assert.Equal(t, "info", j.Level, "%v", j)
+}
+
+func TestCallerHook_NewLoggerInfo(t *testing.T) {
+	var buffer bytes.Buffer
+	logr := logrus.New()
+	// Caller hook
+	logr.Hooks.Add(NewHook(&CallerHookOptions{
+		Field: "src",
+		Flags: log.Lshortfile,
+	}))
+	logr.Formatter = &logrus.JSONFormatter{}
+	logr.Out = &buffer
+
+	testCallerHookInfo(t, logr, "Testing")
+	testCallerHookInfo(t, logr, "Testing 2")
+	testCallerHookInfo(t, logr, "Testing 3")
+
+	// Test in goroutines
+	count := 50
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(t *testing.T, wg *sync.WaitGroup, logr *logrus.Logger, i int) {
+			defer wg.Done()
+			logr.Info(fmt.Sprintf("Testing for race conditions %d", i))
+		}(t, &wg, logr, i)
+	}
+	// Wait for goroutines
+	wg.Wait()
+}
+
+func TestCallerHook_LoggerInfo(t *testing.T) {
+	var buffer bytes.Buffer
+	logr := &logrus.Logger{
+		Out:              &buffer,
+		Formatter:        new(logrus.JSONFormatter),
+		Hooks:            make(logrus.LevelHooks),
+		Level:            logrus.InfoLevel,
+	}
+	// Caller hook
+	logr.Hooks.Add(NewHook(&CallerHookOptions{
+		Field: "src",
+		Flags: log.Lshortfile,
+	}))
+
+	testCallerHookInfo(t, logr, "Testing")
+	testCallerHookInfo(t, logr, "Testing 2")
+	testCallerHookInfo(t, logr, "Testing 3")
+
+	// Test in goroutines
+	count := 50
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(t *testing.T, wg *sync.WaitGroup, logr *logrus.Logger, i int) {
+			defer wg.Done()
+			logr.Info(fmt.Sprintf("Testing for race conditions %d", i))
+		}(t, &wg, logr, i)
+	}
+	// Wait for goroutines
+	wg.Wait()
+}
+
+func testCallerHookInfo(t *testing.T, logr *logrus.Logger, msg string) {
+	var j logJson
+	logr.Info(msg)
+	scanner := bufio.NewScanner(logr.Out.(*bytes.Buffer))
+	scanner.Scan()
+	line := scanner.Text()
+	assert.NoError(t, scanner.Err(), "Scanner error")
+	json.Unmarshal([]byte(line), &j)
+	assert.Equal(t, "caller_test.go:169", j.Src, "%v", j)
+	assert.Equal(t, msg, j.Msg, "%v", j)
+	assert.Equal(t, "info", j.Level, "%v", j)
+}

--- a/logger.go
+++ b/logger.go
@@ -84,6 +84,7 @@ func (logger *Logger) newEntry() *Entry {
 }
 
 func (logger *Logger) releaseEntry(entry *Entry) {
+	entry.resetCallerFrames() // reset frame state on entry
 	logger.entryPool.Put(entry)
 }
 
@@ -115,6 +116,7 @@ func (logger *Logger) WithError(err error) *Entry {
 func (logger *Logger) Debugf(format string, args ...interface{}) {
 	if logger.level() >= DebugLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Debugf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -123,6 +125,7 @@ func (logger *Logger) Debugf(format string, args ...interface{}) {
 func (logger *Logger) Infof(format string, args ...interface{}) {
 	if logger.level() >= InfoLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Infof(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -130,6 +133,7 @@ func (logger *Logger) Infof(format string, args ...interface{}) {
 
 func (logger *Logger) Printf(format string, args ...interface{}) {
 	entry := logger.newEntry()
+	entry.addCallerFrames(1)
 	entry.Printf(format, args...)
 	logger.releaseEntry(entry)
 }
@@ -137,6 +141,7 @@ func (logger *Logger) Printf(format string, args ...interface{}) {
 func (logger *Logger) Warnf(format string, args ...interface{}) {
 	if logger.level() >= WarnLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Warnf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -145,6 +150,7 @@ func (logger *Logger) Warnf(format string, args ...interface{}) {
 func (logger *Logger) Warningf(format string, args ...interface{}) {
 	if logger.level() >= WarnLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Warnf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -153,6 +159,7 @@ func (logger *Logger) Warningf(format string, args ...interface{}) {
 func (logger *Logger) Errorf(format string, args ...interface{}) {
 	if logger.level() >= ErrorLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Errorf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -161,6 +168,7 @@ func (logger *Logger) Errorf(format string, args ...interface{}) {
 func (logger *Logger) Fatalf(format string, args ...interface{}) {
 	if logger.level() >= FatalLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Fatalf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -170,6 +178,7 @@ func (logger *Logger) Fatalf(format string, args ...interface{}) {
 func (logger *Logger) Panicf(format string, args ...interface{}) {
 	if logger.level() >= PanicLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Panicf(format, args...)
 		logger.releaseEntry(entry)
 	}
@@ -178,6 +187,7 @@ func (logger *Logger) Panicf(format string, args ...interface{}) {
 func (logger *Logger) Debug(args ...interface{}) {
 	if logger.level() >= DebugLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Debug(args...)
 		logger.releaseEntry(entry)
 	}
@@ -186,6 +196,7 @@ func (logger *Logger) Debug(args ...interface{}) {
 func (logger *Logger) Info(args ...interface{}) {
 	if logger.level() >= InfoLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Info(args...)
 		logger.releaseEntry(entry)
 	}
@@ -193,6 +204,7 @@ func (logger *Logger) Info(args ...interface{}) {
 
 func (logger *Logger) Print(args ...interface{}) {
 	entry := logger.newEntry()
+	entry.addCallerFrames(1)
 	entry.Info(args...)
 	logger.releaseEntry(entry)
 }
@@ -200,6 +212,7 @@ func (logger *Logger) Print(args ...interface{}) {
 func (logger *Logger) Warn(args ...interface{}) {
 	if logger.level() >= WarnLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Warn(args...)
 		logger.releaseEntry(entry)
 	}
@@ -208,6 +221,7 @@ func (logger *Logger) Warn(args ...interface{}) {
 func (logger *Logger) Warning(args ...interface{}) {
 	if logger.level() >= WarnLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Warn(args...)
 		logger.releaseEntry(entry)
 	}
@@ -216,6 +230,7 @@ func (logger *Logger) Warning(args ...interface{}) {
 func (logger *Logger) Error(args ...interface{}) {
 	if logger.level() >= ErrorLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Error(args...)
 		logger.releaseEntry(entry)
 	}
@@ -224,6 +239,7 @@ func (logger *Logger) Error(args ...interface{}) {
 func (logger *Logger) Fatal(args ...interface{}) {
 	if logger.level() >= FatalLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Fatal(args...)
 		logger.releaseEntry(entry)
 	}
@@ -233,6 +249,7 @@ func (logger *Logger) Fatal(args ...interface{}) {
 func (logger *Logger) Panic(args ...interface{}) {
 	if logger.level() >= PanicLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Panic(args...)
 		logger.releaseEntry(entry)
 	}
@@ -241,6 +258,7 @@ func (logger *Logger) Panic(args ...interface{}) {
 func (logger *Logger) Debugln(args ...interface{}) {
 	if logger.level() >= DebugLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Debugln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -249,6 +267,7 @@ func (logger *Logger) Debugln(args ...interface{}) {
 func (logger *Logger) Infoln(args ...interface{}) {
 	if logger.level() >= InfoLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Infoln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -256,6 +275,7 @@ func (logger *Logger) Infoln(args ...interface{}) {
 
 func (logger *Logger) Println(args ...interface{}) {
 	entry := logger.newEntry()
+	entry.addCallerFrames(1)
 	entry.Println(args...)
 	logger.releaseEntry(entry)
 }
@@ -263,6 +283,7 @@ func (logger *Logger) Println(args ...interface{}) {
 func (logger *Logger) Warnln(args ...interface{}) {
 	if logger.level() >= WarnLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Warnln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -271,6 +292,7 @@ func (logger *Logger) Warnln(args ...interface{}) {
 func (logger *Logger) Warningln(args ...interface{}) {
 	if logger.level() >= WarnLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Warnln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -279,6 +301,7 @@ func (logger *Logger) Warningln(args ...interface{}) {
 func (logger *Logger) Errorln(args ...interface{}) {
 	if logger.level() >= ErrorLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Errorln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -287,6 +310,7 @@ func (logger *Logger) Errorln(args ...interface{}) {
 func (logger *Logger) Fatalln(args ...interface{}) {
 	if logger.level() >= FatalLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Fatalln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -296,6 +320,7 @@ func (logger *Logger) Fatalln(args ...interface{}) {
 func (logger *Logger) Panicln(args ...interface{}) {
 	if logger.level() >= PanicLevel {
 		entry := logger.newEntry()
+		entry.addCallerFrames(1)
 		entry.Panicln(args...)
 		logger.releaseEntry(entry)
 	}
@@ -314,4 +339,221 @@ func (logger *Logger) level() Level {
 
 func (logger *Logger) setLevel(level Level) {
 	atomic.StoreUint32((*uint32)(&logger.Level), uint32(level))
+}
+
+
+
+// These methods contain a field for passing caller frames
+
+func (logger *Logger) fDebugf(frames int, format string, args ...interface{}) {
+	if logger.level() >= DebugLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Debugf(format, args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fInfof(frames int, format string, args ...interface{}) {
+	if logger.level() >= InfoLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Infof(format, args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fPrintf(frames int, format string, args ...interface{}) {
+	entry := logger.newEntry()
+	entry.addCallerFrames(frames + 1)
+	entry.Printf(format, args...)
+	logger.releaseEntry(entry)
+}
+
+func (logger *Logger) fWarnf(frames int, format string, args ...interface{}) {
+	if logger.level() >= WarnLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Warnf(format, args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fWarningf(frames int, format string, args ...interface{}) {
+	if logger.level() >= WarnLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Warnf(format, args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fErrorf(frames int, format string, args ...interface{}) {
+	if logger.level() >= ErrorLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Errorf(format, args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fFatalf(frames int, format string, args ...interface{}) {
+	if logger.level() >= FatalLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Fatalf(format, args...)
+		logger.releaseEntry(entry)
+	}
+	Exit(1)
+}
+
+func (logger *Logger) fPanicf(frames int, format string, args ...interface{}) {
+	if logger.level() >= PanicLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Panicf(format, args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fDebug(frames int, args ...interface{}) {
+	if logger.level() >= DebugLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Debug(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fInfo(frames int, args ...interface{}) {
+	if logger.level() >= InfoLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Info(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fPrint(frames int, args ...interface{}) {
+	entry := logger.newEntry()
+	entry.addCallerFrames(frames + 1)
+	entry.Info(args...)
+	logger.releaseEntry(entry)
+}
+
+func (logger *Logger) fWarn(frames int, args ...interface{}) {
+	if logger.level() >= WarnLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Warn(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fWarning(frames int, args ...interface{}) {
+	if logger.level() >= WarnLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Warn(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fError(frames int, args ...interface{}) {
+	if logger.level() >= ErrorLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Error(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fFatal(frames int, args ...interface{}) {
+	if logger.level() >= FatalLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Fatal(args...)
+		logger.releaseEntry(entry)
+	}
+	Exit(1)
+}
+
+func (logger *Logger) fPanic(frames int, args ...interface{}) {
+	if logger.level() >= PanicLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Panic(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fDebugln(frames int, args ...interface{}) {
+	if logger.level() >= DebugLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Debugln(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fInfoln(frames int, args ...interface{}) {
+	if logger.level() >= InfoLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Infoln(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fPrintln(frames int, args ...interface{}) {
+	entry := logger.newEntry()
+	entry.addCallerFrames(frames + 1)
+	entry.Println(args...)
+	logger.releaseEntry(entry)
+}
+
+func (logger *Logger) fWarnln(frames int, args ...interface{}) {
+	if logger.level() >= WarnLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Warnln(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fWarningln(frames int, args ...interface{}) {
+	if logger.level() >= WarnLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Warnln(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fErrorln(frames int, args ...interface{}) {
+	if logger.level() >= ErrorLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Errorln(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) fFatalln(frames int, args ...interface{}) {
+	if logger.level() >= FatalLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Fatalln(args...)
+		logger.releaseEntry(entry)
+	}
+	Exit(1)
+}
+
+func (logger *Logger) fPanicln(frames int, args ...interface{}) {
+	if logger.level() >= PanicLevel {
+		entry := logger.newEntry()
+		entry.addCallerFrames(frames + 1)
+		entry.Panicln(args...)
+		logger.releaseEntry(entry)
+	}
 }


### PR DESCRIPTION
**Proposal - Report Caller Info**
*Re: Issue #63*
- Core determines caller frames and safely passes this to Hooks
  - Hooks can safely access logger Entry without making assumptions about stack frames
- Core stores caller frames in `Entry.CallerFrames()`
- Hooks shouldn't determine caller frames
  - If core changes placement of one nested function call it would break those implementations
  - Some implementations are dynamically traversing the stack to guess caller (maintenance nightmare and runtime.Caller is expensive)

*Notes*
`exported.go` uses a duplicate set of log functions that accept `frames` in the first parameter. This avoids the need to use locks and state management at the logger level.

**Sample code**
```
package main

import (
	stdlog "log"
	log "github.com/Sirupsen/logrus"
	"github.com/Sirupsen/logrus/hooks/caller"
)

func init() {
	log.SetFormatter(&log.JSONFormatter{})
	log.AddHook(caller.NewHook(&caller.CallerHookOptions{
		Field: "src",
		Flags: stdlog.Lshortfile,
	}))
}

func main() {
	log.Info("Test log.Info")
	log.Warn("Test log.Warn")

	log.WithFields(log.Fields{
		"animal": "walrus",
		"size":   10,
	}).Info("Test log.Fields.Info")

	log.WithFields(log.Fields{
		"omg":    true,
		"number": 122,
	}).Warn("Test log.Fields.Warn")

	contextLogger := log.WithFields(log.Fields{
		"common": "this is a common field",
		"other":  "I also should be logged always",
	})

	contextLogger.Info("I'll be logged with common and other field")
	contextLogger.Info("Me too")
}

// OUTPUT
// {"level":"info","msg":"Test log.Info","src":"logtest.go:18","time":"2017-05-15T18:33:41-05:00"}
// {"level":"warning","msg":"Test log.Warn","src":"logtest.go:19","time":"2017-05-15T18:33:41-05:00"}
// {"animal":"walrus","level":"info","msg":"Test log.Fields.Info","size":10,"src":"logtest.go:24","time":"2017-05-15T18:33:41-05:00"}
// {"level":"warning","msg":"Test log.Fields.Warn","number":122,"omg":true,"src":"logtest.go:29","time":"2017-05-15T18:33:41-05:00"}
// {"common":"this is a common field","level":"info","msg":"I'll be logged with common and other field","other":"I also should be logged always","src":"logtest.go:36","time":"2017-05-15T18:33:41-05:00"}
// {"common":"this is a common field","level":"info","msg":"Me too","other":"I also should be logged always","src":"logtest.go:37","time":"2017-05-15T18:33:41-05:00"}

```