### PR TITLE
Fix func and file field clash (duplicated fields)

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -69,10 +69,12 @@ func prefixFieldClashes(data Fields, fieldMap FieldMap, reportCaller bool) {
 		funcKey := fieldMap.resolve(FieldKeyFunc)
 		if l, ok := data[funcKey]; ok {
 			data["fields."+funcKey] = l
+			delete(data, funcKey)
 		}
 		fileKey := fieldMap.resolve(FieldKeyFile)
 		if l, ok := data[fileKey]; ok {
 			data["fields."+fileKey] = l
+			delete(data, fileKey)
 		}
 	}
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,54 @@
+package logrus
+
+import (
+	//"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefixFieldClashesFuncReportCaller(t *testing.T) {
+	data := Fields{FieldKeyFunc: "CustomFunc", FieldKeyFile: "custom.go"}
+	var fieldMap FieldMap
+	var value interface{}
+	var hasKey bool
+
+	prefixFieldClashes(data, fieldMap, true)
+
+	_, hasKey = data[FieldKeyFunc]
+	assert.False(t, hasKey, "func not deleted when ReportCaller=true")
+
+	_, hasKey = data[FieldKeyFile]
+	assert.False(t, hasKey, "file not deleted when ReportCaller=true")
+
+	value, hasKey = data["fields."+FieldKeyFunc]
+	assert.True(t, hasKey, "fields.func not set when ReportCaller=true")
+	assert.Equal(t, "CustomFunc", value, "fields.func not set as expected when ReportCaller=true")
+
+	value, hasKey = data["fields."+FieldKeyFile]
+	assert.True(t, hasKey, "fields.file not set when ReportCaller=true")
+	assert.Equal(t, "custom.go", value, "fields.file not set as expected when ReportCaller=true")
+}
+
+func TestPrefixFieldClashesFuncNoReportCaller(t *testing.T) {
+	data := Fields{FieldKeyFunc: "CustomFunc", FieldKeyFile: "custom.go"}
+	var fieldMap FieldMap
+	var value interface{}
+	var hasKey bool
+
+	prefixFieldClashes(data, fieldMap, false)
+
+	value, hasKey = data[FieldKeyFunc]
+	assert.True(t, hasKey, "func deleted when ReportCaller=false")
+	assert.Equal(t, "CustomFunc", value, "func set when ReportCaller=false")
+
+	value, hasKey = data[FieldKeyFile]
+	assert.True(t, hasKey, "file deleted when ReportCaller=false")
+	assert.Equal(t, "custom.go", value, "file set when ReportCaller=false")
+
+	value, hasKey = data["fields."+FieldKeyFunc]
+	assert.False(t, hasKey, "fields.func set when ReportCaller=false")
+
+	value, hasKey = data["fields."+FieldKeyFile]
+	assert.False(t, hasKey, "fields.file set when ReportCaller=false")
+}

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -268,7 +268,7 @@ func TestJSONTimeKey(t *testing.T) {
 	}
 }
 
-func TestFieldDoesNotClashWithCaller(t *testing.T) {
+func TestJSONFieldDoesNotClashWithCaller(t *testing.T) {
 	SetReportCaller(false)
 	formatter := &JSONFormatter{}
 
@@ -288,8 +288,10 @@ func TestFieldDoesNotClashWithCaller(t *testing.T) {
 	}
 }
 
-func TestFieldClashWithCaller(t *testing.T) {
+func TestJSONFieldClashWithCaller(t *testing.T) {
 	SetReportCaller(true)
+	defer SetReportCaller(false)
+
 	formatter := &JSONFormatter{}
 	e := WithField("func", "howdy pardner")
 	e.Caller = &runtime.Frame{Function: "somefunc"}
@@ -313,8 +315,6 @@ func TestFieldClashWithCaller(t *testing.T) {
 		t.Fatalf("func not set as expected when ReportCaller=true (got '%s')",
 			entry["func"])
 	}
-
-	SetReportCaller(false) // return to default value
 }
 
 func TestJSONDisableTimestamp(t *testing.T) {

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -580,3 +580,74 @@ func TestCustomSorting(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(string(b), "prefix="), "format output is %q", string(b))
 }
+
+func TestTextFieldClashWithCaller(t *testing.T) {
+	formatter := &TextFormatter{
+		DisableColors: true,
+	}
+
+	logger := New()
+	logger.SetReportCaller(true)
+
+	entry := &Entry{
+		Logger:  logger,
+		Caller:  &runtime.Frame{Function: "CallerFunc", File: "caller.go", Line: 42},
+		Message: "oh hi",
+		Level:   WarnLevel,
+		Time:    time.Date(1981, time.February, 24, 4, 28, 3, 100, time.UTC),
+		Data: Fields{
+			"field1":     "f1",
+			FieldKeyFunc: "CustomFunc",
+			FieldKeyFile: "custom.go",
+		},
+	}
+
+	b, err := formatter.Format(entry)
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	assert.Equal(t,
+		FieldKeyTime+`="1981-02-24T04:28:03Z" `+
+			FieldKeyLevel+`=`+WarnLevel.String()+` `+
+			FieldKeyMsg+`="oh hi" `+
+			FieldKeyFunc+`=CallerFunc `+
+			FieldKeyFile+`="caller.go:42" `+
+			`field1=f1 `+
+			`fields.`+FieldKeyFile+`=custom.go `+
+			`fields.`+FieldKeyFunc+`=CustomFunc`+"\n",
+		string(b),
+		"Formatted output doesn't respect ReportCaller=true")
+}
+
+func TestTextFieldDoesNotClashWithCaller(t *testing.T) {
+	formatter := &TextFormatter{
+		DisableColors: true,
+	}
+
+	entry := &Entry{
+		Message: "oh hi",
+		Level:   WarnLevel,
+		Time:    time.Date(1981, time.February, 24, 4, 28, 3, 100, time.UTC),
+		Data: Fields{
+			"field1":     "f1",
+			FieldKeyFunc: "CustomFunc",
+			FieldKeyFile: "custom.go",
+		},
+	}
+
+	b, err := formatter.Format(entry)
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	assert.Equal(t,
+		FieldKeyTime+`="1981-02-24T04:28:03Z" `+
+			FieldKeyLevel+`=`+WarnLevel.String()+` `+
+			FieldKeyMsg+`="oh hi" `+
+			`field1=f1 `+
+			FieldKeyFile+`=custom.go `+
+			FieldKeyFunc+`=CustomFunc`+"\n",
+		string(b),
+		"Formatted output doesn't respect ReportCaller=false")
+}


### PR DESCRIPTION
In case of:
* ReportCaller=true
* `func` and/or `file` fields are clased (set by `WithField()` or `WithFields()`)

**The `TextFormatter` duplicates the clashed `func` and/or `file` fields.**

Root cause: `prefixFieldClashes()` does not delete `func` and/or `file` fields, if it are renamed to `fileds.func` and/or `fields.file`. The `TextFormatter.Format()` merges `keys` and `fixedKeys`, so `func` and `file` are duplicated in the merged slice, because `TextFormatter.Format()` does not use unique list.

`TestJSONFieldClashWithCaller` didn't detect this problem, because it uses unique data model (map instead of slice)

Solution: 
* deleting `func` and/or `file` fields in `prefixFieldClashes()`, if it are renamed.
* new unit tests
