### PR TITLE
return new entry for Entry.WithContext

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -103,8 +103,7 @@ func (entry *Entry) WithError(err error) *Entry {
 
 // Add a context to the Entry.
 func (entry *Entry) WithContext(ctx context.Context) *Entry {
-	entry.Context = ctx
-	return entry
+	return &Entry{Logger: entry.Logger, Data: entry.Data, Time: entry.Time, err: entry.err, Context: ctx}
 }
 
 // Add a single field to the Entry.


### PR DESCRIPTION
Just like Entry.WithError,  Entry.WithField and Entry.WithFields, return a new entry for Entry.WithContext. If we don't return a new entry, the old entry with context will be released to entry pool, this may cause some unexpected errors. 