### PR TITLE
add option to split streams on severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ func init() {
   // Can be any io.Writer, see below for File example
   log.SetOutput(os.Stdout)
 
+  // Output log messages with error severity or above to a separate io.Writer
+  // Can be any io.Writer
+  log.SetErrOutput(os.Stderr)
+
   // Only log the warning severity or above.
   log.SetLevel(log.WarnLevel)
 }

--- a/entry.go
+++ b/entry.go
@@ -114,7 +114,11 @@ func (entry Entry) log(level Level, msg string) {
 		entry.Logger.mu.Unlock()
 	} else {
 		entry.Logger.mu.Lock()
-		_, err = entry.Logger.Out.Write(serialized)
+		if entry.Logger.ErrOut != nil && entry.Level <= ErrorLevel {
+			_, err = entry.Logger.ErrOut.Write(serialized)
+		} else {
+			_, err = entry.Logger.Out.Write(serialized)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)
 		}

--- a/exported.go
+++ b/exported.go
@@ -20,6 +20,14 @@ func SetOutput(out io.Writer) {
 	std.Out = out
 }
 
+// SetErrOutput sets an optional, dedidated io.Writer for log messages with
+// error severity or above
+func SetErrOutput(errOut io.Writer) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	std.ErrOut = errOut
+}
+
 // SetFormatter sets the standard logger formatter.
 func SetFormatter(formatter Formatter) {
 	std.mu.Lock()

--- a/formatter.go
+++ b/formatter.go
@@ -13,7 +13,8 @@ const defaultTimestampFormat = time.RFC3339
 //
 // Any additional fields added with `WithField` or `WithFields` are also in
 // `entry.Data`. Format is expected to return an array of bytes which are then
-// logged to `logger.Out`.
+// logged to `logger.Out` (or `logger.ErrOut`, if configured and warranted by
+// the severity).
 type Formatter interface {
 	Format(*Entry) ([]byte, error)
 }

--- a/logger.go
+++ b/logger.go
@@ -12,16 +12,19 @@ type Logger struct {
 	// file, or leave it default which is `os.Stderr`. You can also set this to
 	// something more adventorous, such as logging to Kafka.
 	Out io.Writer
+	// An optional, separate io.Writer for log messages with error severity or
+	// above
+	ErrOut io.Writer
 	// Hooks for the logger instance. These allow firing events based on logging
 	// levels and log entries. For example, to send errors to an error tracking
 	// service, log to StatsD or dump the core on fatal errors.
 	Hooks LevelHooks
-	// All log entries pass through the formatter before logged to Out. The
-	// included formatters are `TextFormatter` and `JSONFormatter` for which
-	// TextFormatter is the default. In development (when a TTY is attached) it
-	// logs with colors, but to a file it wouldn't. You can easily implement your
-	// own that implements the `Formatter` interface, see the `README` or included
-	// formatters for examples.
+	// All log entries pass through the formatter before being logged to Out or
+	// ErrOut. The included formatters are `TextFormatter` and `JSONFormatter` for
+	// which TextFormatter is the default. In development (when a TTY is attached)
+	// it logs with colors, but to a file it wouldn't. You can easily implement
+	// your own that implements the `Formatter` interface, see the `README` or
+	// included formatters for examples.
 	Formatter Formatter
 	// The logging level the logger should log at. This is typically (and defaults
 	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
@@ -55,8 +58,8 @@ func (mw *MutexWrap) Disable() {
 }
 
 // Creates a new logger. Configuration should be set by changing `Formatter`,
-// `Out` and `Hooks` directly on the default logger instance. You can also just
-// instantiate your own:
+// `Out`, `ErrOut`, and `Hooks` directly on the default logger instance. You can
+// also just instantiate your own:
 //
 //    var log = &Logger{
 //      Out: os.Stderr,


### PR DESCRIPTION
Fixes #403 

#403 was closed with the following rationale:

> Yeah, we won't support this directly in core since the use-case is too narrow. A custom hook or formatter is recommended.

Since that that time, I've humbly proposed that the use case may not be so narrow. ([See comment](https://github.com/sirupsen/logrus/issues/403#issuecomment-332970055).)

> @sirupsen any chance you could consider re-opening this? I think there are log forwarders or aggregators that will assume messages received on stderr are indeed errors and therefore augment the message with text like ERR (for instance).
>
> A co-worker recently ran into this with Cloud Foundry:
>
> ```
> 2017-09-08T06:38:28.86+0000 [APP/PROC/WEB/0] ERR time="2017-09-08T06:38:28Z" level=info msg="setting log level" logLevel=DEBUG
> 2017-09-08T06:38:28.86+0000 [APP/PROC/WEB/0] ERR time="2017-09-08T06:38:28Z" level=info msg="API server is listening" address="http://0.0.0.0:8080"
> ```
>
> Given the prevalence of various container orchestrators and PaaSes and the wide array of log forwarders and aggregators they use (fluentd and logspout come to mind), this issue is likely to affect more and more people.

Since we need this functionality to continue using logrus, I decided to see what I could do with a hook, as had been suggested. I found, quickly, that using a hook wasn't the best idea from a performance standpoint. While I'd be relying on the hook to actually output formatted messaged to `os.Stdout` or `os.Stderr`, I'd have to set the logger's `Out` field to something like `ioutil.Discard` to avoid getting duplicate messages-- and that's totally fine, except for the fact that the overhead of formatting the message is then incurred twice over, only to discard it in one of those two cases. This didn't seem optimal.

Given the upvotes on my proposal that this may not be a narrow use case, I decided to look into how easy it might be to add support for this behavior directly into logrus. It wasn't hard as it turns out, and this PR is the result of that effort.

Please note that, quite importantly, this change preserves original behavior and merely enables the _option_ to split log messages across two different `io.Writer`s, depending on log message severity.