### PR TITLE
Fix spelling in Entry.Buffer comment

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -41,7 +41,7 @@ type Entry struct {
 	// Message passed to Debug, Info, Warn, Error, Fatal or Panic
 	Message string
 
-	// When formatter is called in entry.log(), an Buffer may be set to entry
+	// When formatter is called in entry.log(), a Buffer may be set to entry
 	Buffer *bytes.Buffer
 }
 


### PR DESCRIPTION
Noticed a little spelling mistake while browsing the definition for `Entry` 😆 