### PR TITLE
add SNS Hook: Hook for logging to [Amazon Simple Notification Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Typetalk](https://github.com/dragon3/logrus-typetalk-hook) | Hook for logging to [Typetalk](https://www.typetalk.in/) |
 | [logz.io](https://github.com/ripcurld00d/logrus-logzio-hook) | Hook for logging to [logz.io](https://logz.io), a Log as a Service using Logstash |
 | [SQS-Hook](https://github.com/tsarpaul/logrus_sqs) | Hook for logging to [Amazon Simple Queue Service (SQS)](https://aws.amazon.com/sqs/) |
+| [SNS-Hook](https://github.com/stvvan/logrus-sns) | Hook for logging to [Amazon Simple Notification Service (SNS)](https://aws.amazon.com/sns/) |
 
 #### Level logging
 


### PR DESCRIPTION
Hi,

I found no existing plugin for logrus to publish message to AWS SNS, which is helpful for certain system alerts. Hence I wrote one.

please help to merge.
thanks
steve