### PR TITLE
Travis: fix checkout dir to help contributors run Travis on their fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+go_import_path: github.com/sirupsen/logrus
 env:
   - GOMAXPROCS=4 GORACE=halt_on_error=1
 matrix:


### PR DESCRIPTION
Set the Travis-CI checkout path to allow contributors running Travis-CI on their fork to have Travis-CI launching using the canonical import path instead of the path of the fork.