### PR TITLE
PERF: use buffer pool in json formatter

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -71,9 +72,15 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
 	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
 
-	serialized, err := json.Marshal(data)
+	var b *bytes.Buffer
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+	err := json.NewEncoder(b).Encode(data)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
 	}
-	return append(serialized, '\n'), nil
+	return b.Bytes(), nil
 }


### PR DESCRIPTION
```
benchmark             old ns/op     new ns/op     delta
BenchmarkLogrus-8     4163          4369          +4.95%

benchmark             old allocs     new allocs     delta
BenchmarkLogrus-8     36             31             -13.89%

benchmark             old bytes     new bytes     delta
BenchmarkLogrus-8     3027          2163          -28.54%
```

```
func BenchmarkLogrus(b *testing.B) {
	log := logrus.New()
	log.Formatter = &logrus.JSONFormatter{}
	log.Out = ioutil.Discard
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		log.
			WithField("foo1", "bar1").
			WithField("foo2", "bar2").
			Info("this is a dummy log")
	}
}
```