### PR TITLE
Prevent TextFormatter from modifying entry.Data

### DIFF
--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -144,7 +144,7 @@ func TestDisableLevelTruncation(t *testing.T) {
 		tf := &TextFormatter{DisableLevelTruncation: disabled}
 		var b bytes.Buffer
 		entry.Level = level
-		tf.printColored(&b, entry, keys, timestampFormat)
+		tf.printColored(&b, entry, keys, nil, timestampFormat)
 		logLine := (&b).String()
 		if disabled {
 			expected := strings.ToUpper(level.String())


### PR DESCRIPTION
Current implementation of TextFormatter modifies entry.Fields. If a handler runs after the call to Format, it will see the prefixed fields created by prefixFieldClashes.

The proposed implementation creates a shallow copy of entry.Data. A similar approach is already used in JSONFormatter.

Example:
```go
package main

import (
	"fmt"
	"sync"
	"time"

	"github.com/sirupsen/logrus"
)

func main() {
	l := logrus.New()
	h := &Hook{}
	l.AddHook(h)

	l.WithFields(logrus.Fields{
		"hello": "world",
		"level": "highest",
	}).Info("hello")

	h.Wg.Wait()
}

type Hook struct {
	Wg sync.WaitGroup
}

func (h *Hook) Levels() []logrus.Level {
	return logrus.AllLevels
}

func (h *Hook) Fire(entry *logrus.Entry) error {
	h.Wg.Add(1)
	go func() {
		defer h.Wg.Done()
		time.Sleep(time.Second)
		fmt.Printf("Inside hook: %+v\n", entry.Data)
	}()
	return nil
}
```

Output with current implementation:
```
time="2018-10-11T10:49:44+02:00" level=info msg=hello fields.level=highest hello=world
Inside hook: map[fields.level:highest hello:world]
```

Output with proposed implementation:
```
time="2018-10-11T10:51:36+02:00" level=info msg=hello fields.level=highest hello=world
Inside hook: map[level:highest hello:world]
```