### PR TITLE
Add a redactor mechanism to prevent leaks of credentials and confiden…

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -145,6 +145,7 @@ func (entry *Entry) write() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to obtain reader, %v\n", err)
 	} else {
+		serialized = entry.Logger.Redactor(serialized)
 		_, err = entry.Logger.Out.Write(serialized)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)

--- a/logger.go
+++ b/logger.go
@@ -28,6 +28,9 @@ type Logger struct {
 	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
 	// logged.
 	Level Level
+	// The output might contains credential or confidential data, to avoid any
+	// leaks you may define you own redactor to obfuscate the output
+	Redactor RedactorFun
 	// Used to sync writing to the log. Locking is enabled by Default
 	mu MutexWrap
 	// Reusable empty entry
@@ -73,6 +76,7 @@ func New() *Logger {
 		Formatter: new(TextFormatter),
 		Hooks:     make(LevelHooks),
 		Level:     InfoLevel,
+		Redactor:  defaultRedactor,
 	}
 }
 
@@ -334,4 +338,9 @@ func (logger *Logger) AddHook(hook Hook) {
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
 	logger.Hooks.Add(hook)
+
+}
+
+func (logger *Logger) SetRedactor(redactor RedactorFun) {
+	logger.Redactor = redactor
 }

--- a/redactor.go
+++ b/redactor.go
@@ -1,0 +1,7 @@
+package logrus
+
+type RedactorFun func(serialized []byte) []byte
+
+func defaultRedactor(serialized []byte) []byte {
+	return serialized
+}

--- a/redactor_test.go
+++ b/redactor_test.go
@@ -1,0 +1,40 @@
+package logrus
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testSentence = "this is a test sentence"
+
+func TestNoRedactor(t *testing.T) {
+	logger := New()
+	var buffer bytes.Buffer
+	logger.Out = &buffer
+	logger.Warning(testSentence)
+	assert.Equal(t, bytes.Contains(buffer.Bytes(), []byte("test")), true, "test has been redacted but it shouldn't")
+}
+
+func TestRedactorOnText(t *testing.T) {
+	logger := New()
+	var buffer bytes.Buffer
+	logger.Out = &buffer
+	logger.SetRedactor(func(in []byte) []byte {
+		return bytes.Replace(in, []byte("test"), []byte("****"), -1)
+	})
+	logger.Warning(testSentence)
+	assert.Equal(t, bytes.Contains(buffer.Bytes(), []byte("test")), false, "test has not been redacted but it shouldn't")
+}
+
+func TestRedactorOnField(t *testing.T) {
+	logger := New()
+	var buffer bytes.Buffer
+	logger.Out = &buffer
+	logger.SetRedactor(func(in []byte) []byte {
+		return bytes.Replace(in, []byte("test"), []byte("****"), -1)
+	})
+	logger.WithField("field_one", testSentence).Warning(testSentence)
+	assert.Equal(t, bytes.Contains(buffer.Bytes(), []byte("test")), false, "test has not been redacted but it shouldn't")
+}


### PR DESCRIPTION
I think It would be nice to have a redactor mechanism to hide credentials and confidentials data to prevent any leaks or compromising data in logs.

Here is a proposition to do it, I'm not sure it fit very well the architecture (as it is at the end of the process on the serialized data) but seems to be working.

I know I could have done it by overriding the JSONFormatter and TextFormatter but as it should be a standard feature (IMHO) I wanted to have it as is.