### PR TITLE
Ability to change the message formatting of the TextFormatter as well as the ability to turn off empty messages.

### DIFF
--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -28,6 +28,51 @@ func TestFormatting(t *testing.T) {
 	}
 }
 
+func TestColoredStringFormatting(t *testing.T) {
+	tf := &TextFormatter{ForceColors: true}
+
+	testCases := []struct {
+		message  string
+		expected string
+	}{
+		{"hello", "\x1b[31mPANI\x1b[0m[-9223372036] hello                                        \n"},
+		{"", "\x1b[31mPANI\x1b[0m[-9223372036]                                              \n"},
+	}
+
+	for _, tc := range testCases {
+		e := &Entry{Message: tc.message}
+		b, _ := tf.Format(e)
+
+		if string(b) != tc.expected {
+			t.Errorf("formatting expected for %q (result was %q instead of %q)", tc.message, string(b), tc.expected)
+		}
+	}
+}
+
+func TestEmptyStringFormatting(t *testing.T) {
+	tf := &TextFormatter{
+		ForceColors:          true,
+		DisableEmptyMessages: true,
+	}
+
+	testCases := []struct {
+		message  string
+		expected string
+	}{
+		{"hello", "\x1b[31mPANI\x1b[0m[-9223372036] hello                                        \n"},
+		{"", "\x1b[31mPANI\x1b[0m[-9223372036]\n"},
+	}
+
+	for _, tc := range testCases {
+		e := &Entry{Message: tc.message}
+		b, _ := tf.Format(e)
+
+		if string(b) != tc.expected {
+			t.Errorf("formatting expected for %q (result was %q instead of %q)", tc.message, string(b), tc.expected)
+		}
+	}
+}
+
 func TestQuoting(t *testing.T) {
 	tf := &TextFormatter{DisableColors: true}
 


### PR DESCRIPTION
Previous if you were to call the logger with an empty message you would get something like this:

```
INFO                                              db=0s duration="554.299µs" human_size="9.0 kB" method=GET params="{}" path=/ render="227.675µs" request_id=010483c6e8-472c3590e0 size=9016 status=200
```

The big space at the beginning was rather weird and ugly.

This PR adds two things. The first is the ability to format the space where the message goes. Previously it was hard coded to `%-44s`.

The second is the ability to disable printing empty messages.

This PR is completely backward compatible, there is no breaking changes, and people's logs will continue to behave just as they do now.