### PR TITLE
Bugfix/clear context when release entry

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -97,6 +97,7 @@ func (logger *Logger) newEntry() *Entry {
 
 func (logger *Logger) releaseEntry(entry *Entry) {
 	entry.Data = map[string]interface{}{}
+	entry.Context = nil
 	logger.entryPool.Put(entry)
 }
 

--- a/logger.go
+++ b/logger.go
@@ -97,7 +97,6 @@ func (logger *Logger) newEntry() *Entry {
 
 func (logger *Logger) releaseEntry(entry *Entry) {
 	entry.Data = map[string]interface{}{}
-	entry.Context = nil
 	logger.entryPool.Put(entry)
 }
 


### PR DESCRIPTION
Clear context when release entry to pool.

If the context is set and there are hooks which use the context,  release entry to pool with context  may cause error when entry is used in the later.