### PR TITLE
Fix AppEngine builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,26 @@ matrix:
         - go get golang.org/x/sys/windows
       script:
         - go test -race -v ./...
+    - go: 1.10.x
+      install:
+        - go get github.com/stretchr/testify/assert
+        - go get golang.org/x/crypto/ssh/terminal
+        - go get golang.org/x/sys/unix
+        - go get golang.org/x/sys/windows
+      script:
+        - go test -race -v -tags appengine ./...
+    - go: 1.11.x
+      env: GO111MODULE=on
+      install:
+        - go mod download
+      script:
+        - go test -race -v -tags appengine ./...
+    - go: 1.11.x
+      env: GO111MODULE=off
+      install:
+        - go get github.com/stretchr/testify/assert
+        - go get golang.org/x/crypto/ssh/terminal
+        - go get golang.org/x/sys/unix
+        - go get golang.org/x/sys/windows
+      script:
+        - go test -race -v -tags appengine ./...

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -1,14 +1,16 @@
 package logrus_test
 
 import (
-	"github.com/sirupsen/logrus"
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
 func Example_basic() {
 	var log = logrus.New()
 	log.Formatter = new(logrus.JSONFormatter)
 	log.Formatter = new(logrus.TextFormatter)                     //default
+	log.Formatter.(*logrus.TextFormatter).DisableColors = true    // remove colors
 	log.Formatter.(*logrus.TextFormatter).DisableTimestamp = true // remove timestamp from test output
 	log.Level = logrus.DebugLevel
 	log.Out = os.Stdout

--- a/example_hook_test.go
+++ b/example_hook_test.go
@@ -3,16 +3,18 @@
 package logrus_test
 
 import (
-	"github.com/sirupsen/logrus"
-	slhooks "github.com/sirupsen/logrus/hooks/syslog"
 	"log/syslog"
 	"os"
+
+	"github.com/sirupsen/logrus"
+	slhooks "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 // An example on how to use a hook
 func Example_hook() {
 	var log = logrus.New()
 	log.Formatter = new(logrus.TextFormatter)                     // default
+	log.Formatter.(*logrus.TextFormatter).DisableColors = true    // remove colors
 	log.Formatter.(*logrus.TextFormatter).DisableTimestamp = true // remove timestamp from test output
 	if sl, err := slhooks.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, ""); err != nil {
 		log.Hooks.Add(sl)

--- a/terminal_appengine.go
+++ b/terminal_appengine.go
@@ -1,11 +1,13 @@
 // Based on ssh/terminal:
-// Copyright 2013 The Go Authors. All rights reserved.
+// Copyright 2018 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 // +build appengine
 
 package logrus
+
+import "io"
 
 func initTerminal(w io.Writer) {
 }

--- a/terminal_appengine.go
+++ b/terminal_appengine.go
@@ -1,0 +1,11 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package logrus
+
+func initTerminal(w io.Writer) {
+}


### PR DESCRIPTION
`go build -tags appengine [...]` currently yields:

```
.../github.com/sirupsen/logrus/text_formatter.go:84:4: undefined: initTerminal
```

This change implements `initTerminal` for AppEngine builds.