### PR TITLE
TextFormatter behaviour aligned with stdlib log (fixes #167)

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -126,6 +126,10 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 
 	levelText := strings.ToUpper(entry.Level.String())[0:4]
 
+	// Remove a single newline if it already exists in the message to keep
+	// the behavior of logrus text_formatter the same as the stdlib log package
+	entry.Message = strings.TrimSuffix(entry.Message, "\n")
+
 	if f.DisableTimestamp {
 		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %-44s ", levelColor, levelText, entry.Message)
 	} else if !f.FullTimestamp {

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -137,5 +137,28 @@ func TestDisableTimestampWithColoredOutput(t *testing.T) {
 	}
 }
 
+func TestNewlineBehavior(t *testing.T) {
+	tf := &TextFormatter{ForceColors: true}
+
+	// Ensure a single new line is removed as per stdlib log
+	e := NewEntry(StandardLogger())
+	e.Message = "test message\n"
+	b, _ := tf.Format(e)
+	if bytes.Contains(b, []byte("test message\n")) {
+		t.Error("first newline at end of Entry.Message resulted in unexpected 2 newlines in output. Expected newline to be removed.")
+	}
+
+	// Ensure a double new line is reduced to a single new line
+	e = NewEntry(StandardLogger())
+	e.Message = "test message\n\n"
+	b, _ = tf.Format(e)
+	if bytes.Contains(b, []byte("test message\n\n")) {
+		t.Error("Double newline at end of Entry.Message resulted in unexpected 2 newlines in output. Expected single newline")
+	}
+	if !bytes.Contains(b, []byte("test message\n")) {
+		t.Error("Double newline at end of Entry.Message did not result in a single newline after formatting")
+	}
+}
+
 // TODO add tests for sorting etc., this requires a parser for the text
 // formatter output.

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -198,6 +198,7 @@ func TestNewlineBehavior(t *testing.T) {
 	if !bytes.Contains(b, []byte("test message\n")) {
 		t.Error("Double newline at end of Entry.Message did not result in a single newline after formatting")
 	}
+}
 
 func TestTextFormatterFieldMap(t *testing.T) {
 	formatter := &TextFormatter{


### PR DESCRIPTION
Hoping to help logrus with a small fix for a long-lived issues (#167). I've made the newline behavior consistent with the standard library log package. The fix to `TextFormatter` removes a single new-line (if present) at the end of the provided `Entry.Message`. e.g. `"testmessage\n\n"` will become `"testmessage\n"`. This is the same behavior as `log.Printf`

Added a test and confirmed existing tests were passing. The benchmark test shows minor impact (up to 1% increase in ns/op), but happy to discuss more efficient options