### PR TITLE
Remove colored output on windows

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -102,7 +103,7 @@ func (f *TextFormatter) isColored() bool {
 		}
 	}
 
-	return isColored && !f.DisableColors
+	return isColored && !f.DisableColors && (runtime.GOOS != "windows")
 }
 
 // Format renders a single log entry

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -91,7 +91,7 @@ func (f *TextFormatter) init(entry *Entry) {
 }
 
 func (f *TextFormatter) isColored() bool {
-	isColored := f.ForceColors || f.isTerminal
+	isColored := f.ForceColors || (f.isTerminal && (runtime.GOOS != "windows"))
 
 	if f.EnvironmentOverrideColors {
 		if force, ok := os.LookupEnv("CLICOLOR_FORCE"); ok && force != "0" {
@@ -103,7 +103,7 @@ func (f *TextFormatter) isColored() bool {
 		}
 	}
 
-	return isColored && !f.DisableColors && (runtime.GOOS != "windows")
+	return isColored && !f.DisableColors
 }
 
 // Format renders a single log entry

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -444,7 +444,7 @@ func TestTextFormatterIsColored(t *testing.T) {
 				os.Setenv("CLICOLOR_FORCE", val.clicolorForceVal)
 			}
 			res := tf.isColored()
-			if runtime.GOOS == "windows" {
+			if runtime.GOOS == "windows" && !tf.ForceColors && !val.clicolorForceIsSet {
 				assert.Equal(subT, false, res)
 			} else {
 				assert.Equal(subT, val.expectedResult, res)

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -443,7 +444,11 @@ func TestTextFormatterIsColored(t *testing.T) {
 				os.Setenv("CLICOLOR_FORCE", val.clicolorForceVal)
 			}
 			res := tf.isColored()
-			assert.Equal(subT, val.expectedResult, res)
+			if runtime.GOOS == "windows" {
+				assert.Equal(subT, false, res)
+			} else {
+				assert.Equal(subT, val.expectedResult, res)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #862

Currently the textformatter on windows outputs 

``←[31mERRO←[0m[0000] test windows``

when coloring is not disabled explicitly.
However, windows up to windows 8.1 does not support colored output on cmd entirely. Windows 10 added support for it, which is off by default and has to be enabled via registry or environment variable. Therefore i suggest removing colored output on windows entirely to make the output usable again.