### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
-  - tip
+  - 1.9.x
+  - master
+go_import_path: github.com/sirupsen/logrus
 env:
   - GOMAXPROCS=4 GORACE=halt_on_error=1
 install:


### PR DESCRIPTION
* Test with Go 1.9.
* `go_import_path` allows forks to use Travis CI too.