### PR TITLE
Add Audit log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ time="2015-03-26T01:27:38-04:00" level=debug msg="Started observing beach" anima
 time="2015-03-26T01:27:38-04:00" level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
 time="2015-03-26T01:27:38-04:00" level=warning msg="The group's number increased tremendously!" number=122 omg=true
 time="2015-03-26T01:27:38-04:00" level=debug msg="Temperature changes" temperature=-4
+time="2015-03-26T01:27:38-04:00" level=audit msg="It's left the building!" animal=orca location=outside
 time="2015-03-26T01:27:38-04:00" level=panic msg="It's over 9000!" animal=orca size=9009
 time="2015-03-26T01:27:38-04:00" level=fatal msg="The ice breaks!" err=&{0x2082280c0 map[animal:orca size:9009] 2015-03-26 01:27:38.441574009 -0400 EDT panic It's over 9000!} number=100 omg=true
 ```
+
 To ensure this behaviour even if a TTY is attached, set your formatter as follows:
 
 ```go
@@ -64,26 +66,34 @@ To ensure this behaviour even if a TTY is attached, set your formatter as follow
 #### Logging Method Name
 
 If you wish to add the calling method as a field, instruct the logger via:
+
 ```go
 log.SetReportCaller(true)
 ```
+
 This adds the caller as 'method' like so:
 
 ```json
-{"animal":"penguin","level":"fatal","method":"github.com/sirupsen/arcticcreatures.migrate","msg":"a penguin swims by",
-"time":"2014-03-10 19:57:38.562543129 -0400 EDT"}
+{
+  "animal": "penguin",
+  "level": "fatal",
+  "method": "github.com/sirupsen/arcticcreatures.migrate",
+  "msg": "a penguin swims by",
+  "time": "2014-03-10 19:57:38.562543129 -0400 EDT"
+}
 ```
 
 ```text
 time="2015-03-26T01:27:38-04:00" level=fatal method=github.com/sirupsen/arcticcreatures.migrate msg="a penguin swims by" animal=penguin
 ```
+
 Note that this does add measurable overhead - the cost will depend on the version of Go, but is
-between 20 and 40% in recent tests with 1.6 and 1.7.  You can validate this in your
-environment via benchmarks: 
+between 20 and 40% in recent tests with 1.6 and 1.7. You can validate this in your
+environment via benchmarks:
+
 ```
 go test -bench=.*CallerTracing
 ```
-
 
 #### Case-sensitivity
 
@@ -199,8 +209,7 @@ func main() {
 #### Fields
 
 Logrus encourages careful, structured logging through logging fields instead of
-long, unparseable error messages. For example, instead of: `log.Fatalf("Failed
-to send event %s to topic %s with key %d")`, you should log the much more
+long, unparseable error messages. For example, instead of: `log.Fatalf("Failed to send event %s to topic %s with key %d")`, you should log the much more
 discoverable:
 
 ```go
@@ -265,14 +274,14 @@ func init() {
   }
 }
 ```
+
 Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "/var/run/log"). For the detail, please check the [syslog hook README](hooks/syslog/README.md).
 
 A list of currently known service hooks can be found in this wiki [page](https://github.com/sirupsen/logrus/wiki/Hooks)
 
-
 #### Level logging
 
-Logrus has seven logging levels: Trace, Debug, Info, Warning, Error, Fatal and Panic.
+Logrus has eight logging levels: Trace, Debug, Info, Warning, Error, Fatal, Panic, and Audit.
 
 ```go
 log.Trace("Something very low level.")
@@ -284,13 +293,14 @@ log.Error("Something failed but I'm not quitting.")
 log.Fatal("Bye.")
 // Calls panic() after logging
 log.Panic("I'm bailing.")
+log.Audit("Something important happened but it's not an error")
 ```
 
 You can set the logging level on a `Logger`, then it will only log entries with
 that severity or anything above it:
 
 ```go
-// Will log anything that is info or above (warn, error, fatal, panic). Default.
+// Will log anything that is info or above (warn, error, fatal, panic, audit). Default.
 log.SetLevel(log.InfoLevel)
 ```
 
@@ -303,7 +313,7 @@ Besides the fields added with `WithField` or `WithFields` some fields are
 automatically added to all logging events:
 
 1. `time`. The timestamp when the entry was created.
-2. `msg`. The logging message passed to `{Info,Warn,Error,Fatal,Panic}` after
+2. `msg`. The logging message passed to `{Info,Warn,Error,Fatal,Panic,Audit}` after
    the `AddFields` call. E.g. `Failed to send event.`
 3. `level`. The logging level. E.g. `info`.
 
@@ -341,28 +351,28 @@ Splunk or Logstash.
 
 The built-in logging formatters are:
 
-* `logrus.TextFormatter`. Logs the event in colors if stdout is a tty, otherwise
+- `logrus.TextFormatter`. Logs the event in colors if stdout is a tty, otherwise
   without colors.
-  * *Note:* to force colored output when there is no TTY, set the `ForceColors`
-    field to `true`.  To force no colored output even if there is a TTY  set the
+  - _Note:_ to force colored output when there is no TTY, set the `ForceColors`
+    field to `true`. To force no colored output even if there is a TTY set the
     `DisableColors` field to `true`. For Windows, see
     [github.com/mattn/go-colorable](https://github.com/mattn/go-colorable).
-  * When colors are enabled, levels are truncated to 4 characters by default. To disable
+  - When colors are enabled, levels are truncated to 4 characters by default. To disable
     truncation set the `DisableLevelTruncation` field to `true`.
-  * When outputting to a TTY, it's often helpful to visually scan down a column where all the levels are the same width. Setting the `PadLevelText` field to `true` enables this behavior, by adding padding to the level text.
-  * All options are listed in the [generated docs](https://godoc.org/github.com/sirupsen/logrus#TextFormatter).
-* `logrus.JSONFormatter`. Logs fields as JSON.
-  * All options are listed in the [generated docs](https://godoc.org/github.com/sirupsen/logrus#JSONFormatter).
+  - When outputting to a TTY, it's often helpful to visually scan down a column where all the levels are the same width. Setting the `PadLevelText` field to `true` enables this behavior, by adding padding to the level text.
+  - All options are listed in the [generated docs](https://godoc.org/github.com/sirupsen/logrus#TextFormatter).
+- `logrus.JSONFormatter`. Logs fields as JSON.
+  - All options are listed in the [generated docs](https://godoc.org/github.com/sirupsen/logrus#JSONFormatter).
 
 Third party logging formatters:
 
-* [`FluentdFormatter`](https://github.com/joonix/log). Formats entries that can be parsed by Kubernetes and Google Container Engine.
-* [`GELF`](https://github.com/fabienm/go-logrus-formatters). Formats entries so they comply to Graylog's [GELF 1.1 specification](http://docs.graylog.org/en/2.4/pages/gelf.html).
-* [`logstash`](https://github.com/bshuster-repo/logrus-logstash-hook). Logs fields as [Logstash](http://logstash.net) Events.
-* [`prefixed`](https://github.com/x-cray/logrus-prefixed-formatter). Displays log entry source along with alternative layout.
-* [`zalgo`](https://github.com/aybabtme/logzalgo). Invoking the P͉̫o̳̼̊w̖͈̰͎e̬͔̭͂r͚̼̹̲ ̫͓͉̳͈ō̠͕͖̚f̝͍̠ ͕̲̞͖͑Z̖̫̤̫ͪa͉̬͈̗l͖͎g̳̥o̰̥̅!̣͔̲̻͊̄ ̙̘̦̹̦.
-* [`nested-logrus-formatter`](https://github.com/antonfisher/nested-logrus-formatter). Converts logrus fields to a nested structure.
-* [`powerful-logrus-formatter`](https://github.com/zput/zxcTool). get fileName, log's line number and the latest function's name when print log; Sava log to files.
+- [`FluentdFormatter`](https://github.com/joonix/log). Formats entries that can be parsed by Kubernetes and Google Container Engine.
+- [`GELF`](https://github.com/fabienm/go-logrus-formatters). Formats entries so they comply to Graylog's [GELF 1.1 specification](http://docs.graylog.org/en/2.4/pages/gelf.html).
+- [`logstash`](https://github.com/bshuster-repo/logrus-logstash-hook). Logs fields as [Logstash](http://logstash.net) Events.
+- [`prefixed`](https://github.com/x-cray/logrus-prefixed-formatter). Displays log entry source along with alternative layout.
+- [`zalgo`](https://github.com/aybabtme/logzalgo). Invoking the P͉̫o̳̼̊w̖͈̰͎e̬͔̭͂r͚̼̹̲ ̫͓͉̳͈ō̠͕͖̚f̝͍̠ ͕̲̞͖͑Z̖̫̤̫ͪa͉̬͈̗l͖͎g̳̥o̰̥̅!̣͔̲̻͊̄ ̙̘̦̹̦.
+- [`nested-logrus-formatter`](https://github.com/antonfisher/nested-logrus-formatter). Converts logrus fields to a nested structure.
+- [`powerful-logrus-formatter`](https://github.com/zput/zxcTool). get fileName, log's line number and the latest function's name when print log; Sava log to files.
 
 You can define your formatter by implementing the `Formatter` interface,
 requiring a `Format` method. `Format` takes an `*Entry`. `entry.Data` is a
@@ -425,17 +435,17 @@ entries. It should not be a feature of the application-level logger.
 
 #### Tools
 
-| Tool | Description |
-| ---- | ----------- |
-|[Logrus Mate](https://github.com/gogap/logrus_mate)|Logrus mate is a tool for Logrus to manage loggers, you can initial logger's level, hook and formatter by config file, the logger will be generated with different configs in different environments.|
-|[Logrus Viper Helper](https://github.com/heirko/go-contrib/tree/master/logrusHelper)|An Helper around Logrus to wrap with spf13/Viper to load configuration with fangs! And to simplify Logrus configuration use some behavior of [Logrus Mate](https://github.com/gogap/logrus_mate). [sample](https://github.com/heirko/iris-contrib/blob/master/middleware/logrus-logger/example) |
+| Tool                                                                                 | Description                                                                                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Logrus Mate](https://github.com/gogap/logrus_mate)                                  | Logrus mate is a tool for Logrus to manage loggers, you can initial logger's level, hook and formatter by config file, the logger will be generated with different configs in different environments.                                                                                           |
+| [Logrus Viper Helper](https://github.com/heirko/go-contrib/tree/master/logrusHelper) | An Helper around Logrus to wrap with spf13/Viper to load configuration with fangs! And to simplify Logrus configuration use some behavior of [Logrus Mate](https://github.com/gogap/logrus_mate). [sample](https://github.com/heirko/iris-contrib/blob/master/middleware/logrus-logger/example) |
 
 #### Testing
 
 Logrus has a built in facility for asserting the presence of log messages. This is implemented through the `test` hook and provides:
 
-* decorators for existing logger (`test.NewLocal` and `test.NewGlobal`) which basically just adds the `test` hook
-* a test logger (`test.NewNullLogger`) that just records log messages (and does not output any):
+- decorators for existing logger (`test.NewLocal` and `test.NewGlobal`) which basically just adds the `test` hook
+- a test logger (`test.NewNullLogger`) that just records log messages (and does not output any):
 
 ```go
 import(
@@ -481,12 +491,12 @@ If you are sure such locking is not needed, you can call logger.SetNoLock() to d
 
 Situation when locking is not needed includes:
 
-* You have no hooks registered, or hooks calling is already thread-safe.
+- You have no hooks registered, or hooks calling is already thread-safe.
 
-* Writing to logger.Out is already thread-safe, for example:
+- Writing to logger.Out is already thread-safe, for example:
 
-  1) logger.Out is protected by locks.
+  1. logger.Out is protected by locks.
 
-  2) logger.Out is an os.File handler opened with `O_APPEND` flag, and every write is smaller than 4k. (This allows multi-thread/multi-process writing)
+  2. logger.Out is an os.File handler opened with `O_APPEND` flag, and every write is smaller than 4k. (This allows multi-thread/multi-process writing)
 
      (Refer to http://www.notthewizard.com/2014/06/17/are-files-appends-really-atomic/)

--- a/entry.go
+++ b/entry.go
@@ -46,7 +46,7 @@ var ErrorKey = "error"
 
 // An entry is the final or intermediate Logrus logging entry. It contains all
 // the fields passed with WithField{,s}. It's finally logged when Trace, Debug,
-// Info, Warn, Error, Fatal or Panic is called on it. These objects can be
+// Info, Warn, Error, Fatal, Panic, or Audit is called on it. These objects can be
 // reused and passed around as much as you wish to avoid field duplication.
 type Entry struct {
 	Logger *Logger
@@ -57,14 +57,14 @@ type Entry struct {
 	// Time at which the log entry was created
 	Time time.Time
 
-	// Level the log entry was logged at: Trace, Debug, Info, Warn, Error, Fatal or Panic
+	// Level the log entry was logged at: Trace, Debug, Info, Warn, Error, Fatal, Panic, or Audit
 	// This field will be set on entry firing and the value will be equal to the one in Logger struct field.
 	Level Level
 
 	// Calling method, with package name
 	Caller *runtime.Frame
 
-	// Message passed to Trace, Debug, Info, Warn, Error, Fatal or Panic
+	// Message passed to Trace, Debug, Info, Warn, Error, Fatal, Panic, or Audit
 	Message string
 
 	// When formatter is called in entry.log(), a Buffer may be set to entry
@@ -235,7 +235,7 @@ func (entry Entry) log(level Level, msg string) {
 	// To avoid Entry#log() returning a value that only would make sense for
 	// panic() to use in Entry#Panic(), we avoid the allocation by checking
 	// directly here.
-	if level <= PanicLevel {
+	if level <= PanicLevel && level != AuditLevel {
 		panic(&entry)
 	}
 }
@@ -306,6 +306,10 @@ func (entry *Entry) Panic(args ...interface{}) {
 	panic(fmt.Sprint(args...))
 }
 
+func (entry *Entry) Audit(args ...interface{}) {
+	entry.Log(AuditLevel, args...)
+}
+
 // Entry Printf family functions
 
 func (entry *Entry) Logf(level Level, format string, args ...interface{}) {
@@ -351,6 +355,10 @@ func (entry *Entry) Panicf(format string, args ...interface{}) {
 	entry.Logf(PanicLevel, format, args...)
 }
 
+func (entry *Entry) Auditf(format string, args ...interface{}) {
+	entry.Logf(AuditLevel, format, args...)
+}
+
 // Entry Println family functions
 
 func (entry *Entry) Logln(level Level, args ...interface{}) {
@@ -394,6 +402,10 @@ func (entry *Entry) Fatalln(args ...interface{}) {
 
 func (entry *Entry) Panicln(args ...interface{}) {
 	entry.Logln(PanicLevel, args...)
+}
+
+func (entry *Entry) Auditln(args ...interface{}) {
+	entry.Logln(AuditLevel, args...)
 }
 
 // Sprintlnn => Sprint no newline. This is to get the behavior of how

--- a/entry_test.go
+++ b/entry_test.go
@@ -162,8 +162,21 @@ func TestEntryLogfLevel(t *testing.T) {
 	entry := NewEntry(logger)
 
 	entry.Logf(DebugLevel, "%s", "debug")
-	assert.NotContains(t, buffer.String(), "debug", )
+	assert.NotContains(t, buffer.String(), "debug")
 
 	entry.Logf(WarnLevel, "%s", "warn")
-	assert.Contains(t, buffer.String(), "warn", )
+	assert.Contains(t, buffer.String(), "warn")
+}
+
+func TestEntryAuditDoesNotPanic(t *testing.T) {
+	defer func() {
+		p := recover()
+		assert.Nil(t, p)
+	}()
+
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	entry := NewEntry(logger)
+	entry.WithField("event", "something").Audit("something happened")
+	// if we get this far then it didn't panic
 }

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -62,6 +62,11 @@ func Example_basic() {
 	}).Debug("Temperature changes")
 
 	log.WithFields(logrus.Fields{
+		"animal":   "orca",
+		"location": "outside",
+	}).Audit("It's left the building!")
+
+	log.WithFields(logrus.Fields{
 		"animal": "orca",
 		"size":   9009,
 	}).Panic("It's over 9000!")
@@ -72,6 +77,7 @@ func Example_basic() {
 	// level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
 	// level=warning msg="The group's number increased tremendously!" number=122 omg=true
 	// level=debug msg="Temperature changes" temperature=-4
+	// level=audit msg="It's left the building!" animal=orca location=outside
 	// level=panic msg="It's over 9000!" animal=orca size=9009
 	// level=error msg="The ice breaks!" err_animal=orca err_level=panic err_message="It's over 9000!" err_size=9009 number=100 omg=true
 }

--- a/exported.go
+++ b/exported.go
@@ -64,8 +64,8 @@ func WithContext(ctx context.Context) *Entry {
 // WithField creates an entry from the standard logger and adds a field to
 // it. If you want multiple fields, use `WithFields`.
 //
-// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
-// or Panic on the Entry it returns.
+// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal,
+// Panic, or Audit on the Entry it returns.
 func WithField(key string, value interface{}) *Entry {
 	return std.WithField(key, value)
 }
@@ -74,8 +74,8 @@ func WithField(key string, value interface{}) *Entry {
 // fields to it. This is simply a helper for `WithField`, invoking it
 // once for each field.
 //
-// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
-// or Panic on the Entry it returns.
+// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal,
+// Panic, or Audit on the Entry it returns.
 func WithFields(fields Fields) *Entry {
 	return std.WithFields(fields)
 }
@@ -83,8 +83,8 @@ func WithFields(fields Fields) *Entry {
 // WithTime creats an entry from the standard logger and overrides the time of
 // logs generated with it.
 //
-// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
-// or Panic on the Entry it returns.
+// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal,
+// Panic, or Audit on the Entry it returns.
 func WithTime(t time.Time) *Entry {
 	return std.WithTime(t)
 }
@@ -127,6 +127,11 @@ func Error(args ...interface{}) {
 // Panic logs a message at level Panic on the standard logger.
 func Panic(args ...interface{}) {
 	std.Panic(args...)
+}
+
+// Audit logs a message at level Audit on the standard logger.
+func Audit(args ...interface{}) {
+	std.Audit(args...)
 }
 
 // Fatal logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
@@ -174,6 +179,11 @@ func Panicf(format string, args ...interface{}) {
 	std.Panicf(format, args...)
 }
 
+// Auditf logs a message at level Audit on the standard logger.
+func Auditf(format string, args ...interface{}) {
+	std.Auditf(format, args...)
+}
+
 // Fatalf logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
 func Fatalf(format string, args ...interface{}) {
 	std.Fatalf(format, args...)
@@ -217,6 +227,11 @@ func Errorln(args ...interface{}) {
 // Panicln logs a message at level Panic on the standard logger.
 func Panicln(args ...interface{}) {
 	std.Panicln(args...)
+}
+
+// Auditln logs a message at level Audit on the standard logger.
+func Auditln(args ...interface{}) {
+	std.Auditln(args...)
 }
 
 // Fatalln logs a message at level Fatal on the standard logger then the process will exit with status set to 1.

--- a/hook_test.go
+++ b/hook_test.go
@@ -31,6 +31,7 @@ func (hook *TestHook) Levels() []Level {
 		ErrorLevel,
 		FatalLevel,
 		PanicLevel,
+		AuditLevel,
 	}
 }
 
@@ -64,6 +65,7 @@ func (hook *ModifyHook) Levels() []Level {
 		ErrorLevel,
 		FatalLevel,
 		PanicLevel,
+		AuditLevel,
 	}
 }
 

--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -33,6 +33,8 @@ func (hook *SyslogHook) Fire(entry *logrus.Entry) error {
 	}
 
 	switch entry.Level {
+	case logrus.AuditLevel:
+		return hook.Writer.Crit(line)
 	case logrus.PanicLevel:
 		return hook.Writer.Crit(line)
 	case logrus.FatalLevel:

--- a/level_test.go
+++ b/level_test.go
@@ -39,6 +39,7 @@ func TestLevelUnmarshalText(t *testing.T) {
 
 func TestLevelMarshalText(t *testing.T) {
 	levelStrings := []string{
+		"audit",
 		"panic",
 		"fatal",
 		"error",

--- a/logger.go
+++ b/logger.go
@@ -101,7 +101,7 @@ func (logger *Logger) releaseEntry(entry *Entry) {
 }
 
 // Adds a field to the log entry, note that it doesn't log until you call
-// Debug, Print, Info, Warn, Error, Fatal or Panic. It only creates a log entry.
+// Debug, Print, Info, Warn, Error, Fatal, Panic, or Audit. It only creates a log entry.
 // If you want multiple fields, use `WithFields`.
 func (logger *Logger) WithField(key string, value interface{}) *Entry {
 	entry := logger.newEntry()
@@ -186,6 +186,10 @@ func (logger *Logger) Panicf(format string, args ...interface{}) {
 	logger.Logf(PanicLevel, format, args...)
 }
 
+func (logger *Logger) Auditf(format string, args ...interface{}) {
+	logger.Logf(AuditLevel, format, args...)
+}
+
 func (logger *Logger) Log(level Level, args ...interface{}) {
 	if logger.IsLevelEnabled(level) {
 		entry := logger.newEntry()
@@ -233,6 +237,10 @@ func (logger *Logger) Panic(args ...interface{}) {
 	logger.Log(PanicLevel, args...)
 }
 
+func (logger *Logger) Audit(args ...interface{}) {
+	logger.Log(AuditLevel, args...)
+}
+
 func (logger *Logger) Logln(level Level, args ...interface{}) {
 	if logger.IsLevelEnabled(level) {
 		entry := logger.newEntry()
@@ -278,6 +286,10 @@ func (logger *Logger) Fatalln(args ...interface{}) {
 
 func (logger *Logger) Panicln(args ...interface{}) {
 	logger.Logln(PanicLevel, args...)
+}
+
+func (logger *Logger) Auditln(args ...interface{}) {
+	logger.Logln(AuditLevel, args...)
 }
 
 func (logger *Logger) Exit(code int) {

--- a/logrus.go
+++ b/logrus.go
@@ -24,6 +24,8 @@ func (level Level) String() string {
 // ParseLevel takes a string level and returns the Logrus log level constant.
 func ParseLevel(lvl string) (Level, error) {
 	switch strings.ToLower(lvl) {
+	case "audit":
+		return AuditLevel, nil
 	case "panic":
 		return PanicLevel, nil
 	case "fatal":
@@ -72,6 +74,8 @@ func (level Level) MarshalText() ([]byte, error) {
 		return []byte("fatal"), nil
 	case PanicLevel:
 		return []byte("panic"), nil
+	case AuditLevel:
+		return []byte("audit"), nil
 	}
 
 	return nil, fmt.Errorf("not a valid logrus level %d", level)
@@ -79,6 +83,7 @@ func (level Level) MarshalText() ([]byte, error) {
 
 // A constant exposing all logging levels
 var AllLevels = []Level{
+	AuditLevel,
 	PanicLevel,
 	FatalLevel,
 	ErrorLevel,
@@ -91,9 +96,13 @@ var AllLevels = []Level{
 // These are the different logging levels. You can set the logging level to log
 // on your instance of logger, obtained with `logrus.New()`.
 const (
+	// AuditLevel level, real highest level of severity. Logs. Used for audit messages that
+	// should always be reported but are not errors. Commonly used for hooks to send logs
+	// to security auditing services.
+	AuditLevel Level = iota
 	// PanicLevel level, highest level of severity. Logs and then calls panic with the
 	// message passed to Debug, Info, ...
-	PanicLevel Level = iota
+	PanicLevel
 	// FatalLevel level. Logs and then calls `logger.Exit(1)`. It will exit even if the
 	// logging level is set to Panic.
 	FatalLevel
@@ -149,6 +158,7 @@ type FieldLogger interface {
 	Errorf(format string, args ...interface{})
 	Fatalf(format string, args ...interface{})
 	Panicf(format string, args ...interface{})
+	Auditf(format string, args ...interface{})
 
 	Debug(args ...interface{})
 	Info(args ...interface{})
@@ -158,6 +168,7 @@ type FieldLogger interface {
 	Error(args ...interface{})
 	Fatal(args ...interface{})
 	Panic(args ...interface{})
+	Audit(args ...interface{})
 
 	Debugln(args ...interface{})
 	Infoln(args ...interface{})
@@ -167,6 +178,7 @@ type FieldLogger interface {
 	Errorln(args ...interface{})
 	Fatalln(args ...interface{})
 	Panicln(args ...interface{})
+	Auditln(args ...interface{})
 
 	// IsDebugEnabled() bool
 	// IsInfoEnabled() bool
@@ -174,6 +186,7 @@ type FieldLogger interface {
 	// IsErrorEnabled() bool
 	// IsFatalEnabled() bool
 	// IsPanicEnabled() bool
+	// IsAuditEnabled() bool
 }
 
 // Ext1FieldLogger (the first extension to FieldLogger) is superfluous, it is

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -472,10 +472,19 @@ func TestConvertLevelToString(t *testing.T) {
 	assert.Equal(t, "error", ErrorLevel.String())
 	assert.Equal(t, "fatal", FatalLevel.String())
 	assert.Equal(t, "panic", PanicLevel.String())
+	assert.Equal(t, "audit", AuditLevel.String())
 }
 
 func TestParseLevel(t *testing.T) {
-	l, err := ParseLevel("panic")
+	l, err := ParseLevel("audit")
+	assert.Nil(t, err)
+	assert.Equal(t, AuditLevel, l)
+
+	l, err = ParseLevel("AUDIT")
+	assert.Nil(t, err)
+	assert.Equal(t, AuditLevel, l)
+
+	l, err = ParseLevel("panic")
 	assert.Nil(t, err)
 	assert.Equal(t, PanicLevel, l)
 
@@ -671,7 +680,19 @@ func TestEntryWriter(t *testing.T) {
 
 func TestLogLevelEnabled(t *testing.T) {
 	log := New()
+
+	log.SetLevel(AuditLevel)
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
+	assert.Equal(t, false, log.IsLevelEnabled(PanicLevel))
+	assert.Equal(t, false, log.IsLevelEnabled(FatalLevel))
+	assert.Equal(t, false, log.IsLevelEnabled(ErrorLevel))
+	assert.Equal(t, false, log.IsLevelEnabled(WarnLevel))
+	assert.Equal(t, false, log.IsLevelEnabled(InfoLevel))
+	assert.Equal(t, false, log.IsLevelEnabled(DebugLevel))
+	assert.Equal(t, false, log.IsLevelEnabled(TraceLevel))
+
 	log.SetLevel(PanicLevel)
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(PanicLevel))
 	assert.Equal(t, false, log.IsLevelEnabled(FatalLevel))
 	assert.Equal(t, false, log.IsLevelEnabled(ErrorLevel))
@@ -681,6 +702,7 @@ func TestLogLevelEnabled(t *testing.T) {
 	assert.Equal(t, false, log.IsLevelEnabled(TraceLevel))
 
 	log.SetLevel(FatalLevel)
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(PanicLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(FatalLevel))
 	assert.Equal(t, false, log.IsLevelEnabled(ErrorLevel))
@@ -690,6 +712,8 @@ func TestLogLevelEnabled(t *testing.T) {
 	assert.Equal(t, false, log.IsLevelEnabled(TraceLevel))
 
 	log.SetLevel(ErrorLevel)
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(PanicLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(FatalLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(ErrorLevel))
@@ -699,6 +723,7 @@ func TestLogLevelEnabled(t *testing.T) {
 	assert.Equal(t, false, log.IsLevelEnabled(TraceLevel))
 
 	log.SetLevel(WarnLevel)
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(PanicLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(FatalLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(ErrorLevel))
@@ -708,6 +733,7 @@ func TestLogLevelEnabled(t *testing.T) {
 	assert.Equal(t, false, log.IsLevelEnabled(TraceLevel))
 
 	log.SetLevel(InfoLevel)
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(PanicLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(FatalLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(ErrorLevel))
@@ -717,6 +743,7 @@ func TestLogLevelEnabled(t *testing.T) {
 	assert.Equal(t, false, log.IsLevelEnabled(TraceLevel))
 
 	log.SetLevel(DebugLevel)
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(PanicLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(FatalLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(ErrorLevel))
@@ -726,6 +753,7 @@ func TestLogLevelEnabled(t *testing.T) {
 	assert.Equal(t, false, log.IsLevelEnabled(TraceLevel))
 
 	log.SetLevel(TraceLevel)
+	assert.Equal(t, true, log.IsLevelEnabled(AuditLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(PanicLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(FatalLevel))
 	assert.Equal(t, true, log.IsLevelEnabled(ErrorLevel))

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	red    = 31
-	yellow = 33
-	blue   = 36
-	gray   = 37
+	nocolor = 0
+	red     = 31
+	yellow  = 33
+	blue    = 36
+	gray    = 37
 )
 
 var baseTimestamp time.Time
@@ -231,6 +232,8 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 		levelColor = yellow
 	case ErrorLevel, FatalLevel, PanicLevel:
 		levelColor = red
+	case AuditLevel:
+		levelColor = nocolor
 	default:
 		levelColor = blue
 	}

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -22,7 +22,7 @@ func TestFormatting(t *testing.T) {
 		value    string
 		expected string
 	}{
-		{`foo`, "time=\"0001-01-01T00:00:00Z\" level=panic test=foo\n"},
+		{`foo`, "time=\"0001-01-01T00:00:00Z\" level=audit test=foo\n"},
 	}
 
 	for _, tc := range testCases {
@@ -190,6 +190,11 @@ func TestPadLevelText(t *testing.T) {
 		level           Level
 		paddedLevelText string
 	}{
+		{
+			name:            "AuditLevel",
+			level:           AuditLevel,
+			paddedLevelText: "AUDIT  ", // 2 extra spaces
+		},
 		{
 			name:            "PanicLevel",
 			level:           PanicLevel,

--- a/writer.go
+++ b/writer.go
@@ -44,6 +44,8 @@ func (entry *Entry) WriterLevel(level Level) *io.PipeWriter {
 		printFunc = entry.Fatal
 	case PanicLevel:
 		printFunc = entry.Panic
+	case AuditLevel:
+		printFunc = entry.Audit
 	default:
 		printFunc = entry.Print
 	}


### PR DESCRIPTION
Audit logs are intended for security audits -- things you want to log all the time that are not errors.

Hoping other people will find this useful.