### PR TITLE
add logatee test package

### DIFF
--- a/logatee/README.md
+++ b/logatee/README.md
@@ -1,0 +1,40 @@
+# Logatee
+A timid logrus. Useful for testing code that uses logrus instances.
+
+# Usage
+Logatee will only help with code that injects a `*logrus.Logger`. To test with logatee, simply call `logatee.New(t)` to get a `*logrus.Logger` instance, and then pass it to your service under test. Logatee will group your log output with each test, and allow you to inspect what your service logged from your tests.
+
+```golang
+func TestMyService(t *testing.T) {
+    logger := logatee.New(t)
+    svc := NewMyService(logger)
+    svc.DoSomeThings()
+
+    // All logs from svc.DoSomeThings() will be written to
+    // test output. Use go test -v to see logs for passing tests.
+
+    logs := logatee.Logs(logger) 
+    // logs has each logrus.Entry that was sent to logger. inspect it
+    // to check that your error handling is doing the right thing. 
+
+    // Before testing anything else that re-uses logger, reset its log 
+    // count.
+    logatee.Reset(logger)
+}
+```
+
+# Test Suites
+Logatee is designed to play nicely with test [suites](https://godoc.org/github.com/stretchr/testify/suite). Use `logatee.NewFunc` to ensure that tests are always grouped correctly with suite-based tests.
+
+```golang
+func (suite *TestSuite) SetupSuite() {
+    // re-use logger throughout all tests in suite
+    logger := logatee.NewFunc(suite.T)
+    suite.logger = logger
+}
+
+func (suite *TestSuite) SetupTest() {
+    // reset the logs for each test
+    logatee.Reset(suite.logger)
+}
+```

--- a/logatee/hook.go
+++ b/logatee/hook.go
@@ -1,0 +1,55 @@
+package logatee
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	logs = make(map[*logrus.Logger][]logrus.Entry)
+	lock sync.RWMutex
+)
+
+type hook struct {
+	tFunc  func() *testing.T
+	logger *logrus.Logger
+}
+
+// Levels implements the logrus.Hook interface
+// It returns all levels
+func (h *hook) Levels() []logrus.Level {
+	var lvls []logrus.Level
+
+	// loop backwards through levels until the uint flips from 0s to 1s
+	for l := uint32(logrus.TraceLevel); l <= uint32(logrus.TraceLevel); l-- {
+		lvls = append(lvls, logrus.Level(l))
+	}
+
+	return lvls
+}
+
+// Fire implements the logrus.Hook interface
+// It saves the entry to a list associated with the logger
+func (h *hook) Fire(e *logrus.Entry) error {
+	lock.Lock()
+	defer lock.Unlock()
+	logs[h.logger] = append(logs[h.logger], *e)
+	return nil
+}
+
+// Logs returns all entries that were written through logger
+func Logs(logger *logrus.Logger) []logrus.Entry {
+	lock.RLock()
+	defer lock.RUnlock()
+	return logs[logger]
+}
+
+// Reset clears all entries associated with logger. Use it to
+// reset tracking between tests
+func Reset(logger *logrus.Logger) {
+	lock.Lock()
+	defer lock.Unlock()
+	logs[logger] = nil
+}

--- a/logatee/logatee.go
+++ b/logatee/logatee.go
@@ -1,0 +1,36 @@
+package logatee
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func New(t *testing.T) *logrus.Logger {
+	return NewFunc(func() *testing.T {
+		return t
+	})
+}
+
+func NewFunc(tFunc func() *testing.T) *logrus.Logger {
+	log := logrus.New()
+	log.Out = &testWriter{tFunc}
+	log.Level = logrus.TraceLevel
+	log.Hooks.Add(&hook{
+		tFunc:  tFunc,
+		logger: log,
+	})
+
+	return log
+}
+
+type testWriter struct {
+	tFunc func() *testing.T
+}
+
+func (w *testWriter) Write(b []byte) (int, error) {
+	w.tFunc().Helper()
+	w.tFunc().Log(string(b))
+
+	return len(b), nil
+}

--- a/logatee/logatee_test.go
+++ b/logatee/logatee_test.go
@@ -1,0 +1,76 @@
+package logatee_test
+
+import (
+	"testing"
+
+	"github.com/itzamna314/logrus/logatee"
+	"github.com/sirupsen/logrus"
+)
+
+func TestLogatee(t *testing.T) {
+	logger := logatee.New(t)
+	logger.WithFields(logrus.Fields{
+		"speed": "3 km/h",
+		"depth": "6m",
+	}).Trace("swimming")
+
+	logger.WithFields(logrus.Fields{
+		"animal":   "logatee",
+		"diet":     "seaweed",
+		"nickname": "sea cow",
+	}).Info("hi guys! i'm the logatee!")
+
+	logs := logatee.Logs(logger)
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs, but found %d", len(logs))
+	}
+
+	ok := logs[0].Message == "swimming"
+	ok = ok && logs[0].Level == logrus.TraceLevel
+	ok = ok && len(logs[0].Data) == 2
+	if ok {
+		ok = ok && logs[0].Data["speed"] == "3 km/h"
+		ok = ok && logs[0].Data["depth"] == "6m"
+	}
+	if !ok {
+		t.Errorf("unexpected logs[0]: %#v", logs[0])
+	}
+
+	ok = logs[1].Message == "hi guys! i'm the logatee!"
+	ok = ok && logs[1].Level == logrus.InfoLevel
+	ok = ok && len(logs[1].Data) == 3
+	if ok {
+		ok = ok && logs[1].Data["animal"] == "logatee"
+		ok = ok && logs[1].Data["diet"] == "seaweed"
+		ok = ok && logs[1].Data["nickname"] == "sea cow"
+	}
+	if !ok {
+		t.Errorf("unexpected logs[1]: %#v", logs[1])
+	}
+
+	logatee.Reset(logger)
+	logs = logatee.Logs(logger)
+	if len(logs) != 0 {
+		t.Fatalf("expected 0 logs after reset, but found %d", len(logs))
+	}
+
+	logger.WithFields(logrus.Fields{
+		"cause": "propeller",
+	}).Error("ow")
+
+	logs = logatee.Logs(logger)
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log after reset and log, but found %d", len(logs))
+	}
+
+	ok = logs[0].Message == "ow"
+	ok = ok && logs[0].Level == logrus.ErrorLevel
+	ok = ok && len(logs[0].Data) == 1
+	if ok {
+		ok = ok && logs[0].Data["cause"] == "propeller"
+	}
+
+	if !ok {
+		t.Errorf("unexpected error log: %#v", logs[0])
+	}
+}


### PR DESCRIPTION
I'm not sure where this belongs in logrus, if at all. This is a nice utility package for projects that use `*logrus.Logger` instances. It provides nicely-formatted test output, and makes it easy to inspect log messages from tests. Its been really useful for me.

The tests are failing because the import paths are pointed to my fork. If there's interest in adopting this package I'll clean up the import paths. I'm also open to suggestions of somewhere else where this utility could live.