### PR TITLE
add success logging level, close #699

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ attached, the output is compatible with the
 ```text
 time="2015-03-26T01:27:38-04:00" level=debug msg="Started observing beach" animal=walrus number=8
 time="2015-03-26T01:27:38-04:00" level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
+time="2015-03-26T01:27:38-04:00" level=success msg="Group emerged" animal=walrus
 time="2015-03-26T01:27:38-04:00" level=warning msg="The group's number increased tremendously!" number=122 omg=true
 time="2015-03-26T01:27:38-04:00" level=debug msg="Temperature changes" temperature=-4
 time="2015-03-26T01:27:38-04:00" level=panic msg="It's over 9000!" animal=orca size=9009
@@ -113,6 +114,10 @@ func main() {
     "animal": "walrus",
     "size":   10,
   }).Info("A group of walrus emerges from the ocean")
+
+  log.WithFields(logrus.Fields{
+    "animal": "walrus",
+  }).Success("Group emerged")
 
   log.WithFields(log.Fields{
     "omg":    true,

--- a/entry.go
+++ b/entry.go
@@ -34,11 +34,11 @@ type Entry struct {
 	// Time at which the log entry was created
 	Time time.Time
 
-	// Level the log entry was logged at: Debug, Info, Warn, Error, Fatal or Panic
+	// Level the log entry was logged at: Debug, Success, Info, Warn, Error, Fatal or Panic
 	// This field will be set on entry firing and the value will be equal to the one in Logger struct field.
 	Level Level
 
-	// Message passed to Debug, Info, Warn, Error, Fatal or Panic
+	// Message passed to Debug, Success, Info, Warn, Error, Fatal or Panic
 	Message string
 
 	// When formatter is called in entry.log(), an Buffer may be set to entry
@@ -146,6 +146,12 @@ func (entry *Entry) Print(args ...interface{}) {
 	entry.Info(args...)
 }
 
+func (entry *Entry) Success(args ...interface{}) {
+	if entry.Logger.level() >= SuccessLevel {
+		entry.log(SuccessLevel, fmt.Sprint(args...))
+	}
+}
+
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.level() >= InfoLevel {
 		entry.log(InfoLevel, fmt.Sprint(args...))
@@ -187,6 +193,12 @@ func (entry *Entry) Panic(args ...interface{}) {
 func (entry *Entry) Debugf(format string, args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
 		entry.Debug(fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Successf(format string, args ...interface{}) {
+	if entry.Logger.level() >= SuccessLevel {
+		entry.Success(fmt.Sprintf(format, args...))
 	}
 }
 
@@ -234,6 +246,12 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 func (entry *Entry) Debugln(args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
 		entry.Debug(entry.sprintlnn(args...))
+	}
+}
+
+func (entry *Entry) Successln(args ...interface{}) {
+	if entry.Logger.level() >= SuccessLevel {
+		entry.Success(entry.sprintlnn(args...))
 	}
 }
 

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -46,6 +46,10 @@ func Example_basic() {
 	}).Info("A group of walrus emerges from the ocean")
 
 	log.WithFields(logrus.Fields{
+		"animal": "walrus",
+	}).Success("Group emerged")
+
+	log.WithFields(logrus.Fields{
 		"omg":    true,
 		"number": 122,
 	}).Warn("The group's number increased tremendously!")
@@ -62,6 +66,7 @@ func Example_basic() {
 	// Output:
 	// level=debug msg="Started observing beach" animal=walrus number=8
 	// level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
+	// level=success msg="Group emerged" animal=walrus
 	// level=warning msg="The group's number increased tremendously!" number=122 omg=true
 	// level=debug msg="Temperature changes" temperature=-4
 	// level=panic msg="It's over 9000!" animal=orca size=9009

--- a/exported.go
+++ b/exported.go
@@ -82,6 +82,11 @@ func Print(args ...interface{}) {
 	std.Print(args...)
 }
 
+// Success logs a message at level Success on the standard logger.
+func Success(args ...interface{}) {
+	std.Success(args...)
+}
+
 // Info logs a message at level Info on the standard logger.
 func Info(args ...interface{}) {
 	std.Info(args...)
@@ -122,6 +127,11 @@ func Printf(format string, args ...interface{}) {
 	std.Printf(format, args...)
 }
 
+// Successf logs a message at level Success on the standard logger.
+func Successf(format string, args ...interface{}) {
+	std.Successf(format, args...)
+}
+
 // Infof logs a message at level Info on the standard logger.
 func Infof(format string, args ...interface{}) {
 	std.Infof(format, args...)
@@ -160,6 +170,11 @@ func Debugln(args ...interface{}) {
 // Println logs a message at level Info on the standard logger.
 func Println(args ...interface{}) {
 	std.Println(args...)
+}
+
+// Successln logs a message at level Success on the standard logger.
+func Successln(args ...interface{}) {
+	std.Successln(args...)
 }
 
 // Infoln logs a message at level Info on the standard logger.

--- a/hook_test.go
+++ b/hook_test.go
@@ -19,6 +19,7 @@ func (hook *TestHook) Fire(entry *Entry) error {
 func (hook *TestHook) Levels() []Level {
 	return []Level{
 		DebugLevel,
+		SuccessLevel,
 		InfoLevel,
 		WarnLevel,
 		ErrorLevel,
@@ -51,6 +52,7 @@ func (hook *ModifyHook) Fire(entry *Entry) error {
 func (hook *ModifyHook) Levels() []Level {
 	return []Level{
 		DebugLevel,
+		SuccessLevel,
 		InfoLevel,
 		WarnLevel,
 		ErrorLevel,

--- a/logger.go
+++ b/logger.go
@@ -24,8 +24,8 @@ type Logger struct {
 	// formatters for examples.
 	Formatter Formatter
 	// The logging level the logger should log at. This is typically (and defaults
-	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
-	// logged.
+	// to) `logrus.Info`, which allows Success(), Info(), Warn(), Error() and Fatal()
+	// to be logged.
 	Level Level
 	// Used to sync writing to the log. Locking is enabled by Default
 	mu MutexWrap
@@ -120,6 +120,14 @@ func (logger *Logger) Debugf(format string, args ...interface{}) {
 	}
 }
 
+func (logger *Logger) Successf(format string, args ...interface{}) {
+	if logger.level() >= SuccessLevel {
+		entry := logger.newEntry()
+		entry.Successf(format, args...)
+		logger.releaseEntry(entry)
+	}
+}
+
 func (logger *Logger) Infof(format string, args ...interface{}) {
 	if logger.level() >= InfoLevel {
 		entry := logger.newEntry()
@@ -183,6 +191,14 @@ func (logger *Logger) Debug(args ...interface{}) {
 	}
 }
 
+func (logger *Logger) Success(args ...interface{}) {
+	if logger.level() >= SuccessLevel {
+		entry := logger.newEntry()
+		entry.Success(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
 func (logger *Logger) Info(args ...interface{}) {
 	if logger.level() >= InfoLevel {
 		entry := logger.newEntry()
@@ -242,6 +258,14 @@ func (logger *Logger) Debugln(args ...interface{}) {
 	if logger.level() >= DebugLevel {
 		entry := logger.newEntry()
 		entry.Debugln(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Successln(args ...interface{}) {
+	if logger.level() >= SuccessLevel {
+		entry := logger.newEntry()
+		entry.Successln(args...)
 		logger.releaseEntry(entry)
 	}
 }

--- a/logrus.go
+++ b/logrus.go
@@ -17,6 +17,8 @@ func (level Level) String() string {
 	switch level {
 	case DebugLevel:
 		return "debug"
+	case SuccessLevel:
+		return "success"
 	case InfoLevel:
 		return "info"
 	case WarnLevel:
@@ -45,6 +47,8 @@ func ParseLevel(lvl string) (Level, error) {
 		return WarnLevel, nil
 	case "info":
 		return InfoLevel, nil
+	case "success":
+		return SuccessLevel, nil
 	case "debug":
 		return DebugLevel, nil
 	}
@@ -60,6 +64,7 @@ var AllLevels = []Level{
 	ErrorLevel,
 	WarnLevel,
 	InfoLevel,
+	SuccessLevel,
 	DebugLevel,
 }
 
@@ -77,6 +82,9 @@ const (
 	ErrorLevel
 	// WarnLevel level. Non-critical entries that deserve eyes.
 	WarnLevel
+	// SuccessLevel level. Used to denote certain operations are complete.
+	// Useful for a CLI application to indicate an action completed successfully.
+	SuccessLevel
 	// InfoLevel level. General operational entries about what's going on inside the
 	// application.
 	InfoLevel
@@ -115,6 +123,7 @@ type FieldLogger interface {
 	WithError(err error) *Entry
 
 	Debugf(format string, args ...interface{})
+	Successf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
 	Printf(format string, args ...interface{})
 	Warnf(format string, args ...interface{})
@@ -124,6 +133,7 @@ type FieldLogger interface {
 	Panicf(format string, args ...interface{})
 
 	Debug(args ...interface{})
+	Success(args ...interface{})
 	Info(args ...interface{})
 	Print(args ...interface{})
 	Warn(args ...interface{})
@@ -133,6 +143,7 @@ type FieldLogger interface {
 	Panic(args ...interface{})
 
 	Debugln(args ...interface{})
+	Successln(args ...interface{})
 	Infoln(args ...interface{})
 	Println(args ...interface{})
 	Warnln(args ...interface{})

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -65,6 +65,15 @@ func TestPrint(t *testing.T) {
 	})
 }
 
+func TestSuccess(t *testing.T) {
+	LogAndAssertJSON(t, func(log *Logger) {
+		log.Success("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["msg"], "test")
+		assert.Equal(t, fields["level"], "success")
+	})
+}
+
 func TestInfo(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.Info("test")
@@ -244,6 +253,7 @@ func TestDoubleLoggingDoesntPrefixPreviousFields(t *testing.T) {
 func TestConvertLevelToString(t *testing.T) {
 	assert.Equal(t, "debug", DebugLevel.String())
 	assert.Equal(t, "info", InfoLevel.String())
+	assert.Equal(t, "success", SuccessLevel.String())
 	assert.Equal(t, "warning", WarnLevel.String())
 	assert.Equal(t, "error", ErrorLevel.String())
 	assert.Equal(t, "fatal", FatalLevel.String())
@@ -298,6 +308,14 @@ func TestParseLevel(t *testing.T) {
 	l, err = ParseLevel("INFO")
 	assert.Nil(t, err)
 	assert.Equal(t, InfoLevel, l)
+
+	l, err = ParseLevel("Success")
+	assert.Nil(t, err)
+	assert.Equal(t, SuccessLevel, l)
+
+	l, err = ParseLevel("SUCCESS")
+	assert.Nil(t, err)
+	assert.Equal(t, SuccessLevel, l)
 
 	l, err = ParseLevel("debug")
 	assert.Nil(t, err)

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -120,6 +120,8 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 		levelColor = yellow
 	case ErrorLevel, FatalLevel, PanicLevel:
 		levelColor = red
+	case SuccessLevel:
+		levelColor = green
 	default:
 		levelColor = blue
 	}

--- a/writer.go
+++ b/writer.go
@@ -28,6 +28,8 @@ func (entry *Entry) WriterLevel(level Level) *io.PipeWriter {
 		printFunc = entry.Debug
 	case InfoLevel:
 		printFunc = entry.Info
+	case SuccessLevel:
+		printFunc = entry.Success
 	case WarnLevel:
 		printFunc = entry.Warn
 	case ErrorLevel:


### PR DESCRIPTION
This PR adds support for success logging level, useful mainly for CLI applications to denote an action has been completed.

The level is kept below `InfoLevel` so that default log level (which is Info) will also prints out success logs.

The actual `int` values for `InfoLevel` and `DebugLevel` changes by `+1`, I hope that is not an issue.

