### PR TITLE
Added the ability to specify if you'd like json logs to be pretty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/sirupsen/logrus.svg?branch=master)](https://travis-ci.org/sirupsen/logrus)&nbsp;[![GoDoc](https://godoc.org/github.com/sirupsen/logrus?status.svg)](https://godoc.org/github.com/sirupsen/logrus)
 
-**this is an exact clone of the Logrus repo [here](https://github.com/sirupsen/logrus), the only change that has been made is json formatter takes in a setting to pretty print json logs for easier debugging**
-
 Logrus is a structured logger for Go (golang), completely API compatible with
 the standard library logger.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/sirupsen/logrus.svg?branch=master)](https://travis-ci.org/sirupsen/logrus)&nbsp;[![GoDoc](https://godoc.org/github.com/sirupsen/logrus?status.svg)](https://godoc.org/github.com/sirupsen/logrus)
 
+**this is an exact clone of the Logrus repo [here](https://github.com/sirupsen/logrus), the only change that has been made is json formatter takes in a setting to pretty print json logs for easier debugging**
+
 Logrus is a structured logger for Go (golang), completely API compatible with
 the standard library logger.
 

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -43,6 +43,9 @@ type JSONFormatter struct {
 	//    },
 	// }
 	FieldMap FieldMap
+
+	// PrettyPrint will indent all json logs
+	PrettyPrint bool
 }
 
 // Format renders a single log entry
@@ -71,7 +74,15 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
 	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
 
-	serialized, err := json.Marshal(data)
+	var serialized []byte
+	var err error
+
+	if f.PrettyPrint {
+		serialized, err = json.MarshalIndent(data, "", "\t")
+	} else {
+		serialized, err = json.Marshal(data)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
 	}


### PR DESCRIPTION
json logs are nice but I have a difficult time reading them when they're unformatted. Added an optional field into the json formatter that will pretty print your json indented by tabs, useful when running applications locally and debugging. 