### PR TITLE
logger: fix wrong callback method

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -200,7 +200,7 @@ func (logger *Logger) Info(args ...interface{}) {
 
 func (logger *Logger) Print(args ...interface{}) {
 	entry := logger.newEntry()
-	entry.Info(args...)
+	entry.Print(args...)
 	logger.releaseEntry(entry)
 }
 
@@ -256,7 +256,7 @@ func (logger *Logger) Warnln(args ...interface{}) {
 }
 
 func (logger *Logger) Warningln(args ...interface{}) {
-	logger.Warn(args...)
+	logger.Warnln(args...)
 }
 
 func (logger *Logger) Errorln(args ...interface{}) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +40,26 @@ func TestNoFieldValueError(t *testing.T) {
 	json.Unmarshal(buf.Bytes(), &data)
 	_, ok := data[FieldKeyLogrusError]
 	require.False(t, ok)
+}
+
+func TestWarninglnNotEqualToWarning(t *testing.T) {
+	buf := &bytes.Buffer{}
+	bufln := &bytes.Buffer{}
+
+	formatter := new(TextFormatter)
+	formatter.DisableTimestamp = true
+	formatter.DisableLevelTruncation = true
+
+	l := &Logger{
+		Out:       buf,
+		Formatter: formatter,
+		Hooks:     make(LevelHooks),
+		Level:     DebugLevel,
+	}
+	l.Warning("hello,", "world")
+
+	l.SetOutput(bufln)
+	l.Warningln("hello,", "world")
+
+	assert.NotEqual(t, buf.String(), bufln.String(), "Warning() and Wantingln() should not be equal")
 }


### PR DESCRIPTION
Fix wrong callback in `logger.go`, and add test cases:

1. `logger.Warningln` should call `logger.Warnln`, not `logger.Warn`.

2. It's ok for `logger.Print` to call `entry.Info`, but calling `entry.Print`
   is better.

Signed-off-by: Jiang Xin <zhiyou.jx@alibaba-inc.com>