### PR TITLE
[#241] Allow to set writer during logger usage.

### DIFF
--- a/exported.go
+++ b/exported.go
@@ -15,9 +15,7 @@ func StandardLogger() *Logger {
 
 // SetOutput sets the standard logger output.
 func SetOutput(out io.Writer) {
-	std.mu.Lock()
-	defer std.mu.Unlock()
-	std.Out = out
+	std.SetOutput(out)
 }
 
 // SetFormatter sets the standard logger formatter.

--- a/logger.go
+++ b/logger.go
@@ -316,6 +316,12 @@ func (logger *Logger) SetLevel(level Level) {
 	atomic.StoreUint32((*uint32)(&logger.Level), uint32(level))
 }
 
+func (logger *Logger) SetOutput(out io.Writer) {
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+	logger.Out = out
+}
+
 func (logger *Logger) AddHook(hook Hook) {
 	logger.mu.Lock()
 	defer logger.mu.Unlock()


### PR DESCRIPTION
In this pull request I am trying to partially fix issue #241. Now, one could reset output writer,