### PR TITLE
prevent string formatting in Entry.Logf when log level is not enabled

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -298,7 +298,9 @@ func (entry *Entry) Panic(args ...interface{}) {
 // Entry Printf family functions
 
 func (entry *Entry) Logf(level Level, format string, args ...interface{}) {
-	entry.Log(level, fmt.Sprintf(format, args...))
+	if entry.Logger.IsLevelEnabled(level) {
+		entry.Log(level, fmt.Sprintf(format, args...))
+	}
 }
 
 func (entry *Entry) Tracef(format string, args ...interface{}) {

--- a/entry_test.go
+++ b/entry_test.go
@@ -139,3 +139,17 @@ func TestEntryWithIncorrectField(t *testing.T) {
 	assert.Equal(eWithFunc.err, `can not add field "func"`)
 	assert.Equal(eWithFuncPtr.err, `can not add field "funcPtr"`)
 }
+
+func TestEntryLogfLevel(t *testing.T) {
+	logger := New()
+	buffer := &bytes.Buffer{}
+	logger.Out = buffer
+	logger.SetLevel(InfoLevel)
+	entry := NewEntry(logger)
+
+	entry.Logf(DebugLevel, "%s", "debug")
+	assert.NotContains(t, buffer.String(), "debug", )
+
+	entry.Logf(WarnLevel, "%s", "warn")
+	assert.Contains(t, buffer.String(), "warn", )
+}


### PR DESCRIPTION
This PR adds a conditional to `Entry.Logf` to avoid string formatting when the given log level is not enabled.

Actual log production is guarded against in `Entry.Log`, however this still results in a call to `fmt.Sprintf` in `Entry.Logf` before calling `Entry.Log`. The conditional is necessary in both places since both `Entry.Logf` and `Entry.Log` are public methods.

My team ran into high memory usage as a result of this "hidden" formatting when we deployed a service with lots of calls to `Debugf` with debug logging disabled. The change in this PR will prevent others from running into this issue in the future. It also maintains consistency with [`Logger.Logf`](https://github.com/sirupsen/logrus/blob/master/logger.go#L135) by avoiding any formatting or other work if the given log level is not enabled.