### PR TITLE
Make logrus.Level implement encoding.TextUnmarshaler

### DIFF
--- a/logrus.go
+++ b/logrus.go
@@ -53,6 +53,18 @@ func ParseLevel(lvl string) (Level, error) {
 	return l, fmt.Errorf("not a valid logrus Level: %q", lvl)
 }
 
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (level *Level) UnmarshalText(text []byte) error {
+	l, err := ParseLevel(string(text))
+	if err != nil {
+		return err
+	}
+
+	*level = Level(l)
+
+	return nil
+}
+
 // A constant exposing all logging levels
 var AllLevels = []Level{
 	PanicLevel,

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -372,6 +372,19 @@ func TestParseLevel(t *testing.T) {
 	assert.Equal(t, "not a valid logrus Level: \"invalid\"", err.Error())
 }
 
+func TestUnmarshalText(t *testing.T) {
+	var u Level
+	for _, level := range AllLevels {
+		t.Run(level.String(), func(t *testing.T) {
+			assert.NoError(t, u.UnmarshalText([]byte(level.String())))
+			assert.Equal(t, level, u)
+		})
+	}
+	t.Run("invalid", func(t *testing.T) {
+		assert.Error(t, u.UnmarshalText([]byte("invalid")))
+	})
+}
+
 func TestGetSetLevelRace(t *testing.T) {
 	wg := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Implemented `encoding.TextUnmarshaler` for `logrus.Level` to utilize the type in libraries that accept `encoding.TextUnmarshaler`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sirupsen/logrus/845)
<!-- Reviewable:end -->
