### PR TITLE
clear context when get entry from pool

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -90,6 +90,7 @@ func New() *Logger {
 func (logger *Logger) newEntry() *Entry {
 	entry, ok := logger.entryPool.Get().(*Entry)
 	if ok {
+		entry.Context = nil
 		return entry
 	}
 	return NewEntry(logger)


### PR DESCRIPTION
The Logger.WithContext method release the entry with context to the pool. If this entry is reused and context is used for hooks, this may cause error.