### PR TITLE
Correct "end of line" symbol for Windows OS

### DIFF
--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -5,6 +5,10 @@ import (
 	"os"
 )
 
+func init() {
+	logrus.EndOfLine = "\n"
+}
+
 func Example_basic() {
 	var log = logrus.New()
 	log.Formatter = new(logrus.JSONFormatter)

--- a/formatter.go
+++ b/formatter.go
@@ -1,8 +1,13 @@
 package logrus
 
-import "time"
+import (
+	"runtime"
+	"time"
+)
 
 const defaultTimestampFormat = time.RFC3339
+
+var EndOfLine string
 
 // The Formatter interface is used to implement a custom Formatter. It takes an
 // `Entry`. It exposes all the fields, including the default ones:
@@ -16,6 +21,14 @@ const defaultTimestampFormat = time.RFC3339
 // logged to `logger.Out`.
 type Formatter interface {
 	Format(*Entry) ([]byte, error)
+}
+
+func init() {
+	if runtime.GOOS == "windows" {
+		EndOfLine = "\r\n"
+	} else {
+		EndOfLine = "\n"
+	}
 }
 
 // This is to not silently overwrite `time`, `msg` and `level` fields when

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -75,5 +75,5 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
 	}
-	return append(serialized, '\n'), nil
+	return append(serialized, EndOfLine...), nil
 }

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -120,7 +120,12 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		}
 	}
 
-	b.WriteByte('\n')
+	if len(EndOfLine) == 1 {
+		b.WriteByte(EndOfLine[0])
+	} else {
+		b.WriteString(EndOfLine)
+	}
+
 	return b.Bytes(), nil
 }
 

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -16,7 +16,7 @@ func TestFormatting(t *testing.T) {
 		value    string
 		expected string
 	}{
-		{`foo`, "time=\"0001-01-01T00:00:00Z\" level=panic test=foo\n"},
+		{`foo`, "time=\"0001-01-01T00:00:00Z\" level=panic test=foo" + EndOfLine},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
- closes #637 