### PR TITLE
add public Logger#Log & make Entry#Log public

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -178,9 +178,9 @@ func (entry Entry) HasCaller() (has bool) {
 		entry.Caller != nil
 }
 
-// This function is not declared with a pointer value because otherwise
+// Log is not declared with a pointer value because otherwise
 // race conditions will occur when using multiple goroutines
-func (entry Entry) log(level Level, msg string) {
+func (entry Entry) Log(level Level, msg string) {
 	var buffer *bytes.Buffer
 
 	// Default to now, but allow users to override if they want.
@@ -242,13 +242,13 @@ func (entry *Entry) write() {
 
 func (entry *Entry) Trace(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(TraceLevel) {
-		entry.log(TraceLevel, fmt.Sprint(args...))
+		entry.Log(TraceLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Debug(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(DebugLevel) {
-		entry.log(DebugLevel, fmt.Sprint(args...))
+		entry.Log(DebugLevel, fmt.Sprint(args...))
 	}
 }
 
@@ -258,13 +258,13 @@ func (entry *Entry) Print(args ...interface{}) {
 
 func (entry *Entry) Info(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(InfoLevel) {
-		entry.log(InfoLevel, fmt.Sprint(args...))
+		entry.Log(InfoLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(WarnLevel) {
-		entry.log(WarnLevel, fmt.Sprint(args...))
+		entry.Log(WarnLevel, fmt.Sprint(args...))
 	}
 }
 
@@ -274,20 +274,20 @@ func (entry *Entry) Warning(args ...interface{}) {
 
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(ErrorLevel) {
-		entry.log(ErrorLevel, fmt.Sprint(args...))
+		entry.Log(ErrorLevel, fmt.Sprint(args...))
 	}
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(FatalLevel) {
-		entry.log(FatalLevel, fmt.Sprint(args...))
+		entry.Log(FatalLevel, fmt.Sprint(args...))
 	}
 	entry.Logger.Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(PanicLevel) {
-		entry.log(PanicLevel, fmt.Sprint(args...))
+		entry.Log(PanicLevel, fmt.Sprint(args...))
 	}
 	panic(fmt.Sprint(args...))
 }

--- a/logger.go
+++ b/logger.go
@@ -352,9 +352,17 @@ func (logger *Logger) Exit(code int) {
 	logger.ExitFunc(code)
 }
 
-//When file is opened with appending mode, it's safe to
-//write concurrently to a file (within 4k message on Linux).
-//In these cases user can choose to disable the lock.
+func (logger *Logger) Log(level Level, msg string) {
+	if logger.IsLevelEnabled(level) {
+		entry := logger.newEntry()
+		entry.log(level, msg)
+		logger.releaseEntry(entry)
+	}
+}
+
+// SetNoLock When file is opened with appending mode, it's safe to
+// write concurrently to a file (within 4k message on Linux).
+// In these cases user can choose to disable the lock.
 func (logger *Logger) SetNoLock() {
 	logger.mu.Disable()
 }

--- a/logger.go
+++ b/logger.go
@@ -355,7 +355,7 @@ func (logger *Logger) Exit(code int) {
 func (logger *Logger) Log(level Level, msg string) {
 	if logger.IsLevelEnabled(level) {
 		entry := logger.newEntry()
-		entry.log(level, msg)
+		entry.Log(level, msg)
 		logger.releaseEntry(entry)
 	}
 }


### PR DESCRIPTION
In some scenarios, I need to write logs into different target files.
I implements it by using `Hook`, the current workaround like this:
```go
type ConsoleHook struct {
	logger *logrus.Logger
	levels []logrus.Level
}

func (ch *ConsoleHook) Fire(e *logrus.Entry) error {
	if ch.logger.Level >= e.Level {
		switch e.Level {
		case logrus.PanicLevel:
			ch.logger.Panic(e.Message)
		case logrus.FatalLevel:
			ch.logger.Fatal(e.Message)
		case logrus.ErrorLevel:
			ch.logger.Error(e.Message)
		case logrus.WarnLevel:
			ch.logger.Warn(e.Message)
		case logrus.InfoLevel:
			chrus.logger.Info(e.Message)
		case logrus.DebugLevel:
			ch.logger.Debug(e.Message)
		}
	}
	return nil
}
```

This is not convenient and low efficency. More condition statements, more invoking of `fmt.Sprint`. 

So I submit this pull request, and the implementation will be:
```go
func (ch *ConsoleHook) Fire(e *logrus.Entry) error {
	ch.logger.Log(e.Level, e.Message)
	return nil
}
```

If I want to use `WithFiled`, then I can just write code like this:
```go
if ch.logger.Level >= e.Level {
	ch.logger.WithField("key", "value").Log(e.Level, e.Message)
}
```