### PR TITLE
Add GELF to third party formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ The built-in logging formatters are:
 Third party logging formatters:
 
 * [`FluentdFormatter`](https://github.com/joonix/log). Formats entries that can be parsed by Kubernetes and Google Container Engine.
+* [`GELF`](https://github.com/fabienm/go-logrus-formatters). Formats entries so they comply to Graylog's [GELF 1.1 specification](http://docs.graylog.org/en/2.4/pages/gelf.html).
 * [`logstash`](https://github.com/bshuster-repo/logrus-logstash-hook). Logs fields as [Logstash](http://logstash.net) Events.
 * [`prefixed`](https://github.com/x-cray/logrus-prefixed-formatter). Displays log entry source along with alternative layout.
 * [`zalgo`](https://github.com/aybabtme/logzalgo). Invoking the P͉̫o̳̼̊w̖͈̰͎e̬͔̭͂r͚̼̹̲ ̫͓͉̳͈ō̠͕͖̚f̝͍̠ ͕̲̞͖͑Z̖̫̤̫ͪa͉̬͈̗l͖͎g̳̥o̰̥̅!̣͔̲̻͊̄ ̙̘̦̹̦.


### PR DESCRIPTION
I had to create a [GELF](http://docs.graylog.org/en/2.4/pages/gelf.html) implementation for logrus a while ago.

I noticed there is no suggestion for gelf logging in official documentation, so here is my proposal.

Features:
* Logrus level to syslog level mapping
* Logrus entry times are converted to UNIX timestamps
* Logrus entry fields are prefixed with `_`, excepting standardized GELF fields (`version`, `host`, `short_message`, `full_message`, `timestamp` and `level`)