### PR TITLE
Solaris Build Flags

### DIFF
--- a/terminal_check_bsd.go
+++ b/terminal_check_bsd.go
@@ -1,4 +1,5 @@
 // +build darwin dragonfly freebsd netbsd openbsd
+// +build !js
 
 package logrus
 

--- a/terminal_check_solaris.go
+++ b/terminal_check_solaris.go
@@ -1,3 +1,5 @@
+// +build solaris
+
 package logrus
 
 import (

--- a/terminal_check_solaris.go
+++ b/terminal_check_solaris.go
@@ -1,4 +1,4 @@
-// +build solaris
+// +build solaris,!js
 
 package logrus
 

--- a/terminal_check_unix.go
+++ b/terminal_check_unix.go
@@ -1,4 +1,5 @@
 // +build linux aix
+// +build !js
 
 package logrus
 


### PR DESCRIPTION
If building with `js`, with references to `"golang.org/x/sys/unix"` causes the following compile errors:
```
golang.org/x/sys/unix/fcntl_darwin.go:15:42: undeclared name: Flock_t
golang.org/x/sys/unix/ioctl.go:14:47: undeclared name: Winsize
golang.org/x/sys/unix/ioctl.go:25:47: undeclared name: Termios
golang.org/x/sys/unix/sockcmsg_unix.go:53:18: undeclared name: Cmsghdr
golang.org/x/sys/unix/sockcmsg_unix.go:59:9: undeclared name: Cmsghdr
golang.org/x/sys/unix/sockcmsg_unix.go:80:52: undeclared name: Cmsghdr
golang.org/x/sys/unix/syscall_bsd.go:128:63: undeclared name: Rusage
golang.org/x/sys/unix/syscall_unix.go:193:7: undeclared name: RawSockaddrInet4
golang.org/x/sys/unix/syscall_bsd.go:147:54: undeclared name: _Socklen
golang.org/x/sys/unix/syscall_unix.go:201:9: undeclared name: RawSockaddrInet6
golang.org/x/sys/unix/syscall_unix.go:201:9: too many errors
```

Previously opened the issue: https://github.com/sirupsen/logrus/issues/1014