### PR TITLE
Add a space at the left of outputing caller's file path for Goland ID…

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -24,6 +24,8 @@ func init() {
 	baseTimestamp = time.Now()
 }
 
+type hyperlink string
+
 // TextFormatter formats logs into text
 type TextFormatter struct {
 	// Set to true to bypass checking for a TTY before outputting colors.
@@ -175,7 +177,7 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 			case key == f.FieldMap.resolve(FieldKeyFunc) && entry.HasCaller():
 				value = entry.Caller.Function
 			case key == f.FieldMap.resolve(FieldKeyFile) && entry.HasCaller():
-				value = fmt.Sprintf("%s:%d", entry.Caller.File, entry.Caller.Line)
+				value = hyperlink(fmt.Sprintf("%s:%d", entry.Caller.File, entry.Caller.Line))
 			default:
 				value = data[key]
 			}
@@ -255,6 +257,11 @@ func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interf
 }
 
 func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
+	if stringVal, ok := value.(hyperlink);ok {
+		b.WriteString(fmt.Sprintf(" " + string(stringVal)))
+		return
+	}
+
 	stringVal, ok := value.(string)
 	if !ok {
 		stringVal = fmt.Sprint(value)


### PR DESCRIPTION
…E's console to recognize as hyperlink

I need it to be shown as 

time="2019-01-29T13:21:38+08:00" level=error msg=aaaaaaaa func=study/study.TestFun 
file= [D:/study/GoPath/src/study/study.go:17](url)

then I can locate it directly by clicking left button of mouse,

**not** 

time="2019-01-29T13:21:38+08:00" level=error msg=aaaaaaaa func=study/study.TestFun file="D:/study/GoPath/src/study/study.go:17"