### PR TITLE
Fields object support directly print log information, add the hook stack of print source lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ env:
   - GOMAXPROCS=4 GORACE=halt_on_error=1
 install:
   - go get github.com/stretchr/testify/assert
+  - go get github.com/kr/pretty
+  - go get github.com/kr/text
+  - go get github.com/kr/pty
 script:
   - go test -race -v .

--- a/entry.go
+++ b/entry.go
@@ -98,13 +98,13 @@ func (entry *Entry) WithSkip(skip int) *Entry {
 
 // This function is not declared with a pointer value because otherwise
 // race conditions will occur when using multiple goroutines
-func (entry *Entry) log(level Level, msg string) {
+func (entry Entry) log(level Level, msg string) {
 	var buffer *bytes.Buffer
 	entry.Time = time.Now()
 	entry.Level = level
 	entry.Message = msg
 
-	if err := entry.Logger.Hooks.Fire(level, entry); err != nil {
+	if err := entry.Logger.Hooks.Fire(level, &entry); err != nil {
 		entry.Logger.mu.Lock()
 		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
 		entry.Logger.mu.Unlock()
@@ -113,7 +113,7 @@ func (entry *Entry) log(level Level, msg string) {
 	buffer.Reset()
 	defer bufferPool.Put(buffer)
 	entry.Buffer = buffer
-	serialized, err := entry.Logger.Formatter.Format(entry)
+	serialized, err := entry.Logger.Formatter.Format(&entry)
 	entry.Buffer = nil
 	if err != nil {
 		entry.Logger.mu.Lock()

--- a/entry.go
+++ b/entry.go
@@ -42,6 +42,9 @@ type Entry struct {
 
 	// When formatter is called in entry.log(), an Buffer may be set to entry
 	Buffer *bytes.Buffer
+
+	// The argument skip is the number of stack frames
+	Skip int
 }
 
 func NewEntry(logger *Logger) *Entry {
@@ -85,15 +88,23 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	return &Entry{Logger: entry.Logger, Data: data}
 }
 
+// Add skip num.
+func (entry *Entry) WithSkip(skip int) *Entry {
+	if skip > entry.Skip {
+		entry.Skip = skip
+	}
+	return entry
+}
+
 // This function is not declared with a pointer value because otherwise
 // race conditions will occur when using multiple goroutines
-func (entry Entry) log(level Level, msg string) {
+func (entry *Entry) log(level Level, msg string) {
 	var buffer *bytes.Buffer
 	entry.Time = time.Now()
 	entry.Level = level
 	entry.Message = msg
 
-	if err := entry.Logger.Hooks.Fire(level, &entry); err != nil {
+	if err := entry.Logger.Hooks.Fire(level, entry); err != nil {
 		entry.Logger.mu.Lock()
 		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
 		entry.Logger.mu.Unlock()
@@ -102,7 +113,7 @@ func (entry Entry) log(level Level, msg string) {
 	buffer.Reset()
 	defer bufferPool.Put(buffer)
 	entry.Buffer = buffer
-	serialized, err := entry.Logger.Formatter.Format(&entry)
+	serialized, err := entry.Logger.Formatter.Format(entry)
 	entry.Buffer = nil
 	if err != nil {
 		entry.Logger.mu.Lock()
@@ -123,98 +134,99 @@ func (entry Entry) log(level Level, msg string) {
 	if level <= PanicLevel {
 		panic(&entry)
 	}
+
+	if level <= FatalLevel {
+		Exit(1)
+	}
 }
 
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
-		entry.log(DebugLevel, fmt.Sprint(args...))
+		entry.WithSkip(skip_4).log(DebugLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Print(args ...interface{}) {
-	entry.Info(args...)
+	entry.WithSkip(skip_5).Info(args...)
 }
 
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.level() >= InfoLevel {
-		entry.log(InfoLevel, fmt.Sprint(args...))
+		entry.WithSkip(skip_4).log(InfoLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
 	if entry.Logger.level() >= WarnLevel {
-		entry.log(WarnLevel, fmt.Sprint(args...))
+		entry.WithSkip(skip_4).log(WarnLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Warning(args ...interface{}) {
-	entry.Warn(args...)
+	entry.WithSkip(skip_5).Warn(args...)
 }
 
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.level() >= ErrorLevel {
-		entry.log(ErrorLevel, fmt.Sprint(args...))
+		entry.WithSkip(skip_4).log(ErrorLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.level() >= FatalLevel {
-		entry.log(FatalLevel, fmt.Sprint(args...))
+		entry.WithSkip(skip_4).log(FatalLevel, fmt.Sprint(args...))
 	}
-	Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.level() >= PanicLevel {
-		entry.log(PanicLevel, fmt.Sprint(args...))
+		entry.WithSkip(skip_4).log(PanicLevel, fmt.Sprint(args...))
 	}
-	panic(fmt.Sprint(args...))
 }
 
 // Entry Printf family functions
 
 func (entry *Entry) Debugf(format string, args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
-		entry.Debug(fmt.Sprintf(format, args...))
+		entry.WithSkip(skip_5).Debug(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Infof(format string, args ...interface{}) {
 	if entry.Logger.level() >= InfoLevel {
-		entry.Info(fmt.Sprintf(format, args...))
+		entry.WithSkip(skip_5).Info(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Printf(format string, args ...interface{}) {
-	entry.Infof(format, args...)
+	entry.WithSkip(skip_6).Infof(format, args...)
 }
 
 func (entry *Entry) Warnf(format string, args ...interface{}) {
 	if entry.Logger.level() >= WarnLevel {
-		entry.Warn(fmt.Sprintf(format, args...))
+		entry.WithSkip(skip_5).Warn(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Warningf(format string, args ...interface{}) {
-	entry.Warnf(format, args...)
+	entry.WithSkip(skip_6).Warnf(format, args...)
 }
 
 func (entry *Entry) Errorf(format string, args ...interface{}) {
 	if entry.Logger.level() >= ErrorLevel {
-		entry.Error(fmt.Sprintf(format, args...))
+		entry.WithSkip(skip_5).Error(fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.level() >= FatalLevel {
-		entry.Fatal(fmt.Sprintf(format, args...))
+		entry.WithSkip(skip_5).Fatal(fmt.Sprintf(format, args...))
 	}
-	Exit(1)
 }
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
 	if entry.Logger.level() >= PanicLevel {
-		entry.Panic(fmt.Sprintf(format, args...))
+		entry.WithSkip(skip_5).Panic(fmt.Sprintf(format, args...))
 	}
 }
 
@@ -222,46 +234,45 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 
 func (entry *Entry) Debugln(args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
-		entry.Debug(entry.sprintlnn(args...))
+		entry.WithSkip(skip_5).Debug(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Infoln(args ...interface{}) {
 	if entry.Logger.level() >= InfoLevel {
-		entry.Info(entry.sprintlnn(args...))
+		entry.WithSkip(skip_5).Info(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Println(args ...interface{}) {
-	entry.Infoln(args...)
+	entry.WithSkip(skip_6).Infoln(args...)
 }
 
 func (entry *Entry) Warnln(args ...interface{}) {
 	if entry.Logger.level() >= WarnLevel {
-		entry.Warn(entry.sprintlnn(args...))
+		entry.WithSkip(skip_5).Warn(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Warningln(args ...interface{}) {
-	entry.Warnln(args...)
+	entry.WithSkip(skip_6).Warnln(args...)
 }
 
 func (entry *Entry) Errorln(args ...interface{}) {
 	if entry.Logger.level() >= ErrorLevel {
-		entry.Error(entry.sprintlnn(args...))
+		entry.WithSkip(skip_5).Error(entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.level() >= FatalLevel {
-		entry.Fatal(entry.sprintlnn(args...))
+		entry.WithSkip(skip_5).Fatal(entry.sprintlnn(args...))
 	}
-	Exit(1)
 }
 
 func (entry *Entry) Panicln(args ...interface{}) {
 	if entry.Logger.level() >= PanicLevel {
-		entry.Panic(entry.sprintlnn(args...))
+		entry.WithSkip(skip_5).Panic(entry.sprintlnn(args...))
 	}
 }
 

--- a/examples/hook/stack.go
+++ b/examples/hook/stack.go
@@ -24,7 +24,7 @@ func main() {
 	}).Warn("The group's number increased tremendously!")
 
 	// If you set FieldsLogger, you can print the log directly to the object Fields
-	log.SetFieldsLogger()
+	logrus.SetFieldsLogger(log)
 	logrus.Fields{
 		"animal": "walrus",
 		"size":   10,

--- a/examples/hook/stack.go
+++ b/examples/hook/stack.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/stack"
+)
+
+var log = logrus.New()
+
+func init() {
+	log.Formatter = new(logrus.TextFormatter) // default
+	log.Hooks.Add(&stack.CodeLineHook{LogLevel: logrus.DebugLevel})
+}
+
+func main() {
+	log.WithFields(logrus.Fields{
+		"animal": "walrus",
+		"size":   10,
+	}).Info("A group of walrus emerges from the ocean")
+
+	log.WithFields(logrus.Fields{
+		"omg":    true,
+		"number": 122,
+	}).Warn("The group's number increased tremendously!")
+
+	log.WithFields(logrus.Fields{
+		"omg":    true,
+		"number": 100,
+	}).Fatal("The ice breaks!")
+}

--- a/examples/hook/stack.go
+++ b/examples/hook/stack.go
@@ -23,6 +23,13 @@ func main() {
 		"number": 122,
 	}).Warn("The group's number increased tremendously!")
 
+	// If you set FieldsLogger, you can print the log directly to the object Fields
+	log.SetFieldsLogger()
+	logrus.Fields{
+		"animal": "walrus",
+		"size":   10,
+	}.Info("A group of walrus emerges from the ocean")
+
 	log.WithFields(logrus.Fields{
 		"omg":    true,
 		"number": 100,

--- a/exported.go
+++ b/exported.go
@@ -74,120 +74,216 @@ func WithFields(fields Fields) *Entry {
 
 // Debug logs a message at level Debug on the standard logger.
 func Debug(args ...interface{}) {
-	std.Debug(args...)
+	if std.level() >= DebugLevel {
+		entry := std.newEntry().WithSkip(skip_5)
+		entry.debug(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Print logs a message at level Info on the standard logger.
 func Print(args ...interface{}) {
-	std.Print(args...)
+	if std.level() >= InfoLevel {
+		entry := std.newEntry().WithSkip(skip_5)
+		entry.info(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Info logs a message at level Info on the standard logger.
 func Info(args ...interface{}) {
-	std.Info(args...)
+	if std.level() >= InfoLevel {
+		entry := std.newEntry().WithSkip(skip_5)
+		entry.info(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Warn logs a message at level Warn on the standard logger.
 func Warn(args ...interface{}) {
-	std.Warn(args...)
+	if std.level() >= WarnLevel {
+		entry := std.newEntry().WithSkip(skip_5)
+		entry.warn(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Warning logs a message at level Warn on the standard logger.
 func Warning(args ...interface{}) {
-	std.Warning(args...)
+	if std.level() >= WarnLevel {
+		entry := std.newEntry().WithSkip(skip_5)
+		entry.warn(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Error logs a message at level Error on the standard logger.
 func Error(args ...interface{}) {
-	std.Error(args...)
+	if std.level() >= ErrorLevel {
+		entry := std.newEntry().WithSkip(skip_5)
+		entry.error(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Panic logs a message at level Panic on the standard logger.
 func Panic(args ...interface{}) {
-	std.Panic(args...)
+	if std.level() >= PanicLevel {
+		entry := std.newEntry().WithSkip(skip_5)
+		entry.panic(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Fatal logs a message at level Fatal on the standard logger.
 func Fatal(args ...interface{}) {
-	std.Fatal(args...)
+	if std.level() >= FatalLevel {
+		entry := std.newEntry().WithSkip(skip_5)
+		entry.fatal(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Debugf logs a message at level Debug on the standard logger.
 func Debugf(format string, args ...interface{}) {
-	std.Debugf(format, args...)
+	if std.level() >= DebugLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.debugf(format, args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Printf logs a message at level Info on the standard logger.
 func Printf(format string, args ...interface{}) {
-	std.Printf(format, args...)
+	if std.level() >= InfoLevel {
+		entry := std.newEntry().WithSkip(skip_7)
+		entry.printf(format, args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Infof logs a message at level Info on the standard logger.
 func Infof(format string, args ...interface{}) {
-	std.Infof(format, args...)
+	if std.level() >= InfoLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.infof(format, args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Warnf logs a message at level Warn on the standard logger.
 func Warnf(format string, args ...interface{}) {
-	std.Warnf(format, args...)
+	if std.level() >= WarnLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.warnf(format, args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Warningf logs a message at level Warn on the standard logger.
 func Warningf(format string, args ...interface{}) {
-	std.Warningf(format, args...)
+	if std.level() >= WarnLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.warnf(format, args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Errorf logs a message at level Error on the standard logger.
 func Errorf(format string, args ...interface{}) {
-	std.Errorf(format, args...)
+	if std.level() >= ErrorLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.errorf(format, args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Panicf logs a message at level Panic on the standard logger.
 func Panicf(format string, args ...interface{}) {
-	std.Panicf(format, args...)
+	if std.level() >= PanicLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.panicf(format, args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Fatalf logs a message at level Fatal on the standard logger.
 func Fatalf(format string, args ...interface{}) {
-	std.Fatalf(format, args...)
+	if std.level() >= FatalLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.fatalf(format, args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Debugln logs a message at level Debug on the standard logger.
 func Debugln(args ...interface{}) {
-	std.Debugln(args...)
+	if std.level() >= DebugLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.debugln(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Println logs a message at level Info on the standard logger.
 func Println(args ...interface{}) {
-	std.Println(args...)
+	if std.level() >= InfoLevel {
+		entry := std.newEntry().WithSkip(skip_7)
+		entry.println(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Infoln logs a message at level Info on the standard logger.
 func Infoln(args ...interface{}) {
-	std.Infoln(args...)
+	if std.level() >= InfoLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.infoln(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Warnln logs a message at level Warn on the standard logger.
 func Warnln(args ...interface{}) {
-	std.Warnln(args...)
+	if std.level() >= WarnLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.warnln(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Warningln logs a message at level Warn on the standard logger.
 func Warningln(args ...interface{}) {
-	std.Warningln(args...)
+	if std.level() >= WarnLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.warnln(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Errorln logs a message at level Error on the standard logger.
 func Errorln(args ...interface{}) {
-	std.Errorln(args...)
+	if std.level() >= ErrorLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.errorln(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Panicln logs a message at level Panic on the standard logger.
 func Panicln(args ...interface{}) {
-	std.Panicln(args...)
+	if std.level() >= PanicLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.panicln(args...)
+		std.releaseEntry(entry)
+	}
 }
 
 // Fatalln logs a message at level Fatal on the standard logger.
 func Fatalln(args ...interface{}) {
-	std.Fatalln(args...)
+	if std.level() >= FatalLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.fatalln(args...)
+		std.releaseEntry(entry)
+	}
 }

--- a/fields.go
+++ b/fields.go
@@ -1,0 +1,457 @@
+package logrus
+
+import (
+	"fmt"
+	"github.com/kr/pretty"
+)
+
+var (
+	FieldsLogger *Logger
+)
+
+const (
+	skip_4 = 4
+	skip_5 = 5
+	skip_6 = 6
+	skip_7 = 7
+)
+
+func (logger *Logger) SetFieldsLogger() {
+	FieldsLogger = logger
+}
+
+func SetFieldsLogger() {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	FieldsLogger = std
+}
+
+// exported, for logrus to pretty printing for Go values
+
+// Debugf logs a message at level Debug on the standard logger.
+func Debugfp(format string, args ...interface{}) {
+	if std.level() >= DebugLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.debugf(format+" ===>%# v", pretty.Formatter(args))
+		std.releaseEntry(entry)
+	}
+}
+
+// Printf logs a message at level Info on the standard logger.
+func Printfp(format string, args ...interface{}) {
+	if std.level() >= InfoLevel {
+		entry := std.newEntry().WithSkip(skip_7)
+		entry.printf(format+" ===>%# v", pretty.Formatter(args))
+		std.releaseEntry(entry)
+	}
+}
+
+// Infof logs a message at level Info on the standard logger.
+func Infofp(format string, args ...interface{}) {
+	if std.level() >= InfoLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.infof(format+" ===>%# v", pretty.Formatter(args))
+		std.releaseEntry(entry)
+	}
+}
+
+// Warnf logs a message at level Warn on the standard logger.
+func Warnfp(format string, args ...interface{}) {
+	if std.level() >= WarnLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.warnf(format+" ===>%# v", pretty.Formatter(args))
+		std.releaseEntry(entry)
+	}
+}
+
+// Warningf logs a message at level Warn on the standard logger.
+func Warningfp(format string, args ...interface{}) {
+	if std.level() >= WarnLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.warnf(format+" ===>%# v", pretty.Formatter(args))
+		std.releaseEntry(entry)
+	}
+}
+
+// Errorf logs a message at level Error on the standard logger.
+func Errorfp(format string, args ...interface{}) {
+	if std.level() >= ErrorLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.errorf(format+" ===>%# v", pretty.Formatter(args))
+		std.releaseEntry(entry)
+	}
+}
+
+// Panicf logs a message at level Panic on the standard logger.
+func Panicfp(format string, args ...interface{}) {
+	if std.level() >= PanicLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.panicf(format+" ===>%# v", pretty.Formatter(args))
+		std.releaseEntry(entry)
+	}
+}
+
+// Fatalf logs a message at level Fatal on the standard logger.
+func Fatalfp(format string, args ...interface{}) {
+	if std.level() >= FatalLevel {
+		entry := std.newEntry().WithSkip(skip_6)
+		entry.fatalf(format+" ===>%# v", pretty.Formatter(args))
+		std.releaseEntry(entry)
+	}
+}
+
+// for fields to pretty printing for Go values
+func (f Fields) Debugfp(format string, args ...interface{}) {
+	if FieldsLogger.level() >= DebugLevel {
+		f.withFields(f, skip_6).debugf(format+" ===>%# v", pretty.Formatter(args))
+	}
+}
+
+func (f Fields) Infofp(format string, args ...interface{}) {
+	if FieldsLogger.level() >= InfoLevel {
+		f.withFields(f, skip_6).infof(format+" ===>%# v", pretty.Formatter(args))
+	}
+}
+
+func (f Fields) Printfp(format string, args ...interface{}) {
+	if FieldsLogger.level() >= InfoLevel {
+		f.withFields(f, skip_7).printf(format+" ===>%# v", pretty.Formatter(args))
+	}
+}
+
+func (f Fields) Warnfp(format string, args ...interface{}) {
+	if FieldsLogger.level() >= WarnLevel {
+		f.withFields(f, skip_6).warnf(format+" ===>%# v", pretty.Formatter(args))
+	}
+}
+
+func (f Fields) Warningfp(format string, args ...interface{}) {
+	if FieldsLogger.level() >= WarnLevel {
+		f.withFields(f, skip_6).warnf(format+" ===>%# v", pretty.Formatter(args))
+	}
+}
+
+func (f Fields) Errorfp(format string, args ...interface{}) {
+	if FieldsLogger.level() >= ErrorLevel {
+		f.withFields(f, skip_6).errorf(format+" ===>%# v", pretty.Formatter(args))
+	}
+}
+
+func (f Fields) Fatalfp(format string, args ...interface{}) {
+	if FieldsLogger.level() >= FatalLevel {
+		f.withFields(f, skip_6).fatalf(format+" ===>%# v", pretty.Formatter(args))
+	}
+}
+
+func (f Fields) Panicfp(format string, args ...interface{}) {
+	if FieldsLogger.level() >= PanicLevel {
+		f.withFields(f, skip_6).panicf(format+" ===>%# v", pretty.Formatter(args))
+	}
+}
+
+// for logger to pretty printing for Go values
+func (logger *Logger) Debugfp(format string, args ...interface{}) {
+	if logger.level() >= DebugLevel {
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.debug(format+" ===>%# v", pretty.Formatter(args))
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Infofp(format string, args ...interface{}) {
+	if logger.level() >= InfoLevel {
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.infof(format+" ===>%# v", pretty.Formatter(args))
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Printfp(format string, args ...interface{}) {
+	if logger.level() >= InfoLevel {
+		entry := logger.newEntry().WithSkip(skip_7)
+		entry.printf(format+" ===>%# v", pretty.Formatter(args))
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Warnfp(format string, args ...interface{}) {
+	if logger.level() >= WarnLevel {
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.warnf(format+" ===>%# v", pretty.Formatter(args))
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Warningfp(format string, args ...interface{}) {
+	if logger.level() >= WarnLevel {
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.warnf(format+" ===>%# v", pretty.Formatter(args))
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Errorfp(format string, args ...interface{}) {
+	if logger.level() >= ErrorLevel {
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.errorf(format+" ===>%# v", pretty.Formatter(args))
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Fatalfp(format string, args ...interface{}) {
+	if logger.level() >= FatalLevel {
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.fatalf(format+" ===>%# v", pretty.Formatter(args))
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Panicfp(format string, args ...interface{}) {
+	if logger.level() >= PanicLevel {
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.panicf(format+" ===>%# v", pretty.Formatter(args))
+		logger.releaseEntry(entry)
+	}
+}
+
+// for fields
+func (f Fields) withFields(fields Fields, skip int) *Entry {
+	entry := FieldsLogger.newEntry()
+	defer FieldsLogger.releaseEntry(entry)
+	return entry.WithFields(f).WithSkip(skip)
+}
+
+func (f Fields) Debugf(format string, args ...interface{}) {
+	if FieldsLogger.level() >= DebugLevel {
+		f.withFields(f, skip_6).debugf(format, args...)
+	}
+}
+
+func (f Fields) Infof(format string, args ...interface{}) {
+	if FieldsLogger.level() >= InfoLevel {
+		f.withFields(f, skip_6).infof(format, args...)
+	}
+}
+
+func (f Fields) Printf(format string, args ...interface{}) {
+	if FieldsLogger.level() >= InfoLevel {
+		f.withFields(f, skip_7).printf(format, args...)
+	}
+}
+
+func (f Fields) Warnf(format string, args ...interface{}) {
+	if FieldsLogger.level() >= WarnLevel {
+		f.withFields(f, skip_6).warnf(format, args...)
+	}
+}
+
+func (f Fields) Warningf(format string, args ...interface{}) {
+	if FieldsLogger.level() >= WarnLevel {
+		f.withFields(f, skip_6).warnf(format, args...)
+	}
+}
+
+func (f Fields) Errorf(format string, args ...interface{}) {
+	if FieldsLogger.level() >= ErrorLevel {
+		f.withFields(f, skip_6).errorf(format, args...)
+	}
+}
+
+func (f Fields) Fatalf(format string, args ...interface{}) {
+	if FieldsLogger.level() >= FatalLevel {
+		f.withFields(f, skip_6).fatalf(format, args...)
+	}
+}
+
+func (f Fields) Panicf(format string, args ...interface{}) {
+	if FieldsLogger.level() >= PanicLevel {
+		f.withFields(f, skip_6).panicf(format, args...)
+	}
+}
+
+func (f Fields) Debug(args ...interface{}) {
+	if FieldsLogger.level() >= DebugLevel {
+		f.withFields(f, skip_5).debug(args...)
+	}
+}
+
+func (f Fields) Info(args ...interface{}) {
+	if FieldsLogger.level() >= InfoLevel {
+		f.withFields(f, skip_5).info(args...)
+	}
+}
+
+func (f Fields) Print(args ...interface{}) {
+	if FieldsLogger.level() >= InfoLevel {
+		f.withFields(f, skip_5).info(args...)
+	}
+}
+
+func (f Fields) Warn(args ...interface{}) {
+	if FieldsLogger.level() >= WarnLevel {
+		f.withFields(f, skip_5).warn(args...)
+	}
+}
+
+func (f Fields) Warning(args ...interface{}) {
+	if FieldsLogger.level() >= WarnLevel {
+		f.withFields(f, skip_5).warn(args...)
+	}
+}
+
+func (f Fields) Error(args ...interface{}) {
+	if FieldsLogger.level() >= ErrorLevel {
+		f.withFields(f, skip_5).error(args...)
+	}
+}
+
+func (f Fields) Fatal(args ...interface{}) {
+	if FieldsLogger.level() >= FatalLevel {
+		f.withFields(f, skip_5).fatal(args...)
+	}
+}
+
+func (f Fields) Panic(args ...interface{}) {
+	if FieldsLogger.level() >= PanicLevel {
+		f.withFields(f, skip_5).panic(args...)
+	}
+}
+
+func (f Fields) Debugln(args ...interface{}) {
+	if FieldsLogger.level() >= DebugLevel {
+		f.withFields(f, skip_6).debugln(args...)
+	}
+}
+
+func (f Fields) Infoln(args ...interface{}) {
+	if FieldsLogger.level() >= InfoLevel {
+		f.withFields(f, skip_6).infoln(args...)
+	}
+}
+
+func (f Fields) Println(args ...interface{}) {
+	if FieldsLogger.level() >= InfoLevel {
+		f.withFields(f, skip_7).println(args...)
+	}
+}
+
+func (f Fields) Warnln(args ...interface{}) {
+	if FieldsLogger.level() >= WarnLevel {
+		f.withFields(f, skip_6).warnln(args...)
+	}
+}
+
+func (f Fields) Warningln(args ...interface{}) {
+	if FieldsLogger.level() >= WarnLevel {
+		f.withFields(f, skip_6).warnln(args...)
+	}
+}
+
+func (f Fields) Errorln(args ...interface{}) {
+	if FieldsLogger.level() >= ErrorLevel {
+		f.withFields(f, skip_6).errorln(args...)
+	}
+}
+
+func (f Fields) Fatalln(args ...interface{}) {
+	if FieldsLogger.level() >= FatalLevel {
+		f.withFields(f, skip_6).fatalln(args...)
+	}
+}
+
+func (f Fields) Panicln(args ...interface{}) {
+	if FieldsLogger.level() >= PanicLevel {
+		f.withFields(f, skip_6).panicln(args...)
+	}
+}
+
+// The entry object should not be added to the log level to judge.
+// Should be in the top function call to determine, then the best performance.
+func (entry *Entry) print(args ...interface{}) {
+	entry.info(args...)
+}
+
+func (entry *Entry) debug(args ...interface{}) {
+	entry.log(DebugLevel, fmt.Sprint(args...))
+}
+
+func (entry *Entry) info(args ...interface{}) {
+	entry.log(InfoLevel, fmt.Sprint(args...))
+}
+
+func (entry *Entry) warn(args ...interface{}) {
+	entry.log(WarnLevel, fmt.Sprint(args...))
+}
+
+func (entry *Entry) error(args ...interface{}) {
+	entry.log(ErrorLevel, fmt.Sprint(args...))
+}
+
+func (entry *Entry) fatal(args ...interface{}) {
+	entry.log(FatalLevel, fmt.Sprint(args...))
+}
+
+func (entry *Entry) panic(args ...interface{}) {
+	entry.log(PanicLevel, fmt.Sprint(args...))
+}
+
+// Entry Printf family functions
+func (entry *Entry) debugf(format string, args ...interface{}) {
+	entry.debug(fmt.Sprintf(format, args...))
+}
+
+func (entry *Entry) infof(format string, args ...interface{}) {
+	entry.info(fmt.Sprintf(format, args...))
+}
+
+func (entry *Entry) warnf(format string, args ...interface{}) {
+	entry.warn(fmt.Sprintf(format, args...))
+}
+
+func (entry *Entry) errorf(format string, args ...interface{}) {
+	entry.error(fmt.Sprintf(format, args...))
+}
+
+func (entry *Entry) fatalf(format string, args ...interface{}) {
+	entry.fatal(fmt.Sprintf(format, args...))
+}
+
+func (entry *Entry) panicf(format string, args ...interface{}) {
+	entry.panic(fmt.Sprintf(format, args...))
+
+}
+
+// Entry Println family functions
+
+func (entry *Entry) debugln(args ...interface{}) {
+	entry.debug(entry.sprintlnn(args...))
+}
+
+func (entry *Entry) infoln(args ...interface{}) {
+	entry.info(entry.sprintlnn(args...))
+}
+
+func (entry *Entry) warnln(args ...interface{}) {
+	entry.warn(entry.sprintlnn(args...))
+
+}
+
+func (entry *Entry) errorln(args ...interface{}) {
+	entry.error(entry.sprintlnn(args...))
+}
+
+func (entry *Entry) fatalln(args ...interface{}) {
+	entry.fatal(entry.sprintlnn(args...))
+}
+
+func (entry *Entry) panicln(args ...interface{}) {
+	entry.panic(entry.sprintlnn(args...))
+}
+
+func (entry *Entry) println(args ...interface{}) {
+	entry.infoln(args...)
+}
+
+func (entry *Entry) printf(format string, args ...interface{}) {
+	entry.infof(format, args...)
+}

--- a/fields.go
+++ b/fields.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	FieldsLogger *Logger
+	FieldsLogger = std
 )
 
 const (
@@ -20,10 +20,10 @@ func (logger *Logger) SetFieldsLogger() {
 	FieldsLogger = logger
 }
 
-func SetFieldsLogger() {
-	std.mu.Lock()
-	defer std.mu.Unlock()
-	FieldsLogger = std
+func SetFieldsLogger(loger *Logger) {
+	loger.mu.Lock()
+	defer loger.mu.Unlock()
+	FieldsLogger = loger
 }
 
 // exported, for logrus to pretty printing for Go values

--- a/hooks/stack/README.md
+++ b/hooks/stack/README.md
@@ -6,38 +6,38 @@
 package main
 
 import (
-    "github.com/sirupsen/logrus"
-    "github.com/sirupsen/logrus/hooks/stack"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/stack"
 )
 
 var log = logrus.New()
 
 func init() {
-    log.Formatter = new(logrus.TextFormatter) // default
-    log.Hooks.Add(&stack.CodeLineHook{LogLevel: logrus.DebugLevel})
+	log.Formatter = new(logrus.TextFormatter) // default
+	log.Hooks.Add(&stack.CodeLineHook{LogLevel: logrus.DebugLevel})
 }
 
 func main() {
-    log.WithFields(logrus.Fields{
-        "animal": "walrus",
-        "size":   10,
-    }).Info("A group of walrus emerges from the ocean")
-    
-    log.WithFields(logrus.Fields{
-        "omg":    true,
-        "number": 122,
-    }).Warn("The group's number increased tremendously!")
-    
-    // If you set FieldsLogger, you can print the log directly to the object Fields
-    log.SetFieldsLogger()
-    logrus.Fields{
-        "animal": "walrus",
-        "size":   10,
-    }.Info("A group of walrus emerges from the ocean")
-    
-    log.WithFields(logrus.Fields{
-        "omg":    true,
-        "number": 100,
-    }).Fatal("The ice breaks!")
+	log.WithFields(logrus.Fields{
+		"animal": "walrus",
+		"size":   10,
+	}).Info("A group of walrus emerges from the ocean")
+
+	log.WithFields(logrus.Fields{
+		"omg":    true,
+		"number": 122,
+	}).Warn("The group's number increased tremendously!")
+
+	// If you set FieldsLogger, you can print the log directly to the object Fields
+	logrus.SetFieldsLogger(log)
+	logrus.Fields{
+		"animal": "walrus",
+		"size":   10,
+	}.Info("A group of walrus emerges from the ocean")
+
+	log.WithFields(logrus.Fields{
+		"omg":    true,
+		"number": 100,
+	}).Fatal("The ice breaks!")
 }
 ```

--- a/hooks/stack/README.md
+++ b/hooks/stack/README.md
@@ -6,31 +6,38 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/stack"
+    "github.com/sirupsen/logrus"
+    "github.com/sirupsen/logrus/hooks/stack"
 )
 
 var log = logrus.New()
 
 func init() {
-	log.Formatter = new(logrus.TextFormatter) // default
-	log.Hooks.Add(&stack.CodeLineHook{LogLevel: logrus.DebugLevel})
+    log.Formatter = new(logrus.TextFormatter) // default
+    log.Hooks.Add(&stack.CodeLineHook{LogLevel: logrus.DebugLevel})
 }
 
 func main() {
-	log.WithFields(logrus.Fields{
-		"animal": "walrus",
-		"size":   10,
-	}).Info("A group of walrus emerges from the ocean")
-	
-	log.WithFields(logrus.Fields{
-		"omg":    true,
-		"number": 122,
-	}).Warn("The group's number increased tremendously!")
-	
-	log.WithFields(logrus.Fields{
-		"omg":    true,
-		"number": 100,
-	}).Fatal("The ice breaks!")
+    log.WithFields(logrus.Fields{
+        "animal": "walrus",
+        "size":   10,
+    }).Info("A group of walrus emerges from the ocean")
+    
+    log.WithFields(logrus.Fields{
+        "omg":    true,
+        "number": 122,
+    }).Warn("The group's number increased tremendously!")
+    
+    // If you set FieldsLogger, you can print the log directly to the object Fields
+    log.SetFieldsLogger()
+    logrus.Fields{
+        "animal": "walrus",
+        "size":   10,
+    }.Info("A group of walrus emerges from the ocean")
+    
+    log.WithFields(logrus.Fields{
+        "omg":    true,
+        "number": 100,
+    }).Fatal("The ice breaks!")
 }
 ```

--- a/hooks/stack/README.md
+++ b/hooks/stack/README.md
@@ -1,0 +1,36 @@
+# CodeLine Hooks for Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
+
+## Usage
+
+```go
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/stack"
+)
+
+var log = logrus.New()
+
+func init() {
+	log.Formatter = new(logrus.TextFormatter) // default
+	log.Hooks.Add(&stack.CodeLineHook{LogLevel: logrus.DebugLevel})
+}
+
+func main() {
+	log.WithFields(logrus.Fields{
+		"animal": "walrus",
+		"size":   10,
+	}).Info("A group of walrus emerges from the ocean")
+	
+	log.WithFields(logrus.Fields{
+		"omg":    true,
+		"number": 122,
+	}).Warn("The group's number increased tremendously!")
+	
+	log.WithFields(logrus.Fields{
+		"omg":    true,
+		"number": 100,
+	}).Fatal("The ice breaks!")
+}
+```

--- a/hooks/stack/code_line_loc.go
+++ b/hooks/stack/code_line_loc.go
@@ -1,0 +1,77 @@
+package stack
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	vendor = "/vendor/"
+)
+
+var (
+	goPath     = fmt.Sprintf("%s/src/", os.Getenv("GOPATH"))
+	goPath_len = len(goPath)
+)
+
+// To hook (that is, switch mode) to support the print source code line of information,
+// such as which one package, which file, which function, which line
+type CodeLineHook struct {
+	LogLevel logrus.Level
+}
+
+type filePos struct {
+	Pkg  string `json:"pkg"`
+	File string `json:"file"`
+	Func string `json:"func"`
+	Line int    `json:"line"`
+}
+
+func (hook *CodeLineHook) Fire(entry *logrus.Entry) (_ error) {
+	if pc, fullPath, line, ok := runtime.Caller(entry.Skip); ok {
+		funcName := runtime.FuncForPC(pc).Name()
+		relativePath := fullPath
+		if temp := vendorPath(fullPath); temp != "" {
+			relativePath = temp
+		}
+
+		pkg, file := path.Split(relativePath)
+		if pkg != "" {
+			pkg = pkg[:len(pkg)-1]
+		}
+		entry.Data["pos"] = filePos{
+			Pkg:  pkg,
+			File: file,
+			Func: path.Base(funcName),
+			Line: line,
+		}
+	}
+	return
+}
+
+func (hook *CodeLineHook) Levels() []logrus.Level {
+	levels := make([]logrus.Level, hook.LogLevel+1)
+	for i, _ := range levels {
+		levels[i] = logrus.Level(i)
+	}
+	return levels
+}
+
+func vendorPath(fullPath string) string {
+	if i := strings.Index(fullPath, vendor); i != -1 {
+		return fullPath[i+len(vendor):]
+	}
+	return trimGoPath(fullPath)
+}
+
+func trimGoPath(fullPath string) string {
+	if i := strings.Index(fullPath, goPath); i != -1 {
+		return fullPath[i+goPath_len:]
+	}
+	return ""
+}

--- a/hooks/stack/code_line_loc_test.go
+++ b/hooks/stack/code_line_loc_test.go
@@ -1,0 +1,22 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestLocalhostAddAndPrint(t *testing.T) {
+	log := logrus.New()
+
+	hook := CodeLineHook{LogLevel: logrus.DebugLevel}
+	log.Hooks.Add(&hook)
+
+	for _, level := range hook.Levels() {
+		if len(log.Hooks[level]) != 1 {
+			t.Errorf("CodeLineHook was not added. The length of log.Hooks[%v]: %v", level, len(log.Hooks[level]))
+		}
+	}
+
+	log.Info("Congratulations!")
+}

--- a/logger.go
+++ b/logger.go
@@ -84,6 +84,7 @@ func (logger *Logger) newEntry() *Entry {
 }
 
 func (logger *Logger) releaseEntry(entry *Entry) {
+	entry.Skip = 0
 	logger.entryPool.Put(entry)
 }
 
@@ -114,189 +115,192 @@ func (logger *Logger) WithError(err error) *Entry {
 
 func (logger *Logger) Debugf(format string, args ...interface{}) {
 	if logger.level() >= DebugLevel {
-		entry := logger.newEntry()
-		entry.Debugf(format, args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.debugf(format, args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Infof(format string, args ...interface{}) {
 	if logger.level() >= InfoLevel {
-		entry := logger.newEntry()
-		entry.Infof(format, args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.infof(format, args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Printf(format string, args ...interface{}) {
-	entry := logger.newEntry()
-	entry.Printf(format, args...)
-	logger.releaseEntry(entry)
+	if logger.level() >= InfoLevel {
+		entry := logger.newEntry().WithSkip(skip_7)
+		entry.printf(format, args...)
+		logger.releaseEntry(entry)
+	}
 }
 
 func (logger *Logger) Warnf(format string, args ...interface{}) {
 	if logger.level() >= WarnLevel {
-		entry := logger.newEntry()
-		entry.Warnf(format, args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.warnf(format, args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Warningf(format string, args ...interface{}) {
 	if logger.level() >= WarnLevel {
-		entry := logger.newEntry()
-		entry.Warnf(format, args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.warnf(format, args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Errorf(format string, args ...interface{}) {
 	if logger.level() >= ErrorLevel {
-		entry := logger.newEntry()
-		entry.Errorf(format, args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.errorf(format, args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Fatalf(format string, args ...interface{}) {
 	if logger.level() >= FatalLevel {
-		entry := logger.newEntry()
-		entry.Fatalf(format, args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.fatalf(format, args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
 }
 
 func (logger *Logger) Panicf(format string, args ...interface{}) {
 	if logger.level() >= PanicLevel {
-		entry := logger.newEntry()
-		entry.Panicf(format, args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.panicf(format, args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Debug(args ...interface{}) {
 	if logger.level() >= DebugLevel {
-		entry := logger.newEntry()
-		entry.Debug(args...)
+		entry := logger.newEntry().WithSkip(skip_5)
+		entry.debug(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Info(args ...interface{}) {
 	if logger.level() >= InfoLevel {
-		entry := logger.newEntry()
-		entry.Info(args...)
+		entry := logger.newEntry().WithSkip(skip_5)
+		entry.info(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Print(args ...interface{}) {
-	entry := logger.newEntry()
-	entry.Info(args...)
-	logger.releaseEntry(entry)
+	if logger.level() >= InfoLevel {
+		entry := logger.newEntry().WithSkip(skip_5)
+		entry.info(args...)
+		logger.releaseEntry(entry)
+	}
 }
 
 func (logger *Logger) Warn(args ...interface{}) {
 	if logger.level() >= WarnLevel {
-		entry := logger.newEntry()
-		entry.Warn(args...)
+		entry := logger.newEntry().WithSkip(skip_5)
+		entry.warn(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Warning(args ...interface{}) {
 	if logger.level() >= WarnLevel {
-		entry := logger.newEntry()
-		entry.Warn(args...)
+		entry := logger.newEntry().WithSkip(skip_5)
+		entry.warn(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Error(args ...interface{}) {
 	if logger.level() >= ErrorLevel {
-		entry := logger.newEntry()
-		entry.Error(args...)
+		entry := logger.newEntry().WithSkip(skip_5)
+		entry.error(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Fatal(args ...interface{}) {
 	if logger.level() >= FatalLevel {
-		entry := logger.newEntry()
-		entry.Fatal(args...)
+		entry := logger.newEntry().WithSkip(skip_5)
+		entry.fatal(args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
 }
 
 func (logger *Logger) Panic(args ...interface{}) {
 	if logger.level() >= PanicLevel {
-		entry := logger.newEntry()
-		entry.Panic(args...)
+		entry := logger.newEntry().WithSkip(skip_5)
+		entry.panic(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Debugln(args ...interface{}) {
 	if logger.level() >= DebugLevel {
-		entry := logger.newEntry()
-		entry.Debugln(args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.debugln(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Infoln(args ...interface{}) {
 	if logger.level() >= InfoLevel {
-		entry := logger.newEntry()
-		entry.Infoln(args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.infoln(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Println(args ...interface{}) {
-	entry := logger.newEntry()
-	entry.Println(args...)
-	logger.releaseEntry(entry)
+	if logger.level() >= InfoLevel {
+		entry := logger.newEntry().WithSkip(skip_7)
+		entry.println(args...)
+		logger.releaseEntry(entry)
+	}
 }
 
 func (logger *Logger) Warnln(args ...interface{}) {
 	if logger.level() >= WarnLevel {
-		entry := logger.newEntry()
-		entry.Warnln(args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.warnln(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Warningln(args ...interface{}) {
 	if logger.level() >= WarnLevel {
-		entry := logger.newEntry()
-		entry.Warnln(args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.warnln(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Errorln(args ...interface{}) {
 	if logger.level() >= ErrorLevel {
-		entry := logger.newEntry()
-		entry.Errorln(args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.errorln(args...)
 		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Fatalln(args ...interface{}) {
 	if logger.level() >= FatalLevel {
-		entry := logger.newEntry()
-		entry.Fatalln(args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.fatalln(args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
 }
 
 func (logger *Logger) Panicln(args ...interface{}) {
 	if logger.level() >= PanicLevel {
-		entry := logger.newEntry()
-		entry.Panicln(args...)
+		entry := logger.newEntry().WithSkip(skip_6)
+		entry.panicln(args...)
 		logger.releaseEntry(entry)
 	}
 }

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -41,7 +41,7 @@ func getVersion() (float64, error) {
 	if err != nil {
 		return -1, err
 	}
-	
+
 	// The output should be like "Microsoft Windows [Version XX.X.XXXXXX]"
 	version := strings.Replace(stdout.String(), "\n", "", -1)
 	version = strings.Replace(version, "\r\n", "", -1)


### PR DESCRIPTION
1. Fields object support direct print log information, the default print to the standard output，also can be set; And completely compatible the old way, this field in the field of direct print log application scene is very simple, and a service will generally only define a log object.
```
// If old must use WithFields to print the log
log.WithFields(logrus.Fields{
	"animal": "walrus",
	"size":   10,
}).Info("A group of walrus emerges from the ocean")

// The new print log is simpler; it prints to standard output by default.
logrus.Fields{
	"animal": "walrus",
	"size":   10,
}.Info("A group of walrus emerges from the ocean")

// Of course you can also be associated with the specified log object, 
// for example, where the log is specified
logrus.SetFieldsLogger(log)
logrus.Fields{
	"animal": "walrus",
	"size":   10,
}.Info("A group of walrus emerges from the ocean")
```

2. Add the stack of print source lines to the line; does not affect the old, and fully compatible with the old way; and does not affect the performance, because only when you add the hook CodeLineHook, it will be executed; Examples of specific examples: example / hook / stack.go

3. Improve the potential consumption performance in high concurrent scenes at the entry level, such as:
```
func (entry *Entry) Info(args ...interface{}) {
	if entry.Logger.level() >= InfoLevel {
		entry.WithSkip(skip_4).log(InfoLevel, fmt.Sprint(args...))
	}
}
```
