### PR TITLE
Field Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,21 @@ requestLogger.Info("something happened on that request") # will log request_id a
 requestLogger.Warn("something not great happened")
 ```
 
+#### Filtering Fields
+
+It might sometimes be required that some fields be filtered out of logs for various reasons.
+For example, one might want to filter out fields that contain empty values.
+
+A `FieldFilter`can be added while instantiating formatters.
+```go
+formatter := &TextFormatter{
+    FieldFilters: []FieldFilter{IgnoreEmptyValueFieldFilter},
+}
+```
+The `TextFormatter` will apply the specified field filters when formatting. 
+`IgnoreEmptyValueFieldFilter` is a field filter that can be used to filter out fields that 
+have empty values.
+
 #### Hooks
 
 You can add hooks for logging levels. For example to send errors to an exception

--- a/entry_test.go
+++ b/entry_test.go
@@ -162,8 +162,8 @@ func TestEntryLogfLevel(t *testing.T) {
 	entry := NewEntry(logger)
 
 	entry.Logf(DebugLevel, "%s", "debug")
-	assert.NotContains(t, buffer.String(), "debug", )
+	assert.NotContains(t, buffer.String(), "debug")
 
 	entry.Logf(WarnLevel, "%s", "warn")
-	assert.Contains(t, buffer.String(), "warn", )
+	assert.Contains(t, buffer.String(), "warn")
 }

--- a/formatter.go
+++ b/formatter.go
@@ -1,6 +1,9 @@
 package logrus
 
-import "time"
+import (
+	"reflect"
+	"time"
+)
 
 // Default key names for the default fields
 const (
@@ -75,4 +78,8 @@ func prefixFieldClashes(data Fields, fieldMap FieldMap, reportCaller bool) {
 			data["fields."+fileKey] = l
 		}
 	}
+}
+
+func ignoreEmptyValueFieldsFilter(_ string, value interface{}) bool {
+	return !(value == nil || reflect.DeepEqual(value, reflect.Zero(reflect.TypeOf(value)).Interface()))
 }

--- a/formatter.go
+++ b/formatter.go
@@ -80,6 +80,12 @@ func prefixFieldClashes(data Fields, fieldMap FieldMap, reportCaller bool) {
 	}
 }
 
-func ignoreEmptyValueFieldsFilter(_ string, value interface{}) bool {
+// FieldFilter represents a filter to be used when adding fields in logs.
+// Returns true if field is to be filtered out.
+type FieldFilter func(string, interface{}) bool
+
+// IgnoreEmptyValueFieldFilter filters out fields that contain empty value.
+// An empty value represents the zero value of the corresponding type.
+func IgnoreEmptyValueFieldFilter(_ string, value interface{}) bool {
 	return !(value == nil || reflect.DeepEqual(value, reflect.Zero(reflect.TypeOf(value)).Interface()))
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestFormattingWithFieldFilters(t *testing.T) {
-	// Text Formatting.
 	textFormatter := &TextFormatter{FieldFilters: []FieldFilter{IgnoreEmptyValueFieldFilter}}
 	jsonFormatter := &JSONFormatter{FieldFilters: []FieldFilter{IgnoreEmptyValueFieldFilter}}
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,37 @@
+package logrus
+
+import (
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormattingWithFieldFilters(t *testing.T) {
+	// Text Formatting.
+	textFormatter := &TextFormatter{FieldFilters: []FieldFilter{IgnoreEmptyValueFieldFilter}}
+	jsonFormatter := &JSONFormatter{FieldFilters: []FieldFilter{IgnoreEmptyValueFieldFilter}}
+
+	entry := &Entry {
+		Message: "Testing field filtering",
+		Time: time.Now(),
+		Level: InfoLevel,
+		Data: Fields{
+			"wantedFieldKey":                  "value",
+			"unwantedFieldKeyWithEmptyStringValue": "",
+			"unwantedFieldKeyWithNilValue":    nil,
+		},
+	}
+
+	testFilteringOfFields := func(formatters ...Formatter) {
+		for _, formatter := range formatters {
+			b, err := formatter.Format(entry)
+			require.NoError(t, err)
+			require.True(t, strings.Contains(string(b), "wantedFieldKey=value"))
+			require.False(t, strings.Contains(string(b), "unwantedFieldKeyWithEmptyStringValue"))
+			require.False(t, strings.Contains(string(b), "unwantedFieldKeyWithNilValue"))
+		}
+	}
+
+	testFilteringOfFields(textFormatter, jsonFormatter)
+}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -26,7 +26,7 @@ func TestFormattingWithFieldFilters(t *testing.T) {
 		for _, formatter := range formatters {
 			b, err := formatter.Format(entry)
 			require.NoError(t, err)
-			require.True(t, strings.Contains(string(b), "wantedFieldKey=value"))
+			require.True(t, strings.Contains(string(b), "wantedFieldKey"))
 			require.False(t, strings.Contains(string(b), "unwantedFieldKeyWithEmptyStringValue"))
 			require.False(t, strings.Contains(string(b), "unwantedFieldKeyWithNilValue"))
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894
 )

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,10 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe h1:CHRGQ8V7OlCYtwaKPJi3iA7J+YdNKdo8j7nG5IgDhjs=
-github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
-github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
-golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -78,6 +78,9 @@ type TextFormatter struct {
 	//         FieldKeyMsg:   "@message"}}
 	FieldMap FieldMap
 
+	// IgnoreFieldsWithEmptyValue will ignore the fields that have empty/nil values.
+	IgnoreFieldsWithEmptyValue bool
+
 	// CallerPrettyfier can be set by the user to modify the content
 	// of the function and file keys in the data when ReportCaller is
 	// activated. If any of the returned value is the empty string the
@@ -123,7 +126,13 @@ func (f *TextFormatter) isColored() bool {
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	data := make(Fields)
 	for k, v := range entry.Data {
-		data[k] = v
+		if f.IgnoreFieldsWithEmptyValue {
+			if ignoreEmptyValueFieldsFilter(k, v) {
+				data[k] = v
+			}
+		} else {
+			data[k] = v
+		}
 	}
 	prefixFieldClashes(data, f.FieldMap, entry.HasCaller())
 	keys := make([]string, 0, len(data))


### PR DESCRIPTION
Allow filtering of fields while formatting.

One might want to filter out some fields based on some criteria. One such criteria might be to not 
include fields with empty values.

Defined `FieldFilter` to be a function that accepts a key (string) and a value (interface{}) and returns boolean indicating whether to allow the field or not.
Return `true` if field should be allowed.
Return `false` if field should be filtered out.

Retrofitted `TextFormatter` and `JSONFormatter` to compose `[]FieldFilter` and use them (if any) while formatting. Included a `FieldFilter` called `IgnoreEmtpyValueFieldFilter` that can be used to filter out fields that have an empty value (zero value).