### PR TITLE
Add Vim swap files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 logrus
+*.swp
+*.swo
+*.swn


### PR DESCRIPTION
Split this out from https://github.com/sirupsen/logrus/pull/612, as it's a separate change.

I noticed this when working on a new computer for which I hadn't yet copied my standard `.gitignore_global`. While it's true that Vim swap files, OS X `.DS_Store` files, and the like should be in a global gitignore, in my experience, if these aren't also in the per-project gitignore, it's easy for them to make their way into the project by accident.