### PR TITLE
Add GopherJS compatibility build tags

### DIFF
--- a/terminal_bsd.go
+++ b/terminal_bsd.go
@@ -1,5 +1,6 @@
 // +build darwin freebsd openbsd netbsd dragonfly
 // +build !appengine
+// +build !js
 
 package logrus
 

--- a/terminal_linux.go
+++ b/terminal_linux.go
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !appengine
+// +build !js
 
 package logrus
 

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -3,14 +3,10 @@ package logrus
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"os"
 	"sort"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -66,15 +62,6 @@ type TextFormatter struct {
 func (f *TextFormatter) init(entry *Entry) {
 	if entry.Logger != nil {
 		f.isTerminal = f.checkIfTerminal(entry.Logger.Out)
-	}
-}
-
-func (f *TextFormatter) checkIfTerminal(w io.Writer) bool {
-	switch v := w.(type) {
-	case *os.File:
-		return terminal.IsTerminal(int(v.Fd()))
-	default:
-		return false
 	}
 }
 

--- a/text_formatter_js.go
+++ b/text_formatter_js.go
@@ -1,0 +1,11 @@
+// +build js
+
+package logrus
+
+import (
+	"io"
+)
+
+func (f *TextFormatter) checkIfTerminal(w io.Writer) bool {
+	return false
+}

--- a/text_formatter_other.go
+++ b/text_formatter_other.go
@@ -1,0 +1,19 @@
+// +build !js
+
+package logrus
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func (f *TextFormatter) checkIfTerminal(w io.Writer) bool {
+	switch v := w.(type) {
+	case *os.File:
+		return terminal.IsTerminal(int(v.Fd()))
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
This adds build tags to exclude the unix-specific stuff from a js build.