### PR TITLE
Allow to print log level as integer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 logrus
+.idea/

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -33,8 +33,8 @@ type JSONFormatter struct {
 	// DisableTimestamp allows disabling automatic timestamps in output
 	DisableTimestamp bool
 
-	// IntLogLevels allows users to print log levels as integers instead of transformed strings
-	IntLogLevels bool
+	// EnableIntLogLevels allows users to print log levels as integers instead of transformed strings
+	EnableIntLogLevels bool
 
 	// FieldMap allows users to customize the names of keys for default fields.
 	// As an example:
@@ -74,7 +74,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
 
 	var logLevel interface{} = entry.Level.String()
-	if f.IntLogLevels {
+	if f.EnableIntLogLevels {
 		logLevel = entry.Level
 	}
 	data[f.FieldMap.resolve(FieldKeyLevel)] = logLevel

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -33,6 +33,9 @@ type JSONFormatter struct {
 	// DisableTimestamp allows disabling automatic timestamps in output
 	DisableTimestamp bool
 
+	// IntLogLevels allows users to print log levels as integers instead of transformed strings
+	IntLogLevels bool
+
 	// FieldMap allows users to customize the names of keys for default fields.
 	// As an example:
 	// formatter := &JSONFormatter{
@@ -69,7 +72,12 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
 	}
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
-	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
+
+	var logLevel interface{} = entry.Level.String()
+	if f.IntLogLevels {
+		logLevel = entry.Level
+	}
+	data[f.FieldMap.resolve(FieldKeyLevel)] = logLevel
 
 	serialized, err := json.Marshal(data)
 	if err != nil {

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -197,3 +197,22 @@ func TestJSONEnableTimestamp(t *testing.T) {
 		t.Error("Timestamp not present", s)
 	}
 }
+
+func TestJSONEnableIntLogLevels(t *testing.T) {
+	formatter := &JSONFormatter{EnableIntLogLevels: true}
+	entry := &Entry{Level: DebugLevel}
+
+	b, err := formatter.Format(entry)
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	entryJSON := make(map[string]interface{})
+	err = json.Unmarshal(b, &entryJSON)
+	if err != nil {
+		t.Fatal("Unable to unmarshal formatted entry: ", err)
+	}
+
+	if entryJSON["level"] != float64(DebugLevel) {
+		t.Fatal("level not set to original level field")
+	}
+}

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -45,8 +45,8 @@ type TextFormatter struct {
 	// TimestampFormat to use for display when a full timestamp is printed
 	TimestampFormat string
 
-	// IntLogLevels allows users to print log levels as integers instead of transformed strings
-	IntLogLevels bool
+	// EnableIntLogLevels allows users to print log levels as integers instead of transformed strings
+	EnableIntLogLevels bool
 
 	// The fields are sorted by default for a consistent output. For applications
 	// that log extremely frequently and don't use the JSON formatter this may not
@@ -102,8 +102,8 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
 		}
 		var logLevel interface{} = entry.Level.String()
-		if f.IntLogLevels {
-			logLevel = entry.Level
+		if f.EnableIntLogLevels {
+			logLevel = int(entry.Level)
 		}
 		f.appendKeyValue(b, "level", logLevel)
 		if entry.Message != "" {

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -45,6 +45,9 @@ type TextFormatter struct {
 	// TimestampFormat to use for display when a full timestamp is printed
 	TimestampFormat string
 
+	// IntLogLevels allows users to print log levels as integers instead of transformed strings
+	IntLogLevels bool
+
 	// The fields are sorted by default for a consistent output. For applications
 	// that log extremely frequently and don't use the JSON formatter this may not
 	// be desired.
@@ -98,7 +101,11 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		if !f.DisableTimestamp {
 			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
 		}
-		f.appendKeyValue(b, "level", entry.Level.String())
+		var logLevel interface{} = entry.Level.String()
+		if f.IntLogLevels {
+			logLevel = entry.Level
+		}
+		f.appendKeyValue(b, "level", logLevel)
 		if entry.Message != "" {
 			f.appendKeyValue(b, "msg", entry.Message)
 		}

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -137,5 +137,17 @@ func TestDisableTimestampWithColoredOutput(t *testing.T) {
 	}
 }
 
+func TestEnableIntLogLevels(t *testing.T) {
+	expected := "time=\"0001-01-01T00:00:00Z\" level=5"
+
+	tf := &TextFormatter{EnableIntLogLevels: true}
+	entry := &Entry{Level: DebugLevel}
+
+	b, _ := tf.Format(entry)
+	if !strings.Contains(string(b), expected) {
+		t.Errorf("expected: '%s' got: '%s'\n", expected, string(b))
+	}
+}
+
 // TODO add tests for sorting etc., this requires a parser for the text
 // formatter output.


### PR DESCRIPTION
### Reason
To be able to have logs compliant with the Syslog Protocol ([RFC5424](http://www.ietf.org/rfc/rfc5424.txt) and [RFC3164](http://www.ietf.org/rfc/rfc3164.txt)), we need to print the log levels as integers.

### Changes
Adds a flag to both Text and JSON Formatters struct that, if set to true, will make the log levels print as integers (the default is the old behaviour, i.e. print the resolved level name).

### Issues
Fixes #355.