### PR TITLE
Add DisableEscapeHTML parameter to JSONFormatter

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -51,6 +51,9 @@ type JSONFormatter struct {
 
 	// PrettyPrint will indent all json logs
 	PrettyPrint bool
+
+	// DisableEscapeHTML allows disabling HTML escape.
+	DisableEscapeHTML bool
 }
 
 // Format renders a single log entry
@@ -110,6 +113,9 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	}
 
 	encoder := json.NewEncoder(b)
+	if f.DisableEscapeHTML {
+		encoder.SetEscapeHTML(false)
+	}
 	if f.PrettyPrint {
 		encoder.SetIndent("", "  ")
 	}

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -344,3 +344,32 @@ func TestJSONEnableTimestamp(t *testing.T) {
 		t.Error("Timestamp not present", s)
 	}
 }
+
+func TestJSONDisableEscapeHTML(t *testing.T) {
+	formatter := &JSONFormatter{
+		DisableEscapeHTML: true,
+	}
+
+	b, err := formatter.Format(WithField("xml", "<xml>&</xml>"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "<xml>&</xml>") {
+		t.Error("Raw keyword does not find", s)
+	}
+}
+
+func TestJSONEnableEscapeHTML(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	b, err := formatter.Format(WithField("xml", "<xml>&</xml>"))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	escaped := `\u003cxml\u003e\u0026\u003c/xml\u003e` // same `<xml>&</xml>`
+	if !strings.Contains(s, escaped) {
+		t.Error("Escaped keyword does not find", s)
+	}
+}


### PR DESCRIPTION
Hi!

I use logrus, but http request and response xml is escaped by json encoder.
So, i add this parameter.

Logging sample.

1. `DisableEscapeHTML`=`false` or `default`
```text
{"level":"panic","msg":"","time":"0001-01-01T00:00:00Z","xml":"\u003cxml\u003e\u0026\u003c/xml\u003e"}
```

2. `DisableEscapeHTML`=`true`
```text
{"level":"panic","msg":"","time":"0001-01-01T00:00:00Z","xml":"<xml>&</xml>"}
```

Thank you!