### PR TITLE
Clean up travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,6 @@ go: [1.11.x, 1.12.x, 1.13.x]
 os: [linux, osx]
 install:
   - ./travis/install.sh
-  - if [[ "$GO111MODULE" ==  "on" ]]; then go mod download; fi
-  - if [[ "$GO111MODULE" == "off" ]]; then go get \
-    github.com/stretchr/testify/assert \
-    golang.org/x/sys/unix \
-    github.com/konsorten/go-windows-terminal-sequences \
-    github.com/hashicorp/go-version \
-    github.com/hashicorp/go-version; fi
 script:
   - ./travis/cross_build.sh
   - export GOMAXPROCS=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,12 @@ os: [linux, osx]
 install:
   - ./travis/install.sh
   - if [[ "$GO111MODULE" ==  "on" ]]; then go mod download; fi
-  - if [[ "$GO111MODULE" == "off" ]]; then go get github.com/stretchr/testify/assert golang.org/x/sys/unix github.com/konsorten/go-windows-terminal-sequences; fi
+  - if [[ "$GO111MODULE" == "off" ]]; then go get \
+    github.com/stretchr/testify/assert \
+    golang.org/x/sys/unix \
+    github.com/konsorten/go-windows-terminal-sequences \
+    github.com/hashicorp/go-version \
+    github.com/hashicorp/go-version; fi
 script:
   - ./travis/cross_build.sh
   - export GOMAXPROCS=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,6 @@ env:
   - GO111MODULE=off
 go: [1.11.x, 1.12.x, 1.13.x]
 os: [linux, osx]
-matrix:
-  exclude:
-    - go: 1.11.x
-      env: GO111MODULE=off
-    - go: 1.12.x
-      env: GO111MODULE=off
-    - go: 1.13.x
-      env: GO111MODULE=off
 install:
   - ./travis/install.sh
   - if [[ "$GO111MODULE" ==  "on" ]]; then go mod download; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,16 @@ git:
 env:
   - GO111MODULE=on
   - GO111MODULE=off
-go: [ 1.11.x, 1.12.x, 1.13.x ]
-os: [ linux, osx ]
+go: [1.11.x, 1.12.x, 1.13.x]
+os: [linux, osx]
 matrix:
   exclude:
+    - go: 1.11.x
+      env: GO111MODULE=off
     - go: 1.12.x
       env: GO111MODULE=off
-    - go: 1.11.x
-      os: osx
+    - go: 1.13.x
+      env: GO111MODULE=off
 install:
   - ./travis/install.sh
   - if [[ "$GO111MODULE" ==  "on" ]]; then go mod download; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ env:
   - GO111MODULE=off
 go: [1.11.x, 1.12.x, 1.13.x]
 os: [linux, osx]
+matrix:
+  exclude:
+    - go: 1.13.x
+      env: GO111MODULE=off ## Modules are the default now.
 install:
   - ./travis/install.sh
 script:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,10 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe h1:CHRGQ8V7OlCYtwaKPJi3iA7J+YdNKdo8j7nG5IgDhjs=
-github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
-github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
-golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/travis/cross_build.sh
+++ b/travis/cross_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_GO_VERSION" =~ ^1.\12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+if [[ "$TRAVIS_GO_VERSION" =~ ^1\.12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     /tmp/gox/gox -build-lib -all
 fi

--- a/travis/cross_build.sh
+++ b/travis/cross_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_GO_VERSION" =~ ^1\.12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+if [[ "$TRAVIS_GO_VERSION" =~ ^1\.13\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$GO111MODULE" == "on" ]]; then
     $(go env GOPATH)/bin/gox -build-lib
 fi

--- a/travis/cross_build.sh
+++ b/travis/cross_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [[ "$TRAVIS_GO_VERSION" =~ ^1\.12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    /tmp/gox/gox -build-lib -all
+    $(go env GOPATH)/bin/gox -build-lib
 fi

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-if [[ "$TRAVIS_GO_VERSION" =~ ^1\.12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+# Only do this for go1.12 when modules are on so that it doesn't need to be done when modules are off as well.
+if [[ "$TRAVIS_GO_VERSION" =~ ^1\.13\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$GO111MODULE" == "on" ]]; then
     GO111MODULE=off go get github.com/dgsb/gox
 fi
 
@@ -11,5 +12,6 @@ if [[ "$GO111MODULE" ==  "on" ]]; then
 fi
 
 if [[ "$GO111MODULE" == "off" ]]; then
-    go get github.com/stretchr/testify/assert golang.org/x/sys/unix github.com/konsorten/go-windows-terminal-sequences
+    # Should contain all regular (not indirect) modules from go.mod
+    go get github.com/stretchr/testify golang.org/x/sys/unix github.com/konsorten/go-windows-terminal-sequences
 fi

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -9,3 +9,12 @@ if [[ "$TRAVIS_GO_VERSION" =~ ^1\.12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]];
     go build ./
     popd
 fi
+
+if [[ "$GO111MODULE" ==  "on" ]]; then
+    go mod download
+fi
+
+if [[ "$GO111MODULE" == "off" ]]; then
+    go get github.com/stretchr/testify/assert golang.org/x/sys/unix github.com/konsorten/go-windows-terminal-sequences
+    go get github.com/hashicorp/go-version github.com/hashicorp/go-version
+fi

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -3,11 +3,7 @@
 set -e
 
 if [[ "$TRAVIS_GO_VERSION" =~ ^1\.12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    git clone https://github.com/dgsb/gox.git /tmp/gox
-    pushd /tmp/gox
-    git checkout new_master
-    go build ./
-    popd
+    GO111MODULE=off go get github.com/dgsb/gox
 fi
 
 if [[ "$GO111MODULE" ==  "on" ]]; then
@@ -16,5 +12,4 @@ fi
 
 if [[ "$GO111MODULE" == "off" ]]; then
     go get github.com/stretchr/testify/assert golang.org/x/sys/unix github.com/konsorten/go-windows-terminal-sequences
-    go get github.com/hashicorp/go-version github.com/hashicorp/go-version
 fi

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ "$TRAVIS_GO_VERSION" =~ ^1.\12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+if [[ "$TRAVIS_GO_VERSION" =~ ^1\.12\. ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     git clone https://github.com/dgsb/gox.git /tmp/gox
     pushd /tmp/gox
     git checkout new_master


### PR DESCRIPTION
This enables testing for go 1.11.x, 1.12,x, & 1.13.x on linux and osx for both modules on and off (except for go1.13.x where only modules are on).

This also moves the buildall to go1.13.x (instead of go1.12.x) because go1.13.x is the primary supported go version atm.

This also tidy's the mod file.