### PR TITLE
Rename logrus_syslog package to syslog

### DIFF
--- a/hooks/syslog/README.md
+++ b/hooks/syslog/README.md
@@ -6,12 +6,12 @@
 import (
   "log/syslog"
   "github.com/sirupsen/logrus"
-  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
+  lSyslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func main() {
   log       := logrus.New()
-  hook, err := logrus_syslog.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, "")
+  hook, err := lSyslog.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, "")
 
   if err == nil {
     log.Hooks.Add(hook)
@@ -25,12 +25,12 @@ If you want to connect to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "
 import (
   "log/syslog"
   "github.com/sirupsen/logrus"
-  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
+  lSyslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func main() {
   log       := logrus.New()
-  hook, err := logrus_syslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
+  hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
 
   if err == nil {
     log.Hooks.Add(hook)

--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -1,12 +1,13 @@
 // +build !windows,!nacl,!plan9
 
-package logrus_syslog
+package syslog
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"log/syslog"
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
 // SyslogHook to send logs via syslog.

--- a/hooks/syslog/syslog_test.go
+++ b/hooks/syslog/syslog_test.go
@@ -1,9 +1,10 @@
-package logrus_syslog
+package syslog
 
 import (
-	"github.com/sirupsen/logrus"
 	"log/syslog"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestLocalhostAddAndPrint(t *testing.T) {


### PR DESCRIPTION
Package names shouldn't be using underscores.
There is also nothing wrong with naming this package `syslog`. People can include it with any name they wish.

Closes #108