### PR TITLE
Add FieldMap support to TestFormatter

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -60,6 +60,15 @@ type TextFormatter struct {
 	// Whether the logger's out is to a terminal
 	isTerminal bool
 
+	// FieldMap allows users to customize the names of keys for default fields.
+	// As an example:
+	// formatter := &JSONFormatter{
+	//     FieldMap: FieldMap{
+	//         FieldKeyTime: "@timestamp",
+	//         FieldKeyLevel: "@level",
+	//         FieldKeyMsg: "@message"}}
+	FieldMap FieldMap
+
 	sync.Once
 }
 
@@ -109,11 +118,11 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		f.printColored(b, entry, keys, timestampFormat)
 	} else {
 		if !f.DisableTimestamp {
-			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+			f.appendKeyValue(b, f.FieldMap.resolve(FieldKeyTime), entry.Time.Format(timestampFormat))
 		}
-		f.appendKeyValue(b, "level", entry.Level.String())
+		f.appendKeyValue(b, f.FieldMap.resolve(FieldKeyLevel), entry.Level.String())
 		if entry.Message != "" {
-			f.appendKeyValue(b, "msg", entry.Message)
+			f.appendKeyValue(b, f.FieldMap.resolve(FieldKeyMsg), entry.Message)
 		}
 		for _, key := range keys {
 			f.appendKeyValue(b, key, entry.Data[key])

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatting(t *testing.T) {
@@ -135,6 +137,33 @@ func TestDisableTimestampWithColoredOutput(t *testing.T) {
 	if strings.Contains(string(b), "[0000]") {
 		t.Error("timestamp not expected when DisableTimestamp is true")
 	}
+}
+
+func TestTextFormatterFieldMap(t *testing.T) {
+	formatter := &TextFormatter{
+		DisableColors: true,
+		FieldMap: FieldMap{
+			FieldKeyMsg:   "message",
+			FieldKeyLevel: "somelevel",
+			FieldKeyTime:  "timeywimey",
+		},
+	}
+
+	entry := &Entry{
+		Message: "oh hi",
+		Level:   WarnLevel,
+		Time:    time.Date(1981, time.February, 24, 4, 28, 3, 100, time.UTC),
+	}
+
+	b, err := formatter.Format(entry)
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	assert.Equal(t,
+		`timeywimey="1981-02-24T04:28:03Z" somelevel=warning message="oh hi"`+"\n",
+		string(b),
+		"Formatted doesn't respect correct FieldMap")
 }
 
 // TODO add tests for sorting etc., this requires a parser for the text


### PR DESCRIPTION
Use the same FieldMap class used by JSONFormatter for TextFormatter.