### PR TITLE
Fix GopherJS build tags

### DIFF
--- a/terminal_bsd.go
+++ b/terminal_bsd.go
@@ -1,5 +1,5 @@
 // +build darwin freebsd openbsd netbsd dragonfly
-// +build !appengine,!gopherjs
+// +build !appengine,!js
 
 package logrus
 

--- a/terminal_check_appengine.go
+++ b/terminal_check_appengine.go
@@ -1,4 +1,4 @@
-// +build appengine gopherjs
+// +build appengine js
 
 package logrus
 

--- a/terminal_check_notappengine.go
+++ b/terminal_check_notappengine.go
@@ -1,4 +1,4 @@
-// +build !appengine,!gopherjs
+// +build !appengine,!js
 
 package logrus
 

--- a/terminal_linux.go
+++ b/terminal_linux.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !appengine,!gopherjs
+// +build !appengine,!js
 
 package logrus
 

--- a/text_formatter_js.go
+++ b/text_formatter_js.go
@@ -1,0 +1,11 @@
+// +build js
+
+package logrus
+
+import (
+	"io"
+)
+
+func (f *TextFormatter) checkIfTerminal(w io.Writer) bool {
+	return false
+}

--- a/text_formatter_other.go
+++ b/text_formatter_other.go
@@ -1,0 +1,3 @@
+// +build !js
+
+package logrus


### PR DESCRIPTION
The GopherJS build tag is "js" not "gopherjs"
