### PR TITLE
text_formatter: add support for GoString

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -34,6 +34,10 @@ type TextFormatter struct {
 	// Force disabling colors.
 	DisableColors bool
 
+	// try GoString() for field representation: if that works,
+	// don't quote the field at all, just print the result.
+	UseGoString bool
+
 	// Force quoting of all values
 	ForceQuote bool
 
@@ -313,6 +317,13 @@ func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interf
 }
 
 func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
+	if f.UseGoString {
+		stringer, ok := value.(fmt.GoStringer)
+		if ok {
+			b.WriteString(stringer.GoString())
+			return
+		}
+	}
 	stringVal, ok := value.(string)
 	if !ok {
 		stringVal = fmt.Sprint(value)


### PR DESCRIPTION
Note: I have not created an issue for this and don't really feel all that strongly one way or another about it.  I was experimenting with some logging options and it seemed to me that logging fields in their GoString output format was clearer when they weren't quoted.

Without this, given a type like this (the Stringer and GoStringer are the same mainly for illustration):

```
type Walrus struct {
        name   string
        weight float64
}

func (w Walrus) GoString() string {
        return fmt.Sprintf("Walrus{name: %q, weight: %g}", w.name, w.weight)
}
func (w Walrus) String() string {
        return fmt.Sprintf("Walrus{name: %q, weight: %g}", w.name, w.weight)
}
...
        log.WithField("walrus", Walrus{"Fred", 300}).Debug("walrus details")
```

produces (I've trimmed a bit of interior whitespace for this PR text):
```
DEBU[0000] walrus details                walrus="Walrus{name: \"Fred\", weight: 300}"
```
With GoString enabled we get:
```
DEBU[0000] walrus details                walrus=Walrus{name: "Fred", weight: 300}
```
which just seems prettier.  A well-formed GoString should produce unambiguously encoded results, so it won't need quotes.

Commit message text follows...

---

Allow logging fields with their GoString result.  When using
GoString, never add extra quotes, regardless of the ForceQuote
setting: the GoString format should take care of this.

Note that if some field does not implement the GoString
interface, we fall through to the remaining logic, which
obeys ForceQuote as usual.