### PR TITLE
Do not assume no color on windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changed:
   * Improve TextFormatter performance and reduce allocations.
   * Optimize Entry hot paths (including WithError and caller reporting).
   * TextFormatter now renders `[]byte` values as raw/quoted strings instead of slice-of-ints.
+  * TextFormatter now automatically enables colors on Windows terminals with ANSI support,
+    matching the behavior on other platforms.
 
 Performance:
   * ~17% geomean runtime improvement and ~26% throughput increase overall.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Changed:
   * Improve TextFormatter performance and reduce allocations.
   * Optimize Entry hot paths (including WithError and caller reporting).
   * TextFormatter now renders `[]byte` values as raw/quoted strings instead of slice-of-ints.
+  * TextFormatter now automatically enables colors on Windows terminals with ANSI support,
+    matching the behavior on other platforms.
   * `Entry.HasCaller` is now deprecated in favor of checking `Entry.Caller` directly.
   * Deprecated `MutexWrap`, which was unintentionally exposed as public API.
     It remains available as an alias for compatibility but should not be used

--- a/README.md
+++ b/README.md
@@ -354,18 +354,20 @@ Splunk or Logstash.
 
 The built-in logging formatters are:
 
-* `logrus.TextFormatter`. Logs the event in colors if stdout is a tty, otherwise
-  without colors.
-  * *Note:* to force colored output when there is no TTY, set the `ForceColors`
+* [`logrus.TextFormatter`](https://pkg.go.dev/github.com/sirupsen/logrus#TextFormatter)
+  logs the event in colors if stdout is a TTY, otherwise without colors.
+  * To force colored output when there is no TTY, set the `ForceColors`
     field to `true`.  To force no colored output even if there is a TTY  set the
-    `DisableColors` field to `true`. For Windows, see
-    [github.com/mattn/go-colorable](https://github.com/mattn/go-colorable).
+    `DisableColors` field to `true`.
+  * On modern Windows terminals with ANSI (Virtual Terminal) support, TextFormatter
+    automatically enables colored output. If your environment does not support ANSI
+    escape sequences, [github.com/mattn/go-colorable](https://github.com/mattn/go-colorable)
+    can be used as a compatibility layer.
   * When colors are enabled, levels are truncated to 4 characters by default. To disable
     truncation set the `DisableLevelTruncation` field to `true`.
   * When outputting to a TTY, it's often helpful to visually scan down a column where all the levels are the same width. Setting the `PadLevelText` field to `true` enables this behavior, by adding padding to the level text.
-  * All options are listed in the [generated docs](https://pkg.go.dev/github.com/sirupsen/logrus#TextFormatter).
-* `logrus.JSONFormatter`. Logs fields as JSON.
-  * All options are listed in the [generated docs](https://pkg.go.dev/github.com/sirupsen/logrus#JSONFormatter).
+* [`logrus.JSONFormatter`](https://pkg.go.dev/github.com/sirupsen/logrus#JSONFormatter)
+  logs fields as JSON.
 
 Third-party logging formatters:
 

--- a/README.md
+++ b/README.md
@@ -348,18 +348,21 @@ Splunk or Logstash.
 
 The built-in logging formatters are:
 
-* `logrus.TextFormatter`. Logs the event in colors if stdout is a tty, otherwise
-  without colors.
-  * *Note:* to force colored output when there is no TTY, set the `ForceColors`
+* [`logrus.TextFormatter`](https://pkg.go.dev/github.com/sirupsen/logrus#TextFormatter)
+  logs the event in colors if the logger output is a TTY, otherwise without colors.
+  * To force colored output when there is no TTY, set the `ForceColors`
     field to `true`.  To force no colored output even if there is a TTY  set the
-    `DisableColors` field to `true`. For Windows, see
-    [github.com/mattn/go-colorable](https://github.com/mattn/go-colorable).
+    `DisableColors` field to `true`.
+  * On modern Windows terminals with ANSI (Virtual Terminal) support, TextFormatter
+    automatically enables colored output.
+  * If your environment does not support ANSI escape sequences, wrap the logger output
+    using [github.com/mattn/go-colorable](https://github.com/mattn/go-colorable)
+    and set `ForceColors` (or `CLICOLOR_FORCE=1`) to enable colors through the wrapper.
   * When colors are enabled, levels are truncated to 4 characters by default. To disable
     truncation set the `DisableLevelTruncation` field to `true`.
   * When outputting to a TTY, it's often helpful to visually scan down a column where all the levels are the same width. Setting the `PadLevelText` field to `true` enables this behavior, by adding padding to the level text.
-  * All options are listed in the [generated docs](https://pkg.go.dev/github.com/sirupsen/logrus#TextFormatter).
-* `logrus.JSONFormatter`. Logs fields as JSON.
-  * All options are listed in the [generated docs](https://pkg.go.dev/github.com/sirupsen/logrus#JSONFormatter).
+* [`logrus.JSONFormatter`](https://pkg.go.dev/github.com/sirupsen/logrus#JSONFormatter)
+  logs fields as JSON.
 
 Third-party logging formatters:
 

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -125,7 +125,7 @@ func (f *TextFormatter) isColored(isTerminal bool) bool {
 		return false
 	}
 
-	colored := f.ForceColors || (isTerminal && (runtime.GOOS != "windows"))
+	colored := f.ForceColors || isTerminal
 	if !f.EnvironmentOverrideColors {
 		return colored
 	}

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -503,16 +503,10 @@ func TestTextFormatterIsColored(t *testing.T) {
 				EnvironmentOverrideColors: len(tc.envVars) > 0,
 			}
 
-			expected := tc.expected
-			if runtime.GOOS == "windows" && !tc.forceColors && os.Getenv("CLICOLOR_FORCE") == "" {
-				// On Windows, without ForceColors or CLICOLOR_FORCE, colors are disabled.
-				expected = false
-			}
-
 			// TODO(thaJeztah): need a way to mock "isTerminal" and check "isColored" for testing
 			//  without depending on non-exported methods and fields.
 			res := tf.isColored(tc.isTerminal) // tc.isTerminal avoids depending on a real TTY
-			assert.Equal(t, expected, res)
+			assert.Equal(t, tc.expected, res)
 		})
 	}
 }
@@ -573,9 +567,6 @@ func TestCustomSorting(t *testing.T) {
 //
 // regression test for https://github.com/sirupsen/logrus/issues/1298
 func TestCustomSorting_FirstFormat(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("colored output not supported on Windows")
-	}
 	if !checkIfTerminal(os.Stderr) {
 		if runtime.Compiler == "tinygo" {
 			// TinyGo currently (v0.41.1) doesn't support t.Skip (SkipNow is incomplete, requires runtime.Goexit())


### PR DESCRIPTION
recent windows 10 can support colour (it is even enabled in logrus)
however the default formatter does not use colour and so the default log
format is different on windows to other OSes when logging to the
terminal.  This removed the hard code no colour for windows terminals to
be consistent with other OSes

fixes #763