### PR TITLE
Allow HTML escaping to be disabled in JSONFormatter

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -25,8 +25,11 @@ type JSONFormatter struct {
 	// TimestampFormat sets the format used for marshaling timestamps.
 	TimestampFormat string
 
-	// DisableTimestamp allows disabling automatic timestamps in output
+	// DisableTimestamp allows disabling automatic timestamps in output.
 	DisableTimestamp bool
+
+	// DisableHTMLEscape allows disabling of HTML escaping in output.
+	DisableHTMLEscape bool
 
 	// DataKey allows users to put all the log entry parameters into a nested dictionary at a given key.
 	DataKey string
@@ -113,6 +116,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	if f.PrettyPrint {
 		encoder.SetIndent("", "  ")
 	}
+	encoder.SetEscapeHTML(!f.DisableHTMLEscape)
 	if err := encoder.Encode(data); err != nil {
 		return nil, fmt.Errorf("failed to marshal fields to JSON, %v", err)
 	}

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -344,3 +344,28 @@ func TestJSONEnableTimestamp(t *testing.T) {
 		t.Error("Timestamp not present", s)
 	}
 }
+func TestJSONDisableHTMLEscape(t *testing.T) {
+	formatter := &JSONFormatter{}
+	entry := WithField("key", "<value>")
+
+	// HTMLEscape is enabled by default.
+	b, err := formatter.Format(entry)
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "\\u003cvalue\\u003e") {
+		t.Fatal("Expected JSON to escape HTML")
+	}
+
+	// HTMLEscape can be disabled.
+	formatter.DisableHTMLEscape = true
+	b, err = formatter.Format(entry)
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s = string(b)
+	if !strings.Contains(s, "<value>") {
+		t.Fatal("Expected JSON to not escape HTML")
+	}
+}


### PR DESCRIPTION
This code change allows users of JSONFormatter to disable HTML escaping. A test was also added.