### PR TITLE
Export logger's set level function to address #503.

### DIFF
--- a/exported.go
+++ b/exported.go
@@ -31,7 +31,7 @@ func SetFormatter(formatter Formatter) {
 func SetLevel(level Level) {
 	std.mu.Lock()
 	defer std.mu.Unlock()
-	std.setLevel(level)
+	std.SetLevel(level)
 }
 
 // GetLevel returns the standard logger level.

--- a/logger.go
+++ b/logger.go
@@ -312,6 +312,6 @@ func (logger *Logger) level() Level {
 	return Level(atomic.LoadUint32((*uint32)(&logger.Level)))
 }
 
-func (logger *Logger) setLevel(level Level) {
+func (logger *Logger) SetLevel(level Level) {
 	atomic.StoreUint32((*uint32)(&logger.Level), uint32(level))
 }


### PR DESCRIPTION
There's no way to set the log level on an `New()` logger. This just exports the existing `setLevel` function, as suggested in #503. 