### PR TITLE
Merging AddSkipPackageFromStackTrace API

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -16,7 +16,6 @@ var (
 	bufferPool *sync.Pool
 
 	// qualified package name, cached at first use
-	//logrusPackage string
 	skipPackageNameForCaller = make(map[string]struct{}, 1)
 
 	// Positions in the call stack when tracing to report the calling method
@@ -148,12 +147,6 @@ func (entry *Entry) WithTime(t time.Time) *Entry {
 	return &Entry{Logger: entry.Logger, Data: entry.Data, Time: t, err: entry.err, Context: entry.Context}
 }
 
-// AddSkipPackageFromStackTrace
-// ex: logrus.AddSkipPackageFromStackTrace("github.com/go-xorm/xorm")
-// func AddSkipPackageFromStackTrace(name string) {
-// 	skipPackageNameForCaller[name] = struct{}{}
-// }
-
 // getPackageName reduces a fully qualified function name to the package name
 // There really ought to be to be a better way...
 func getPackageName(f string) string {
@@ -194,7 +187,6 @@ func getCaller() *runtime.Frame {
 		//pkg := getPackageName(f.Function)
 
 		// If the caller isn't part of this package, we're done
-		//if pkg != logrusPackage {a
 		if _, has := skipPackageNameForCaller[getPackageName(f.Function)]; !has {
 			return &f
 		}

--- a/entry.go
+++ b/entry.go
@@ -16,7 +16,8 @@ var (
 	bufferPool *sync.Pool
 
 	// qualified package name, cached at first use
-	logrusPackage string
+	//logrusPackage string
+	skipPackageNameForCaller = make(map[string]struct{}, 1)
 
 	// Positions in the call stack when tracing to report the calling method
 	minimumCallerDepth int
@@ -147,6 +148,12 @@ func (entry *Entry) WithTime(t time.Time) *Entry {
 	return &Entry{Logger: entry.Logger, Data: entry.Data, Time: t, err: entry.err, Context: entry.Context}
 }
 
+// AddSkipPackageFromStackTrace
+// ex: logrus.AddSkipPackageFromStackTrace("github.com/go-xorm/xorm")
+// func AddSkipPackageFromStackTrace(name string) {
+// 	skipPackageNameForCaller[name] = struct{}{}
+// }
+
 // getPackageName reduces a fully qualified function name to the package name
 // There really ought to be to be a better way...
 func getPackageName(f string) string {
@@ -170,7 +177,8 @@ func getCaller() *runtime.Frame {
 	callerInitOnce.Do(func() {
 		pcs := make([]uintptr, 2)
 		_ = runtime.Callers(0, pcs)
-		logrusPackage = getPackageName(runtime.FuncForPC(pcs[1]).Name())
+		//logrusPackage = getPackageName(runtime.FuncForPC(pcs[1]).Name())
+		AddSkipPackageFromStackTrace(getPackageName(runtime.FuncForPC(pcs[1]).Name()))
 
 		// now that we have the cache, we can skip a minimum count of known-logrus functions
 		// XXX this is dubious, the number of frames may vary
@@ -183,11 +191,12 @@ func getCaller() *runtime.Frame {
 	frames := runtime.CallersFrames(pcs[:depth])
 
 	for f, again := frames.Next(); again; f, again = frames.Next() {
-		pkg := getPackageName(f.Function)
+		//pkg := getPackageName(f.Function)
 
 		// If the caller isn't part of this package, we're done
-		if pkg != logrusPackage {
-			return &f //nolint:scopelint
+		//if pkg != logrusPackage {a
+		if _, has := skipPackageNameForCaller[getPackageName(f.Function)]; !has {
+			return &f
 		}
 	}
 

--- a/exported.go
+++ b/exported.go
@@ -31,6 +31,11 @@ func SetReportCaller(include bool) {
 	std.SetReportCaller(include)
 }
 
+// AddSkipPackageFromStackTrace ...
+func AddSkipPackageFromStackTrace(name string) {
+	std.AddSkipPackageFromStackTrace(name)
+}
+
 // SetLevel sets the standard logger level.
 func SetLevel(level Level) {
 	std.SetLevel(level)

--- a/exported.go
+++ b/exported.go
@@ -31,7 +31,9 @@ func SetReportCaller(include bool) {
 	std.SetReportCaller(include)
 }
 
-// AddSkipPackageFromStackTrace ...
+// AddSkipPackageFromStackTrace excludes package names from the caller report when
+// SetReportCaller set to true. Commonly used to skip a custom logrus wrapper package frames.
+// ex. log.AddSkipPackageFromStackTrace("mycoolapp/mylogger") // skip mycoolapp/mylogger wrapper.
 func AddSkipPackageFromStackTrace(name string) {
 	std.AddSkipPackageFromStackTrace(name)
 }

--- a/logger.go
+++ b/logger.go
@@ -335,14 +335,14 @@ func (logger *Logger) SetOutput(output io.Writer) {
 	logger.Out = output
 }
 
-// SetReportCaller ...
+// SetReportCaller logs the caller stack frame.
 func (logger *Logger) SetReportCaller(reportCaller bool) {
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
 	logger.ReportCaller = reportCaller
 }
 
-// AddSkipPackageFromStackTrace ...
+// AddSkipPackageFromStackTrace excludes a package from the caller report.
 func (logger *Logger) AddSkipPackageFromStackTrace(name string) {
 	skipPackageNameForCaller[name] = struct{}{}
 }

--- a/logger.go
+++ b/logger.go
@@ -335,10 +335,16 @@ func (logger *Logger) SetOutput(output io.Writer) {
 	logger.Out = output
 }
 
+// SetReportCaller ...
 func (logger *Logger) SetReportCaller(reportCaller bool) {
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
 	logger.ReportCaller = reportCaller
+}
+
+// AddSkipPackageFromStackTrace ...
+func (logger *Logger) AddSkipPackageFromStackTrace(name string) {
+	skipPackageNameForCaller[name] = struct{}{}
 }
 
 // ReplaceHooks replaces the logger hooks and returns the old ones


### PR DESCRIPTION
AddSkipPackageFromStackTrace excludes package names from the caller report when
SetReportCaller set to true. Commonly used to skip a custom logrus wrapper package frames.
ex. log.AddSkipPackageFromStackTrace("mycoolapp/mylogger") // skip mycoolapp/mylogger wrapper.

Merging changes discussed in https://github.com/sirupsen/logrus/pull/898/files with minor changes.