### PR TITLE
Fix output coloring for terminals on windows

### DIFF
--- a/terminal_check_windows.go
+++ b/terminal_check_windows.go
@@ -10,11 +10,12 @@ import (
 	sequences "github.com/konsorten/go-windows-terminal-sequences"
 )
 
-func initTerminal(w io.Writer) {
+func initTerminal(w io.Writer) error {
 	switch v := w.(type) {
 	case *os.File:
-		sequences.EnableVirtualTerminalProcessing(syscall.Handle(v.Fd()), true)
+		return sequences.EnableVirtualTerminalProcessing(syscall.Handle(v.Fd()), true)
 	}
+	return nil
 }
 
 func checkIfTerminal(w io.Writer) bool {
@@ -28,7 +29,7 @@ func checkIfTerminal(w io.Writer) bool {
 		ret = false
 	}
 	if ret {
-		initTerminal(w)
+		ret = (initTerminal(w) == nil)
 	}
 	return ret
 }

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -88,7 +88,7 @@ func (f *TextFormatter) init(entry *Entry) {
 }
 
 func (f *TextFormatter) isColored() bool {
-	isColored := f.ForceColors || (f.isTerminal && (runtime.GOOS != "windows"))
+	isColored := f.ForceColors || f.isTerminal
 
 	if f.EnvironmentOverrideColors {
 		if force, ok := os.LookupEnv("CLICOLOR_FORCE"); ok && force != "0" {

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -444,11 +443,7 @@ func TestTextFormatterIsColored(t *testing.T) {
 				os.Setenv("CLICOLOR_FORCE", val.clicolorForceVal)
 			}
 			res := tf.isColored()
-			if runtime.GOOS == "windows" && !tf.ForceColors && !val.clicolorForceIsSet {
-				assert.Equal(subT, false, res)
-			} else {
-				assert.Equal(subT, val.expectedResult, res)
-			}
+			assert.Equal(subT, val.expectedResult, res)
 		})
 	}
 }


### PR DESCRIPTION
Recent versions of Windows support ANSI VT100 escape codes to e.g. allow
changing color of output. This support must be opted into by a call to
SetConsoleMode with ENABLE_VIRTUAL_TERMINAL_PROCESSING. Logrus already
has code to make this call (via the sequences package in
terminal_check_windows.go). However, color was never used due to the
check for Windows in text_formatter.go. This check was added due to the
possibility of running on old versions of Windows which don't support
this new console mode.

This change resolves these issues by attempting to set the console mode,
if it fails, we return false from checkIfTerminal, which will cause
colored output to not be used. This should allow color to work properly
on new versions of Windows, without affecting behavior on older
versions.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>