### PR TITLE
[logrus] fixes #732 - 20 level options between each standard log level

### DIFF
--- a/logrus.go
+++ b/logrus.go
@@ -68,7 +68,7 @@ var AllLevels = []Level{
 const (
 	// PanicLevel level, highest level of severity. Logs and then calls panic with the
 	// message passed to Debug, Info, ...
-	PanicLevel Level = iota
+	PanicLevel Level = iota * 20
 	// FatalLevel level. Logs and then calls `os.Exit(1)`. It will exit even if the
 	// logging level is set to Panic.
 	FatalLevel


### PR DESCRIPTION
- fixes https://github.com/sirupsen/logrus/issues/732


Test results 

```sh
$ go test
[...]
PASS
ok  	_/srv/scm/git/simelo/logrus	0.275s
```