### PR TITLE
Revert the change introduced in #707 and do the proper fix

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -113,12 +113,10 @@ func (entry Entry) log(level Level, msg string) {
 	}
 }
 
-// This function is not declared with a pointer value because otherwise
-// race conditions will occur when using multiple goroutines
-func (entry Entry) fireHooks() {
+func (entry *Entry) fireHooks() {
 	entry.Logger.mu.Lock()
 	defer entry.Logger.mu.Unlock()
-	err := entry.Logger.Hooks.Fire(entry.Level, &entry)
+	err := entry.Logger.Hooks.Fire(entry.Level, entry)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
 	}

--- a/hooks/test/test.go
+++ b/hooks/test/test.go
@@ -15,7 +15,7 @@ type Hook struct {
 	// Entries is an array of all entries that have been received by this hook.
 	// For safe access, use the AllEntries() method, rather than reading this
 	// value directly.
-	Entries []*logrus.Entry
+	Entries []logrus.Entry
 	mu      sync.RWMutex
 }
 
@@ -52,7 +52,7 @@ func NewNullLogger() (*logrus.Logger, *Hook) {
 func (t *Hook) Fire(e *logrus.Entry) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.Entries = append(t.Entries, e)
+	t.Entries = append(t.Entries, *e)
 	return nil
 }
 
@@ -68,9 +68,7 @@ func (t *Hook) LastEntry() *logrus.Entry {
 	if i < 0 {
 		return nil
 	}
-	// Make a copy, for safety
-	e := *t.Entries[i]
-	return &e
+	return &t.Entries[i]
 }
 
 // AllEntries returns all entries that were logged.
@@ -79,10 +77,9 @@ func (t *Hook) AllEntries() []*logrus.Entry {
 	defer t.mu.RUnlock()
 	// Make a copy so the returned value won't race with future log requests
 	entries := make([]*logrus.Entry, len(t.Entries))
-	for i, entry := range t.Entries {
+	for i := 0; i < len(t.Entries); i++ {
 		// Make a copy, for safety
-		e := *entry
-		entries[i] = &e
+		entries[i] = &t.Entries[i]
 	}
 	return entries
 }
@@ -91,5 +88,5 @@ func (t *Hook) AllEntries() []*logrus.Entry {
 func (t *Hook) Reset() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.Entries = make([]*logrus.Entry, 0)
+	t.Entries = make([]logrus.Entry, 0)
 }


### PR DESCRIPTION
The problem addressed in #707 is that data race would occur because the dummy hook retains the entries passed to it as pointers to them instead of having their copies.

https://github.com/sirupsen/logrus/blob/0afea37/hooks/test/test.go#L18

Therefore, fixing the actual implementation code is so inappropriate that causes other problems like reported in #729.  The dummy code should have been fixed instead. 