### PR TITLE
Add a checkTerminal for nacl to support running on play.golang.org

### DIFF
--- a/terminal_check_nacl.go
+++ b/terminal_check_nacl.go
@@ -1,0 +1,11 @@
+// +build nacl
+
+package logrus
+
+import (
+	"io"
+)
+
+func checkIfTerminal(w io.Writer) bool {
+	return false
+}

--- a/terminal_check_notappengine.go
+++ b/terminal_check_notappengine.go
@@ -1,4 +1,4 @@
-// +build !appengine,!js,!windows
+// +build !appengine,!js,!windows,!nacl
 
 package logrus
 


### PR DESCRIPTION
Hi :wave: 

[Golang's playground](https://play.golang.org) now supports importing third party libraries, see golang/go#31944

This PR aims to make logrus importable in play.golang.org.

Right now it gives the following error (https://play.golang.org/p/OYWKTdH6gs5):
```
/tmp/gopath845995901/pkg/mod/github.com/sirupsen/logrus@v1.4.1/terminal_check_notappengine.go:13:10: undefined: isTerminal
```

I based my PR on the `checkTerminal` which was added for `GOOS=js`.

In order to validate my PR, I tagged [a modified version on my fork](https://github.com/nlepage/logrus/releases/tag/v1.4.2), which works fine on the playground: https://play.golang.org/p/dase3hMOp2r

Thanks in advance for your review.