### PR TITLE
New systemd's Journal hook supports log messages of any size type, st…

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Honeybadger](https://github.com/agonzalezro/logrus_honeybadger) | Hook for sending exceptions to Honeybadger |
 | [InfluxDB](https://github.com/Abramovic/logrus_influxdb) | Hook for logging to influxdb |
 | [Influxus](http://github.com/vlad-doru/influxus) | Hook for concurrently logging to [InfluxDB](http://influxdata.com/) |
-| [Journalhook](https://github.com/wercker/journalhook) | Hook for logging to `systemd-journald` |
+| [Journalhook](https://github.com/ssgreg/journalhook) | Hook for logging to `systemd-journald` |
 | [KafkaLogrus](https://github.com/tracer0tong/kafkalogrus) | Hook for logging to Kafka |
 | [LFShook](https://github.com/rifflock/lfshook) | Hook for logging to the local filesystem |
 | [Logentries](https://github.com/jcftang/logentriesrus) | Hook for logging to [Logentries](https://logentries.com/) |


### PR DESCRIPTION
The new systemd's Journal hook:

- supports log messages of any size and type

- supports string and binary arrays as is (natively for systemd)

- allows to close journal (registers exit handler) in order not to lose log entries

- real systemd-journald tests