### PR TITLE
Add mutex on entry, not logging the global mutex

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -75,6 +75,8 @@ type Entry struct {
 
 	// err may contain a field formatting error
 	err string
+
+	mu sync.Mutex
 }
 
 func NewEntry(logger *Logger) *Entry {
@@ -122,8 +124,8 @@ func (entry *Entry) WithField(key string, value interface{}) *Entry {
 
 // Add a map of fields to the Entry.
 func (entry *Entry) WithFields(fields Fields) *Entry {
-	entry.Logger.mu.Lock()
-	defer entry.Logger.mu.Unlock()
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
 	data := make(Fields, len(entry.Data)+len(fields))
 	for k, v := range entry.Data {
 		data[k] = v


### PR DESCRIPTION
Potential fix for #1122, #1128 

Adding mutex on entry instead of logging the 'global' logger mutex