### PR TITLE
Move lock to copy

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -75,6 +75,8 @@ type Entry struct {
 
 	// err may contain a field formatting error
 	err string
+
+	mu sync.Mutex
 }
 
 func NewEntry(logger *Logger) *Entry {
@@ -122,8 +124,8 @@ func (entry *Entry) WithField(key string, value interface{}) *Entry {
 
 // Add a map of fields to the Entry.
 func (entry *Entry) WithFields(fields Fields) *Entry {
-	entry.Logger.mu.Lock()
-	defer entry.Logger.mu.Unlock()
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
 	data := make(Fields, len(entry.Data)+len(fields))
 	for k, v := range entry.Data {
 		data[k] = v

--- a/entry.go
+++ b/entry.go
@@ -75,8 +75,6 @@ type Entry struct {
 
 	// err may contain a field formatting error
 	err string
-
-	mu sync.Mutex
 }
 
 func NewEntry(logger *Logger) *Entry {
@@ -124,12 +122,13 @@ func (entry *Entry) WithField(key string, value interface{}) *Entry {
 
 // Add a map of fields to the Entry.
 func (entry *Entry) WithFields(fields Fields) *Entry {
-	entry.mu.Lock()
-	defer entry.mu.Unlock()
+	entry.Logger.mu.Lock()
 	data := make(Fields, len(entry.Data)+len(fields))
 	for k, v := range entry.Data {
 		data[k] = v
 	}
+	entry.Logger.mu.Unlock()
+
 	fieldErr := entry.err
 	for k, v := range fields {
 		isErrField := false


### PR DESCRIPTION
Potential fix for: #1122, #1128
Move the unlock in `entry.WithFields` to after the data copy instead of in a defer