### PR TITLE
Add colorized fields

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -280,9 +280,30 @@ func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
 		stringVal = fmt.Sprint(value)
 	}
 
+	var ca ColorApplicator = ApplicatorFunc(func(s string) string { return s })
+	if c, ok := value.(Colorizer); ok {
+		ca = c.Color()
+	}
+
 	if !f.needsQuoting(stringVal) {
-		b.WriteString(stringVal)
+		b.WriteString(ca.Apply(stringVal))
 	} else {
-		b.WriteString(fmt.Sprintf("%q", stringVal))
+		b.WriteString(ca.Apply(fmt.Sprintf("%q", stringVal)))
 	}
 }
+
+// ColorApplicator applies colors to a string
+type ColorApplicator interface {
+	Apply(string) string
+}
+
+// Colorizer provides a colorized string-representation of the concrete data structure.
+type Colorizer interface {
+	Color() ColorApplicator
+}
+
+// ApplicatorFunc turns a function into a ColorApplicator
+type ApplicatorFunc func(string) string
+
+// Apply color
+func (f ApplicatorFunc) Apply(s string) string { return f(s) }


### PR DESCRIPTION
**N.B.:** This PR accompanies https://github.com/sirupsen/logrus/issues/925.

## Motivation

When debugging complex applications, it can be hard to group lines of logging output together at a glance. Furthermore, there may be several meaningful ways to group lines of output, e.g.:

- by service name
- by process identifier
- by IP
- etc...

Allowing users to define per-field coloration in `logrus.TextFormatter` would give users the tools necessary to create such visual groupings, without forcing its use.

## Example

The following type will be logged with a color that depends on its value.  Note that this example uses `github.com/aybabtme/rgbterm` to generate the color codes, but that this is in no way required.  **For the avoidance of doubt:**  this PR does *not* introduce a dependency to any specific colorization library.

```go
type PeerID uint64

func Color() ColorApplicator {
    return ApplicatorFunc(func(s string) string {
        return rgbterm.FgString(s, uint8(id), uint8(id>>8), uint8(id>>16))
    }
}
```
