### PR TITLE
Sets first letter of all sirupsen imports lower-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Slackrus](https://github.com/johntdyer/slackrus) | Hook for Slack chat. |
 | [Stackdriver](https://github.com/knq/sdhook) | Hook for logging to [Google Stackdriver](https://cloud.google.com/logging/) |
 | [Sumorus](https://github.com/doublefree/sumorus) | Hook for logging to [SumoLogic](https://www.sumologic.com/)|
-| [Syslog](https://github.com/Sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | Send errors to remote syslog server. Uses standard library `log/syslog` behind the scenes. |
+| [Syslog](https://github.com/sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | Send errors to remote syslog server. Uses standard library `log/syslog` behind the scenes. |
 | [TraceView](https://github.com/evalphobia/logrus_appneta) | Hook for logging to [AppNeta TraceView](https://www.appneta.com/products/traceview/) |
 | [Typetalk](https://github.com/dragon3/logrus-typetalk-hook) | Hook for logging to [Typetalk](https://www.typetalk.in/) |
 | [logz.io](https://github.com/ripcurld00d/logrus-logzio-hook) | Hook for logging to [logz.io](https://logz.io), a Log as a Service using Logstash |

--- a/hooks/syslog/README.md
+++ b/hooks/syslog/README.md
@@ -5,8 +5,8 @@
 ```go
 import (
   "log/syslog"
-  "github.com/Sirupsen/logrus"
-  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  "github.com/sirupsen/logrus"
+  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func main() {
@@ -24,8 +24,8 @@ If you want to connect to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "
 ```go
 import (
   "log/syslog"
-  "github.com/Sirupsen/logrus"
-  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  "github.com/sirupsen/logrus"
+  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func main() {

--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -4,7 +4,7 @@ package logrus_syslog
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"log/syslog"
 	"os"
 )

--- a/hooks/syslog/syslog_test.go
+++ b/hooks/syslog/syslog_test.go
@@ -1,7 +1,7 @@
 package logrus_syslog
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"log/syslog"
 	"testing"
 )

--- a/hooks/test/test.go
+++ b/hooks/test/test.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Hook is a hook designed for dealing with logs in test scenarios.

--- a/hooks/test/test_test.go
+++ b/hooks/test/test_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This pull request sets all import paths and other references of "sirupsen" to lower case letters, so everything should be unified.