### PR TITLE
IsTerminal should work in nacl too

### DIFF
--- a/terminal_notwindows.go
+++ b/terminal_notwindows.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux darwin freebsd openbsd netbsd dragonfly
+// +build linux darwin freebsd openbsd netbsd dragonfly nacl
 // +build !appengine
 
 package logrus


### PR DESCRIPTION
I'm running logrus on a nacl environment and I get:

```
github.com/sirupsen/logrus/text_formatter.go:70: undefined: IsTerminal
```