### PR TITLE
Test with Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,21 @@ matrix:
         - go get golang.org/x/sys/windows
       script:
         - go test -race -v ./...
+    - go: 1.12.x
+      env: GO111MODULE=on
+      install:
+        - go mod download
+      script:
+        - go test -race -v ./...
+    - go: 1.12.x
+      env: GO111MODULE=off
+      install:
+        - go get github.com/stretchr/testify/assert
+        - go get golang.org/x/crypto/ssh/terminal
+        - go get golang.org/x/sys/unix
+        - go get golang.org/x/sys/windows
+      script:
+        - go test -race -v ./...
     - go: 1.10.x
       install:
         - go get github.com/stretchr/testify/assert
@@ -42,6 +57,21 @@ matrix:
       script:
         - go test -race -v -tags appengine ./...
     - go: 1.11.x
+      env: GO111MODULE=off
+      install:
+        - go get github.com/stretchr/testify/assert
+        - go get golang.org/x/crypto/ssh/terminal
+        - go get golang.org/x/sys/unix
+        - go get golang.org/x/sys/windows
+      script:
+        - go test -race -v -tags appengine ./...
+    - go: 1.12.x
+      env: GO111MODULE=on
+      install:
+        - go mod download
+      script:
+        - go test -race -v -tags appengine ./...
+    - go: 1.12.x
       env: GO111MODULE=off
       install:
         - go get github.com/stretchr/testify/assert


### PR DESCRIPTION
Add Go 1.12 to Travis CI build matrix.

AppVeyor doesn't seem to support Go 1.12 out of the box yet according to https://www.appveyor.com/docs/windows-images-software/#golang, deferring for later.