### PR TITLE
Support for Entry data under nested JSON dictionary.

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -33,6 +33,9 @@ type JSONFormatter struct {
 	// DisableTimestamp allows disabling automatic timestamps in output
 	DisableTimestamp bool
 
+	// DataKey allows users to put all the log entry parameters into a nested dictionary at a given key.
+	DataKey string
+
 	// FieldMap allows users to customize the names of keys for default fields.
 	// As an example:
 	// formatter := &JSONFormatter{
@@ -58,6 +61,13 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 			data[k] = v
 		}
 	}
+
+	if f.DataKey != "" {
+		newData := make(Fields, 4)
+		newData[f.DataKey] = data
+		data = newData
+	}
+
 	prefixFieldClashes(data, f.FieldMap)
 
 	timestampFormat := f.TimestampFormat


### PR DESCRIPTION
With this change one can use a separate JSON object for log entry parameters. For example, if JSON formatter is created with

```go
formatter = &logrus.JSONFormatter{
    TimestampFormat: time.RFC3339Nano,
    DataKey: "params",
} 
```
sample output looks as follows (after pretty-fying):

```js
{
  "level": "info",
  "msg": "connecting to Kafka cluster",
  "params": {
    "brokers": [
      "localhost:9991",
      "localhost:9992",
      "localhost:9993"
    ]
  },
  "time": "2018-06-19T15:10:17.556928325+02:00"
}
```

I believe it is much better to keep log arguments in a separate namespace. Also it helps to avoid key clashes in a nicer way than renaming `level` to `fields.level`, etc. on the fly.