### PR TITLE
Fixed ineffectual assignment in test

### DIFF
--- a/logrus_test.go
+++ b/logrus_test.go
@@ -539,7 +539,7 @@ func TestParseLevel(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, TraceLevel, l)
 
-	l, err = ParseLevel("invalid")
+	_, err = ParseLevel("invalid")
 	assert.Equal(t, "not a valid logrus Level: \"invalid\"", err.Error())
 }
 


### PR DESCRIPTION
Don't assign l if it's not being checked/used afterwards.