### PR TITLE
Rename gray -> white

### DIFF
--- a/entry_test.go
+++ b/entry_test.go
@@ -162,8 +162,8 @@ func TestEntryLogfLevel(t *testing.T) {
 	entry := NewEntry(logger)
 
 	entry.Logf(DebugLevel, "%s", "debug")
-	assert.NotContains(t, buffer.String(), "debug", )
+	assert.NotContains(t, buffer.String(), "debug")
 
 	entry.Logf(WarnLevel, "%s", "warn")
-	assert.Contains(t, buffer.String(), "warn", )
+	assert.Contains(t, buffer.String(), "warn")
 }

--- a/terminal_check_bsd.go
+++ b/terminal_check_bsd.go
@@ -10,4 +10,3 @@ func isTerminal(fd int) bool {
 	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	return err == nil
 }
-

--- a/terminal_check_unix.go
+++ b/terminal_check_unix.go
@@ -10,4 +10,3 @@ func isTerminal(fd int) bool {
 	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	return err == nil
 }
-

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -15,7 +15,7 @@ const (
 	red    = 31
 	yellow = 33
 	blue   = 36
-	gray   = 37
+	white  = 37
 )
 
 var baseTimestamp time.Time
@@ -211,7 +211,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 	var levelColor int
 	switch entry.Level {
 	case DebugLevel, TraceLevel:
-		levelColor = gray
+		levelColor = white
 	case WarnLevel:
 		levelColor = yellow
 	case ErrorLevel, FatalLevel, PanicLevel:


### PR DESCRIPTION
`<ESC>[37m` is originally called "white".

- https://www.ecma-international.org/publications/standards/Ecma-048.htm
- https://www.google.com/search?q=ANSI+X3.64+gray+white
