### PR TITLE
Add Reference to SEQ Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Typetalk](https://github.com/dragon3/logrus-typetalk-hook) | Hook for logging to [Typetalk](https://www.typetalk.in/) |
 | [logz.io](https://github.com/ripcurld00d/logrus-logzio-hook) | Hook for logging to [logz.io](https://logz.io), a Log as a Service using Logstash |
 | [SQS-Hook](https://github.com/tsarpaul/logrus_sqs) | Hook for logging to [Amazon Simple Queue Service (SQS)](https://aws.amazon.com/sqs/) |
+| [SEQ-Hook](https://github.com/mundipagg/logrus_seq_hook) | Hook for logging to [SEQ](https://getseq.net/) |
 
 #### Level logging
 


### PR DESCRIPTION
Hi,

I've created a Logrus' SEQ (https://getseq.net/) Hook and created a row on the README hook's list.

