### PR TITLE
Deferred creation of log file

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -131,6 +131,10 @@ func (entry *Entry) write() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to obtain reader, %v\n", err)
 	} else {
+		// make sure that log file is created (in case logging shall be done
+		// into a file)
+		entry.Logger.setOut()
+		// write log entry
 		_, err = entry.Logger.Out.Write(serialized)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)

--- a/exported.go
+++ b/exported.go
@@ -20,6 +20,13 @@ func SetOutput(out io.Writer) {
 	std.Out = out
 }
 
+// SetFilename sets the name of the log file
+func SetFilename(filename string) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	std.Filename = filename
+}
+
 // SetFormatter sets the standard logger formatter.
 func SetFormatter(formatter Formatter) {
 	std.mu.Lock()

--- a/logger.go
+++ b/logger.go
@@ -108,7 +108,6 @@ func (logger *Logger) setOut() {
 	}
 
 	// create log file
-	fmt.Println("CREATE")
 	f, err := os.Create(logger.Filename)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Log file could not be created/opened: %v\n", err)


### PR DESCRIPTION
If logging shall be done into a log file, the file had to be create passed to SetOutput. This resulted in an empty log file if no log entry has been written.
With my contribution, the creation of the log file is deferred until the first log entry is made. Thus, if no entry is necessary, no log file is created.
Changes:

- I introduced the file name as new attribute in type Logger.
- I introduced the new function SetFilename in exported.go to set the file name
- I introduced the new function setOut in logger.go that creates the file based on the file name if it is not yet existing
- The only place where setOut is called, is in entry.write just before an entry is written.
