### PR TITLE
Add a getter for the Entry.err

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -201,6 +201,11 @@ func (entry Entry) HasCaller() (has bool) {
 		entry.Caller != nil
 }
 
+// Err returns an internal field formatting error.
+func (entry *Entry) Err() string {
+	return entry.err
+}
+
 // This function is not declared with a pointer value because otherwise
 // race conditions will occur when using multiple goroutines
 func (entry Entry) log(level Level, msg string) {

--- a/entry_test.go
+++ b/entry_test.go
@@ -139,19 +139,25 @@ func TestEntryWithIncorrectField(t *testing.T) {
 	eWithFuncPtr := e.WithFields(Fields{"funcPtr": &fn})
 
 	assert.Equal(eWithFunc.err, `can not add field "func"`)
+	assert.Equal(eWithFunc.err, eWithFunc.Err())
 	assert.Equal(eWithFuncPtr.err, `can not add field "funcPtr"`)
+	assert.Equal(eWithFuncPtr.err, eWithFuncPtr.Err())
 
 	eWithFunc = eWithFunc.WithField("not_a_func", "it is a string")
 	eWithFuncPtr = eWithFuncPtr.WithField("not_a_func", "it is a string")
 
 	assert.Equal(eWithFunc.err, `can not add field "func"`)
+	assert.Equal(eWithFunc.err, eWithFunc.Err())
 	assert.Equal(eWithFuncPtr.err, `can not add field "funcPtr"`)
+	assert.Equal(eWithFuncPtr.err, eWithFuncPtr.Err())
 
 	eWithFunc = eWithFunc.WithTime(time.Now())
 	eWithFuncPtr = eWithFuncPtr.WithTime(time.Now())
 
 	assert.Equal(eWithFunc.err, `can not add field "func"`)
+	assert.Equal(eWithFunc.err, eWithFunc.Err())
 	assert.Equal(eWithFuncPtr.err, `can not add field "funcPtr"`)
+	assert.Equal(eWithFuncPtr.err, eWithFuncPtr.Err())
 }
 
 func TestEntryLogfLevel(t *testing.T) {


### PR DESCRIPTION
Hello!

I want to implement my Formatter and for this I need access to the `Entry.err` field. 
But, unfortunately, this is not possible now, since this field is private.

I ended up adding a getter for this field:
```go
// Err returns an internal field formatting error.
func (entry *Entry) Err() string {
	return entry.err
}
```