### PR TITLE
Adding verbose level

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,10 @@ A list of currently known of service hook can be found in this wiki [page](https
 
 #### Level logging
 
-Logrus has six logging levels: Debug, Info, Warning, Error, Fatal and Panic.
+Logrus has seven logging levels: Verbose, Debug, Info, Warning, Error, Fatal and Panic.
 
 ```go
+log.Verbose("Verbose debugging information.")
 log.Debug("Useful debugging information.")
 log.Info("Something noteworthy happened!")
 log.Warn("You should probably take a look at this.")

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ A list of currently known of service hook can be found in this wiki [page](https
 Logrus has seven logging levels: Verbose, Debug, Info, Warning, Error, Fatal and Panic.
 
 ```go
-log.Verbose("Verbose debugging information.")
+log.Trace("Trace information.")
 log.Debug("Useful debugging information.")
 log.Info("Something noteworthy happened!")
 log.Warn("You should probably take a look at this.")

--- a/entry.go
+++ b/entry.go
@@ -138,9 +138,9 @@ func (entry *Entry) write() {
 	}
 }
 
-func (entry *Entry) Verbose(args ...interface{}) {
-	if entry.Logger.level() >= VerboseLevel {
-		entry.log(VerboseLevel, fmt.Sprint(args...))
+func (entry *Entry) Trace(args ...interface{}) {
+	if entry.Logger.level() >= TraceLevel {
+		entry.log(TraceLevel, fmt.Sprint(args...))
 	}
 }
 
@@ -192,9 +192,9 @@ func (entry *Entry) Panic(args ...interface{}) {
 
 // Entry Printf family functions
 
-func (entry *Entry) Verbosef(format string, args ...interface{}) {
-	if entry.Logger.level() >= VerboseLevel {
-		entry.Verbose(fmt.Sprintf(format, args...))
+func (entry *Entry) Tracef(format string, args ...interface{}) {
+	if entry.Logger.level() >= TraceLevel {
+		entry.Trace(fmt.Sprintf(format, args...))
 	}
 }
 
@@ -244,9 +244,9 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 }
 
 // Entry Println family functions
-func (entry *Entry) Verboseln(args ...interface{}) {
-	if entry.Logger.level() >= VerboseLevel {
-		entry.Verbose(entry.sprintlnn(args...))
+func (entry *Entry) Traceln(args ...interface{}) {
+	if entry.Logger.level() >= TraceLevel {
+		entry.Trace(entry.sprintlnn(args...))
 	}
 }
 

--- a/entry.go
+++ b/entry.go
@@ -138,8 +138,14 @@ func (entry *Entry) write() {
 	}
 }
 
+func (entry *Entry) Verbose(args ...interface{}) {
+	if entry.Logger.level() >= VerboseLevel {
+		entry.log(VerboseLevel, fmt.Sprint(args...))
+	}
+}
+
 func (entry *Entry) Debug(args ...interface{}) {
-	if entry.Logger.level() >= DebugLevel {
+	if entry.Logger.level() >= VerboseLevel {
 		entry.log(DebugLevel, fmt.Sprint(args...))
 	}
 }
@@ -185,6 +191,12 @@ func (entry *Entry) Panic(args ...interface{}) {
 }
 
 // Entry Printf family functions
+
+func (entry *Entry) Verbosef(format string, args ...interface{}) {
+	if entry.Logger.level() >= VerboseLevel {
+		entry.Verbose(fmt.Sprintf(format, args...))
+	}
+}
 
 func (entry *Entry) Debugf(format string, args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {
@@ -232,6 +244,11 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 }
 
 // Entry Println family functions
+func (entry *Entry) Verboseln(args ...interface{}) {
+	if entry.Logger.level() >= VerboseLevel {
+		entry.Verbose(entry.sprintlnn(args...))
+	}
+}
 
 func (entry *Entry) Debugln(args ...interface{}) {
 	if entry.Logger.level() >= DebugLevel {

--- a/entry.go
+++ b/entry.go
@@ -145,7 +145,7 @@ func (entry *Entry) Verbose(args ...interface{}) {
 }
 
 func (entry *Entry) Debug(args ...interface{}) {
-	if entry.Logger.level() >= VerboseLevel {
+	if entry.Logger.level() >= DebugLevel {
 		entry.log(DebugLevel, fmt.Sprint(args...))
 	}
 }

--- a/exported.go
+++ b/exported.go
@@ -72,6 +72,11 @@ func WithFields(fields Fields) *Entry {
 	return std.WithFields(fields)
 }
 
+// Verbose logs a message at level Verbose on the standard logger.
+func Verbose(args ...interface{}) {
+	std.Verbose(args...)
+}
+
 // Debug logs a message at level Debug on the standard logger.
 func Debug(args ...interface{}) {
 	std.Debug(args...)
@@ -112,6 +117,11 @@ func Fatal(args ...interface{}) {
 	std.Fatal(args...)
 }
 
+// Verbosef logs a message at level Verbose on the standard logger.
+func Verbosef(format string, args ...interface{}) {
+	std.Verbosef(format, args...)
+}
+
 // Debugf logs a message at level Debug on the standard logger.
 func Debugf(format string, args ...interface{}) {
 	std.Debugf(format, args...)
@@ -150,6 +160,11 @@ func Panicf(format string, args ...interface{}) {
 // Fatalf logs a message at level Fatal on the standard logger.
 func Fatalf(format string, args ...interface{}) {
 	std.Fatalf(format, args...)
+}
+
+// Verboseln logs a message at level Verbose on the standard logger.
+func Verboseln(args ...interface{}) {
+	std.Verboseln(args...)
 }
 
 // Debugln logs a message at level Debug on the standard logger.

--- a/exported.go
+++ b/exported.go
@@ -72,9 +72,9 @@ func WithFields(fields Fields) *Entry {
 	return std.WithFields(fields)
 }
 
-// Verbose logs a message at level Verbose on the standard logger.
-func Verbose(args ...interface{}) {
-	std.Verbose(args...)
+// Trace logs a message at level Trace on the standard logger.
+func Trace(args ...interface{}) {
+	std.Trace(args...)
 }
 
 // Debug logs a message at level Debug on the standard logger.
@@ -117,9 +117,9 @@ func Fatal(args ...interface{}) {
 	std.Fatal(args...)
 }
 
-// Verbosef logs a message at level Verbose on the standard logger.
-func Verbosef(format string, args ...interface{}) {
-	std.Verbosef(format, args...)
+// Tracef logs a message at level Trace on the standard logger.
+func Tracef(format string, args ...interface{}) {
+	std.Tracef(format, args...)
 }
 
 // Debugf logs a message at level Debug on the standard logger.
@@ -162,9 +162,9 @@ func Fatalf(format string, args ...interface{}) {
 	std.Fatalf(format, args...)
 }
 
-// Verboseln logs a message at level Verbose on the standard logger.
-func Verboseln(args ...interface{}) {
-	std.Verboseln(args...)
+// Traceln logs a message at level Trace on the standard logger.
+func Traceln(args ...interface{}) {
+	std.Traceln(args...)
 }
 
 // Debugln logs a message at level Debug on the standard logger.

--- a/formatter.go
+++ b/formatter.go
@@ -31,17 +31,17 @@ type Formatter interface {
 // It's not exported because it's still using Data in an opinionated way. It's to
 // avoid code duplication between the two default formatters.
 func prefixFieldClashes(data Fields, fieldMap FieldMap) {
-	timeKey := fieldMap.resolve(FieldKeyTime)
+	timeKey := fieldMap.Resolve(FieldKeyTime)
 	if t, ok := data[timeKey]; ok {
 		data["fields."+timeKey] = t
 	}
 
-	msgKey := fieldMap.resolve(FieldKeyMsg)
+	msgKey := fieldMap.Resolve(FieldKeyMsg)
 	if m, ok := data[msgKey]; ok {
 		data["fields."+msgKey] = m
 	}
 
-	levelKey := fieldMap.resolve(FieldKeyLevel)
+	levelKey := fieldMap.Resolve(FieldKeyLevel)
 	if l, ok := data[levelKey]; ok {
 		data["fields."+levelKey] = l
 	}

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -17,7 +17,7 @@ const (
 	FieldKeyTime  = "time"
 )
 
-func (f FieldMap) resolve(key fieldKey) string {
+func (f FieldMap) Resolve(key fieldKey) string {
 	if k, ok := f[key]; ok {
 		return k
 	}
@@ -66,10 +66,10 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	}
 
 	if !f.DisableTimestamp {
-		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
+		data[f.FieldMap.Resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
 	}
-	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
-	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
+	data[f.FieldMap.Resolve(FieldKeyMsg)] = entry.Message
+	data[f.FieldMap.Resolve(FieldKeyLevel)] = entry.Level.String()
 
 	serialized, err := json.Marshal(data)
 	if err != nil {

--- a/logger.go
+++ b/logger.go
@@ -112,10 +112,10 @@ func (logger *Logger) WithError(err error) *Entry {
 	return entry.WithError(err)
 }
 
-func (logger *Logger) Verbosef(format string, args ...interface{}) {
-	if logger.level() >= VerboseLevel {
+func (logger *Logger) Tracef(format string, args ...interface{}) {
+	if logger.level() >= TraceLevel {
 		entry := logger.newEntry()
-		entry.Verbosef(format, args...)
+		entry.Tracef(format, args...)
 		logger.releaseEntry(entry)
 	}
 }
@@ -183,10 +183,10 @@ func (logger *Logger) Panicf(format string, args ...interface{}) {
 	}
 }
 
-func (logger *Logger) Verbose(args ...interface{}) {
-	if logger.level() >= VerboseLevel {
+func (logger *Logger) Trace(args ...interface{}) {
+	if logger.level() >= TraceLevel {
 		entry := logger.newEntry()
-		entry.Verbose(args...)
+		entry.Trace(args...)
 		logger.releaseEntry(entry)
 	}
 }
@@ -254,10 +254,10 @@ func (logger *Logger) Panic(args ...interface{}) {
 	}
 }
 
-func (logger *Logger) Verboseln(args ...interface{}) {
-	if logger.level() >= VerboseLevel {
+func (logger *Logger) Traceln(args ...interface{}) {
+	if logger.level() >= TraceLevel {
 		entry := logger.newEntry()
-		entry.Verboseln(args...)
+		entry.Traceln(args...)
 		logger.releaseEntry(entry)
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -112,6 +112,14 @@ func (logger *Logger) WithError(err error) *Entry {
 	return entry.WithError(err)
 }
 
+func (logger *Logger) Verbosef(format string, args ...interface{}) {
+	if logger.level() >= VerboseLevel {
+		entry := logger.newEntry()
+		entry.Verbosef(format, args...)
+		logger.releaseEntry(entry)
+	}
+}
+
 func (logger *Logger) Debugf(format string, args ...interface{}) {
 	if logger.level() >= DebugLevel {
 		entry := logger.newEntry()
@@ -175,6 +183,14 @@ func (logger *Logger) Panicf(format string, args ...interface{}) {
 	}
 }
 
+func (logger *Logger) Verbose(args ...interface{}) {
+	if logger.level() >= VerboseLevel {
+		entry := logger.newEntry()
+		entry.Verbose(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
 func (logger *Logger) Debug(args ...interface{}) {
 	if logger.level() >= DebugLevel {
 		entry := logger.newEntry()
@@ -234,6 +250,14 @@ func (logger *Logger) Panic(args ...interface{}) {
 	if logger.level() >= PanicLevel {
 		entry := logger.newEntry()
 		entry.Panic(args...)
+		logger.releaseEntry(entry)
+	}
+}
+
+func (logger *Logger) Verboseln(args ...interface{}) {
+	if logger.level() >= VerboseLevel {
+		entry := logger.newEntry()
+		entry.Verboseln(args...)
 		logger.releaseEntry(entry)
 	}
 }

--- a/logrus.go
+++ b/logrus.go
@@ -15,6 +15,8 @@ type Level uint32
 // Convert the Level to a string. E.g. PanicLevel becomes "panic".
 func (level Level) String() string {
 	switch level {
+	case VerboseLevel:
+		return "verbose"
 	case DebugLevel:
 		return "debug"
 	case InfoLevel:
@@ -47,6 +49,8 @@ func ParseLevel(lvl string) (Level, error) {
 		return InfoLevel, nil
 	case "debug":
 		return DebugLevel, nil
+	case "verbose":
+		return VerboseLevel, nil
 	}
 
 	var l Level
@@ -61,6 +65,7 @@ var AllLevels = []Level{
 	WarnLevel,
 	InfoLevel,
 	DebugLevel,
+	VerboseLevel,
 }
 
 // These are the different logging levels. You can set the logging level to log
@@ -82,6 +87,8 @@ const (
 	InfoLevel
 	// DebugLevel level. Usually only enabled when debugging. Very verbose logging.
 	DebugLevel
+	// VerboseLevel level. Verry verbose debug logging. Only use with care.
+	VerboseLevel
 )
 
 // Won't compile if StdLogger can't be realized by a log.Logger
@@ -114,6 +121,7 @@ type FieldLogger interface {
 	WithFields(fields Fields) *Entry
 	WithError(err error) *Entry
 
+	Verbosef(format string, args ...interface{})
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
 	Printf(format string, args ...interface{})
@@ -123,6 +131,7 @@ type FieldLogger interface {
 	Fatalf(format string, args ...interface{})
 	Panicf(format string, args ...interface{})
 
+	Verbose(args ...interface{})
 	Debug(args ...interface{})
 	Info(args ...interface{})
 	Print(args ...interface{})
@@ -132,6 +141,7 @@ type FieldLogger interface {
 	Fatal(args ...interface{})
 	Panic(args ...interface{})
 
+	Verboseln(args ...interface{})
 	Debugln(args ...interface{})
 	Infoln(args ...interface{})
 	Println(args ...interface{})

--- a/logrus.go
+++ b/logrus.go
@@ -15,8 +15,8 @@ type Level uint32
 // Convert the Level to a string. E.g. PanicLevel becomes "panic".
 func (level Level) String() string {
 	switch level {
-	case VerboseLevel:
-		return "verbose"
+	case TraceLevel:
+		return "trace"
 	case DebugLevel:
 		return "debug"
 	case InfoLevel:
@@ -49,8 +49,8 @@ func ParseLevel(lvl string) (Level, error) {
 		return InfoLevel, nil
 	case "debug":
 		return DebugLevel, nil
-	case "verbose":
-		return VerboseLevel, nil
+	case "trace":
+		return TraceLevel, nil
 	}
 
 	var l Level
@@ -65,7 +65,7 @@ var AllLevels = []Level{
 	WarnLevel,
 	InfoLevel,
 	DebugLevel,
-	VerboseLevel,
+	TraceLevel,
 }
 
 // These are the different logging levels. You can set the logging level to log
@@ -87,8 +87,8 @@ const (
 	InfoLevel
 	// DebugLevel level. Usually only enabled when debugging. Very verbose logging.
 	DebugLevel
-	// VerboseLevel level. Verry verbose debug logging. Only use with care.
-	VerboseLevel
+	// TraceLevel level. Usually only used for tracing. Use with care.
+	TraceLevel
 )
 
 // Won't compile if StdLogger can't be realized by a log.Logger
@@ -121,7 +121,7 @@ type FieldLogger interface {
 	WithFields(fields Fields) *Entry
 	WithError(err error) *Entry
 
-	Verbosef(format string, args ...interface{})
+	Tracef(format string, args ...interface{})
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
 	Printf(format string, args ...interface{})
@@ -131,7 +131,7 @@ type FieldLogger interface {
 	Fatalf(format string, args ...interface{})
 	Panicf(format string, args ...interface{})
 
-	Verbose(args ...interface{})
+	Trace(args ...interface{})
 	Debug(args ...interface{})
 	Info(args ...interface{})
 	Print(args ...interface{})
@@ -141,7 +141,7 @@ type FieldLogger interface {
 	Fatal(args ...interface{})
 	Panic(args ...interface{})
 
-	Verboseln(args ...interface{})
+	Traceln(args ...interface{})
 	Debugln(args ...interface{})
 	Infoln(args ...interface{})
 	Println(args ...interface{})

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	nocolor = 0
-	red     = 31
-	green   = 32
-	yellow  = 33
-	blue    = 36
-	gray    = 37
+	nocolor   = 0
+	red       = 31
+	green     = 32
+	yellow    = 33
+	blue      = 36
+	gray      = 37
+	lightgray = 38
 )
 
 var (
@@ -50,7 +51,6 @@ type TextFormatter struct {
 	// that log extremely frequently and don't use the JSON formatter this may not
 	// be desired.
 	DisableSorting bool
-
 
 	// Disables the truncation of the level text to 4 characters.
 	DisableLevelTruncation bool
@@ -119,6 +119,8 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string, timestampFormat string) {
 	var levelColor int
 	switch entry.Level {
+	case VerboseLevel:
+		levelColor = lightgray
 	case DebugLevel:
 		levelColor = gray
 	case WarnLevel:

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -119,7 +119,7 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string, timestampFormat string) {
 	var levelColor int
 	switch entry.Level {
-	case VerboseLevel:
+	case TraceLevel:
 		levelColor = lightgray
 	case DebugLevel:
 		levelColor = gray


### PR DESCRIPTION
I've encountered that often i add debug output in functions which are called quite frequently (event handlers, ...)
I would like to have debug output there, but this would simply just bloat the debug output and would make it unreadable. So i often comment out those debug logs and comment them back in when i need them.
I've decided now to introduce the `VerboseLevel` to solve this problem.

I also added a new color for the verbose output, which looks like this in my terminal:
![screenshot from 2018-06-19 16-34-08](https://user-images.githubusercontent.com/1952599/41604721-34d5e2de-73e0-11e8-918b-9347e71fccbb.png)
