### PR TITLE
add thirdparty formatter, caption-json-formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Third party logging formatters:
 * [`zalgo`](https://github.com/aybabtme/logzalgo). Invoking the P͉̫o̳̼̊w̖͈̰͎e̬͔̭͂r͚̼̹̲ ̫͓͉̳͈ō̠͕͖̚f̝͍̠ ͕̲̞͖͑Z̖̫̤̫ͪa͉̬͈̗l͖͎g̳̥o̰̥̅!̣͔̲̻͊̄ ̙̘̦̹̦.
 * [`nested-logrus-formatter`](https://github.com/antonfisher/nested-logrus-formatter). Converts logrus fields to a nested structure.
 * [`powerful-logrus-formatter`](https://github.com/zput/zxcTool). get fileName, log's line number and the latest function's name when print log; Sava log to files.
+* [`caption-json-formatter`](https://github.com/nolleh/caption-json-formatter). logrus's message json formatter with human-readable caption added.
 
 You can define your formatter by implementing the `Formatter` interface,
 requiring a `Format` method. `Format` takes an `*Entry`. `entry.Data` is a


### PR DESCRIPTION
added thirdparty formatter, caption-json-formatter.

it is used when log message has json, but doesn't want to other fields are json.

for example, print like

[2020-01-20T16:46:08.7452971+09:00] [Debug]
{
    "request": {
        "headers": { "content-type": "application/json" }, 
        "method": "GET", 
        "route": "/user/{userId}/balance",
        "url": "/user/123456/balance"
    }, 
    "response": {
        "body": {
            "userId": 123456,
            "balance": 1000
        }
    }
}

other formatter that exist is now, there isn't way json formatting that applied only for "message field"