### PR TITLE
Fix hook example

### DIFF
--- a/example_hook_test.go
+++ b/example_hook_test.go
@@ -16,7 +16,7 @@ func Example_hook() {
 	log.Formatter = new(logrus.TextFormatter)                     // default
 	log.Formatter.(*logrus.TextFormatter).DisableColors = true    // remove colors
 	log.Formatter.(*logrus.TextFormatter).DisableTimestamp = true // remove timestamp from test output
-	if sl, err := slhooks.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, ""); err != nil {
+	if sl, err := slhooks.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, ""); err == nil {
 		log.Hooks.Add(sl)
 	}
 	log.Out = os.Stdout


### PR DESCRIPTION
The example code for adding a hook would never add a successfully built syslog adapter because the error check was inverted.