### PR TITLE
Add nested-logrus-formatter to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Third party logging formatters:
 * [`logstash`](https://github.com/bshuster-repo/logrus-logstash-hook). Logs fields as [Logstash](http://logstash.net) Events.
 * [`prefixed`](https://github.com/x-cray/logrus-prefixed-formatter). Displays log entry source along with alternative layout.
 * [`zalgo`](https://github.com/aybabtme/logzalgo). Invoking the P͉̫o̳̼̊w̖͈̰͎e̬͔̭͂r͚̼̹̲ ̫͓͉̳͈ō̠͕͖̚f̝͍̠ ͕̲̞͖͑Z̖̫̤̫ͪa͉̬͈̗l͖͎g̳̥o̰̥̅!̣͔̲̻͊̄ ̙̘̦̹̦.
+* [`nested-logrus-formatter`](https://github.com/antonfisher/nested-logrus-formatter). Converts logrus fields to a nested structure.
 
 You can define your formatter by implementing the `Formatter` interface,
 requiring a `Format` method. `Format` takes an `*Entry`. `entry.Data` is a


### PR DESCRIPTION
Hi,
I'd like to propose another one third-party formatter for logrus (https://github.com/antonfisher/nested-logrus-formatter).

This is the demo:
![image](https://user-images.githubusercontent.com/599352/51793405-1349ba80-2175-11e9-85e0-7d875f73debc.png)

Thanks.