### PR TITLE
Fix entry data bleed when using WithContext and WithTime

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -103,7 +103,11 @@ func (entry *Entry) WithError(err error) *Entry {
 
 // Add a context to the Entry.
 func (entry *Entry) WithContext(ctx context.Context) *Entry {
-	return &Entry{Logger: entry.Logger, Data: entry.Data, Time: entry.Time, err: entry.err, Context: ctx}
+	dataCopy := make(Fields, len(entry.Data))
+	for k, v := range entry.Data {
+		dataCopy[k] = v
+	}
+	return &Entry{Logger: entry.Logger, Data: dataCopy, Time: entry.Time, err: entry.err, Context: ctx}
 }
 
 // Add a single field to the Entry.
@@ -144,7 +148,11 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 
 // Overrides the time of the Entry.
 func (entry *Entry) WithTime(t time.Time) *Entry {
-	return &Entry{Logger: entry.Logger, Data: entry.Data, Time: t, err: entry.err, Context: entry.Context}
+	dataCopy := make(Fields, len(entry.Data))
+	for k, v := range entry.Data {
+		dataCopy[k] = v
+	}
+	return &Entry{Logger: entry.Logger, Data: dataCopy, Time: t, err: entry.err, Context: entry.Context}
 }
 
 // getPackageName reduces a fully qualified function name to the package name


### PR DESCRIPTION
Creates a copy of the `Data` map when using `WithContext` to create a
child Entry.  Without this, the data map of the parent Entry,
which is exposed in the Entry struct, is shared between a parent
and all children instances.

This can create bugs of shared or overwritten data when a parent
Entry is used to make children in differing contexts, and behaves
differently than `WithField` and its derivatives which does make
a copy of the `Data` map.

Additionally implements the same logic for `WithTime`, for API
consistency in behavior.