### PR TITLE
add skipPackageNameForCaller

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 // Set the global qualified package name.
-func SetSkipPackageNameForCaller(name string) {
+func AddSkipPackageFromStackTrace(name string) {
 	skipPackageNameForCaller[name] = true
 }
 

--- a/entry.go
+++ b/entry.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 // Set the global qualified package name.
-// ex: logrus.SetSkipPackageNameForCaller("github.com/go-xorm/xorm")
+// ex: logrus.AddSkipPackageFromStackTrace("github.com/go-xorm/xorm")
 func AddSkipPackageFromStackTrace(name string) {
 	skipPackageNameForCaller[name] = struct{}{}
 }

--- a/entry.go
+++ b/entry.go
@@ -176,12 +176,11 @@ func getCaller() *runtime.Frame {
 	callerInitOnce.Do(func() {
     pcs := make([]uintptr, 2)
 		_ = runtime.Callers(0, pcs)
-		logrusPackage = getPackageName(runtime.FuncForPC(pcs[1]).Name())
+		AddSkipPackageFromStackTrace(getPackageName(runtime.FuncForPC(pcs[1]).Name()))
 
 		// now that we have the cache, we can skip a minimum count of known-logrus functions
 		// XXX this is dubious, the number of frames may vary
-		minimumCallerDepth = knownLogrusFrames
-		AddSkipPackageFromStackTrace(logrusPackage)
+		minimumCallerDepth = knownLogrusFrames		
 	})
 
 	// Restrict the lookback frames to avoid runaway lookups


### PR DESCRIPTION
It's just an implementation. It can only be used, but it's not perfect. I hope there's a better solution.😋

ex:
```golang
logrus.AddSkipPackageFromStackTrace("someprogram/package/subpackage")
logrus.AddSkipPackageFromStackTrace("tsl/core/log")
logrus.AddSkipPackageFromStackTrace("github.com/go-xorm/xorm")
```

#887 

