### PR TITLE
Enforce the new fully-lowercase import path with Go 1.4 mecanism

### DIFF
--- a/logrus.go
+++ b/logrus.go
@@ -1,4 +1,4 @@
-package logrus
+package logrus // import "github.com/sirupsen/logrus"
 
 import (
 	"fmt"


### PR DESCRIPTION
The original import path of was github.com/Sirupsen/logrus but it has
changed to a fully lowercase path in July 2017.
References:
- https://github.com/sirupsen/logrus/blob/7eeb7b7cbdeb0a582a5b7a1512d91f956f1674aa/README.md#case-sensitivity
- https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276

To help dependent project to detect the issue with mixing old and new
import path, let's use the Go 1.4 mecanism that enforces the import
path: https://golang.org/doc/go1.4#canonicalimports

This is a complement to go.mod for pre-Go-modules Go versions.