### PR TITLE
Add terminal_check_js.go file, for compatibility with GopherJS

### DIFF
--- a/terminal_check_bsd.go
+++ b/terminal_check_bsd.go
@@ -1,4 +1,5 @@
 // +build darwin dragonfly freebsd netbsd openbsd
+// +build !js
 
 package logrus
 
@@ -10,4 +11,3 @@ func isTerminal(fd int) bool {
 	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	return err == nil
 }
-

--- a/terminal_check_js.go
+++ b/terminal_check_js.go
@@ -1,0 +1,7 @@
+// +build js
+
+package logrus
+
+func isTerminal(fd int) bool {
+	return false
+}

--- a/terminal_check_unix.go
+++ b/terminal_check_unix.go
@@ -1,4 +1,5 @@
 // +build linux aix
+// +build !js
 
 package logrus
 
@@ -10,4 +11,3 @@ func isTerminal(fd int) bool {
 	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	return err == nil
 }
-


### PR DESCRIPTION
This allows logrus to compile with GopherJS.

The test suite still doesn't work with GopherJS, due to the use of `runtime.Caller()` in the test-specific `getPackage()` method.

If running the test suite against GopherJS is desirable, I suggest doing that in a separate PR (and probably adding it to .travis.yml, too).  I'm happy to take on that task, if it would be considered useful.