### PR TITLE
Skip func type value in fields.

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -2,7 +2,14 @@ package logrus
 
 import "time"
 
-const defaultTimestampFormat = time.RFC3339
+// Default key names for the default fields
+const (
+	defaultTimestampFormat = time.RFC3339
+	FieldKeyMsg            = "msg"
+	FieldKeyLevel          = "level"
+	FieldKeyTime           = "time"
+	FieldKeyLogrusError    = "logrus_error"
+)
 
 // The Formatter interface is used to implement a custom Formatter. It takes an
 // `Entry`. It exposes all the fields, including the default ones:
@@ -47,5 +54,11 @@ func prefixFieldClashes(data Fields, fieldMap FieldMap) {
 	if l, ok := data[levelKey]; ok {
 		data["fields."+levelKey] = l
 		delete(data, levelKey)
+	}
+
+	logrusErrKey := fieldMap.resolve(FieldKeyLogrusError)
+	if l, ok := data[logrusErrKey]; ok {
+		data["fields."+logrusErrKey] = l
+		delete(data, logrusErrKey)
 	}
 }

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -11,13 +11,6 @@ type fieldKey string
 // FieldMap allows customization of the key names for default fields.
 type FieldMap map[fieldKey]string
 
-// Default key names for the default fields
-const (
-	FieldKeyMsg   = "msg"
-	FieldKeyLevel = "level"
-	FieldKeyTime  = "time"
-)
-
 func (f FieldMap) resolve(key fieldKey) string {
 	if k, ok := f[key]; ok {
 		return k
@@ -79,6 +72,9 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		timestampFormat = defaultTimestampFormat
 	}
 
+	if entry.err != "" {
+		data[f.FieldMap.resolve(FieldKeyLogrusError)] = entry.err
+	}
 	if !f.DisableTimestamp {
 		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,42 @@
+package logrus
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldValueError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := &Logger{
+		Out:       buf,
+		Formatter: new(JSONFormatter),
+		Hooks:     make(LevelHooks),
+		Level:     DebugLevel,
+	}
+	l.WithField("func", func() {}).Info("test")
+	fmt.Println(buf.String())
+	var data map[string]interface{}
+	json.Unmarshal(buf.Bytes(), &data)
+	_, ok := data[FieldKeyLogrusError]
+	require.True(t, ok)
+}
+
+func TestNoFieldValueError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := &Logger{
+		Out:       buf,
+		Formatter: new(JSONFormatter),
+		Hooks:     make(LevelHooks),
+		Level:     DebugLevel,
+	}
+	l.WithField("str", "str").Info("test")
+	fmt.Println(buf.String())
+	var data map[string]interface{}
+	json.Unmarshal(buf.Bytes(), &data)
+	_, ok := data[FieldKeyLogrusError]
+	require.False(t, ok)
+}

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -114,13 +114,16 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		keys = append(keys, k)
 	}
 
-	fixedKeys := make([]string, 0, 3+len(entry.Data))
+	fixedKeys := make([]string, 0, 4+len(entry.Data))
 	if !f.DisableTimestamp {
 		fixedKeys = append(fixedKeys, f.FieldMap.resolve(FieldKeyTime))
 	}
 	fixedKeys = append(fixedKeys, f.FieldMap.resolve(FieldKeyLevel))
 	if entry.Message != "" {
 		fixedKeys = append(fixedKeys, f.FieldMap.resolve(FieldKeyMsg))
+	}
+	if entry.err != "" {
+		fixedKeys = append(fixedKeys, f.FieldMap.resolve(FieldKeyLogrusError))
 	}
 
 	if !f.DisableSorting {
@@ -164,6 +167,8 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 				value = entry.Level.String()
 			case f.FieldMap.resolve(FieldKeyMsg):
 				value = entry.Message
+			case f.FieldMap.resolve(FieldKeyLogrusError):
+				value = entry.err
 			default:
 				value = entry.Data[key]
 			}


### PR DESCRIPTION
We skip those unprintable fields and an error field
instead of dropping the whole trace.

Fixes #642