### PR TITLE
Fix race condition in entry fireHooks() method

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -113,10 +113,12 @@ func (entry Entry) log(level Level, msg string) {
 	}
 }
 
-func (entry *Entry) fireHooks() {
+// This function is not declared with a pointer value because otherwise
+// race conditions will occur when using multiple goroutines
+func (entry Entry) fireHooks() {
 	entry.Logger.mu.Lock()
 	defer entry.Logger.mu.Unlock()
-	err := entry.Logger.Hooks.Fire(entry.Level, entry)
+	err := entry.Logger.Hooks.Fire(entry.Level, &entry)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
 	}


### PR DESCRIPTION
Fix race condition in entry fireHooks() method.

Calling hook.LastEntry() or hook.AllEntries() results in a race condition when logger is used in multiple goroutines.

Program to reproduce:

```go
package gotest

import (
	"sync"

	"github.com/sirupsen/logrus/hooks/test"
)

func main() {
	logger, hook := test.NewNullLogger()

	var wg sync.WaitGroup
	wg.Add(100)

	for i := 0; i < 100; i++ {
		go func() {
			logger.Info("info")
			wg.Done()
		}()
	}

	logger.Infof("Message: %s", hook.LastEntry().Message)

	wg.Wait()
}
```

Run: ` go run -race gotest/temp.go`

Error:

```
==================
WARNING: DATA RACE
Read at 0x00c4200d48b0 by main goroutine:
  github.com/sirupsen/logrus/hooks/test.(*Hook).LastEntry()
      /Users/imjching/src/github.com/sirupsen/logrus/hooks/test/test.go:72 +0x14e
  main.main()
      /Users/imjching/src/github.com/imjching/logrus/gotest/temp.go:22 +0xec

Previous write at 0x00c4200d48b0 by goroutine 38:
  github.com/sirupsen/logrus.Entry.log()
      /Users/imjching/src/github.com/sirupsen/logrus/entry.go:106 +0x290
  github.com/sirupsen/logrus.(*Entry).Info()
      /Users/imjching/src/github.com/sirupsen/logrus/entry.go:151 +0x116
  github.com/sirupsen/logrus.(*Logger).Info()
      /Users/imjching/src/github.com/sirupsen/logrus/logger.go:189 +0x93
  main.main.func1()
      /Users/imjching/src/github.com/imjching/logrus/gotest/temp.go:17 +0x90

Goroutine 38 (finished) created at:
  main.main()
      /Users/imjching/src/github.com/imjching/logrus/gotest/temp.go:16 +0xd0
==================
Found 1 data race(s)
exit status 66
```
