### PR TITLE
Fix README example log.Info() call

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ func main() {
   // if err == nil {
   //  log.Out = file
   // } else {
-  //  log.Info("Failed to log to file, using default stderr")
+  //  log.Info("Failed to log to file, using default stdout")
   // }
 
   log.WithFields(logrus.Fields{


### PR DESCRIPTION
Update log.Info() call to indicate it is using default stdout (not
stderr) as stdout is set as the output a few lines above and will be
used in the error case here.