### PR TITLE
Allow more chars in unquoted text formatter output

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -153,7 +153,7 @@ func (f *TextFormatter) needsQuoting(text string) bool {
 		if !((ch >= 'a' && ch <= 'z') ||
 			(ch >= 'A' && ch <= 'Z') ||
 			(ch >= '0' && ch <= '9') ||
-			ch == '-' || ch == '.') {
+			ch == '-' || ch == '.' || ch == '_' || ch == '/' || ch == '@' || ch == '^' || ch == '+') {
 			return true
 		}
 	}

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -28,7 +28,13 @@ func TestQuoting(t *testing.T) {
 	checkQuoting(false, "abcd")
 	checkQuoting(false, "v1.0")
 	checkQuoting(false, "1234567890")
-	checkQuoting(true, "/foobar")
+	checkQuoting(false, "/foobar")
+	checkQuoting(false, "foo_bar")
+	checkQuoting(false, "foo@bar")
+	checkQuoting(false, "foobar^")
+	checkQuoting(false, "+/-_^@f.oobar")
+	checkQuoting(true, "foobar$")
+	checkQuoting(true, "&foobar")
 	checkQuoting(true, "x y")
 	checkQuoting(true, "x,y")
 	checkQuoting(false, errors.New("invalid"))
@@ -38,7 +44,12 @@ func TestQuoting(t *testing.T) {
 	tf.QuoteCharacter = "`"
 	checkQuoting(false, "")
 	checkQuoting(false, "abcd")
-	checkQuoting(true, "/foobar")
+	checkQuoting(false, "/foobar")
+	checkQuoting(false, "foo_bar")
+	checkQuoting(false, "foo@bar")
+	checkQuoting(false, "foobar^")
+	checkQuoting(true, "foobar$")
+	checkQuoting(true, "&foobar")
 	checkQuoting(true, errors.New("invalid argument"))
 
 	// Test for multi-character quotes.


### PR DESCRIPTION
I was surprised recently to find that `_` is considered a quotable character, which differs from other l2met implementations I tend to use, which has sometimes meant that I need to perform searches that look like:

```
foo=bar_baz OR foo="bar_baz"
```
It's a minor inconvenience, so I'm happy to accept a _wontmerge_ response 😃 ❤️ 