### PR TITLE
Use syslog instead of airbrake as syslog example

### DIFF
--- a/example_hook_test.go
+++ b/example_hook_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 )
 
+// An example on how to use a hook
 func Example_hook() {
 	var log = logrus.New()
 	log.Formatter = new(logrus.TextFormatter)                     // default


### PR DESCRIPTION
The purpose is to reduce package dependencies, fixes #809.