### PR TITLE
Allow disabling new line appending for json_formatter

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -33,6 +33,9 @@ type JSONFormatter struct {
 	// DisableTimestamp allows disabling automatic timestamps in output
 	DisableTimestamp bool
 
+	// DisableNewline allows disabling of the trailing newline in output
+	DisableNewline bool
+
 	// FieldMap allows users to customize the names of keys for default fields.
 	// As an example:
 	// formatter := &JSONFormatter{
@@ -74,6 +77,10 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	serialized, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+
+	if f.DisableNewline {
+		return serialized, nil
 	}
 	return append(serialized, '\n'), nil
 }

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -197,3 +197,35 @@ func TestJSONEnableTimestamp(t *testing.T) {
 		t.Error("Timestamp not present", s)
 	}
 }
+
+func TestJSONMsgEnableNewline(t *testing.T) {
+	formatter := &JSONFormatter{
+		DisableNewline: false,
+	}
+
+	b, err := formatter.Format(&Entry{Message: "oh hai"})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	c := b[len(b)-1]
+	if c != byte('\n') {
+		t.Fatal("Expected formatted entry to include a trailing newline")
+	}
+}
+
+func TestJSONMsgDisableNewline(t *testing.T) {
+	formatter := &JSONFormatter{
+		DisableNewline: true,
+	}
+
+	b, err := formatter.Format(&Entry{Message: "oh hai"})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	c := b[len(b)-1]
+	if c == byte('\n') {
+		t.Fatal("Expected formatted entry to not include a trailing newline")
+	}
+}


### PR DESCRIPTION
- closes https://github.com/sirupsen/logrus/issues/949

This PR allows disabling of the trailing new line with json_formatter. It retains the default behavior and adds a param to the struct to allow disabling.