### PR TITLE
Adding a flag to TextFormatter to omit level=L

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -42,6 +42,9 @@ type TextFormatter struct {
 	// system that already adds timestamps.
 	DisableTimestamp bool
 
+	// Disable log level logging.
+	DisableLogLevel bool
+
 	// Enable logging the full timestamp when a TTY is attached instead of just
 	// the time passed since beginning of execution.
 	FullTimestamp bool
@@ -111,7 +114,9 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		if !f.DisableTimestamp {
 			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
 		}
-		f.appendKeyValue(b, "level", entry.Level.String())
+		if !f.DisableLogLevel {
+			f.appendKeyValue(b, "level", entry.Level.String())
+		}
 		if entry.Message != "" {
 			f.appendKeyValue(b, "msg", entry.Message)
 		}

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -137,5 +137,24 @@ func TestDisableTimestampWithColoredOutput(t *testing.T) {
 	}
 }
 
+func TestDisableLogLevelWithoutColoredOutput(t *testing.T) {
+	tf := &TextFormatter{DisableColors: true, DisableLogLevel: true}
+
+	testCases := []struct {
+		value    string
+		expected string
+	}{
+		{`foo`, "time=\"0001-01-01T00:00:00Z\" test=foo\n"},
+	}
+
+	for _, tc := range testCases {
+		b, _ := tf.Format(WithField("test", tc.value))
+
+		if string(b) != tc.expected {
+			t.Errorf("formatting expected for %q (result was %q instead of %q)", tc.value, string(b), tc.expected)
+		}
+	}
+}
+
 // TODO add tests for sorting etc., this requires a parser for the text
 // formatter output.


### PR DESCRIPTION
In certain cases, consumers may not want to display the log level.
They should have the option to omit it.