### PR TITLE
Fix unit test failure when tests are run in vendor folder

### DIFF
--- a/alt_exit_test.go
+++ b/alt_exit_test.go
@@ -19,7 +19,7 @@ func TestRegister(t *testing.T) {
 }
 
 func TestHandler(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test_handler")
+	tempDir, err := ioutil.TempDir(".", "test_handler")
 	if err != nil {
 		log.Fatalf("can't create temp dir. %q", err)
 	}


### PR DESCRIPTION
If I vendor logrus under my project (ex. `~/go/src/me/myproject/vendor/github.com/sirupsen/logrus`), then try to run the tests from that folder, I get the following failure:
```
--- FAIL: TestHandler (0.07s)
	alt_exit_test.go:42: can't read output file /var/folders/hx/qdf8j9zn01n67_9642pnc5040000gn/T/test_handler931653449/outfile.out. "open /var/folders/hx/qdf8j9zn01n67_9642pnc5040000gn/T/test_handler931653449/outfile.out: no such file or directory"
```

The root cause is:
```
/var/folders/hx/qdf8j9zn01n67_9642pnc5040000gn/T/test_handler773425229/gofile.go:7:2: cannot find package "github.com/sirupsen/logrus" in any of:
	/usr/local/go/src/github.com/sirupsen/logrus (from $GOROOT)
	/Users/nisaac/go/src/github.com/sirupsen/logrus (from $GOPATH)
```

By generating the go source file using logrus in a subdirectory of logrus, go can find it.