### PR TITLE
Revert #1047

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -122,8 +122,6 @@ func (entry *Entry) WithField(key string, value interface{}) *Entry {
 
 // Add a map of fields to the Entry.
 func (entry *Entry) WithFields(fields Fields) *Entry {
-	entry.Logger.mu.Lock()
-	defer entry.Logger.mu.Unlock()
 	data := make(Fields, len(entry.Data)+len(fields))
 	for k, v := range entry.Data {
 		data[k] = v

--- a/entry_test.go
+++ b/entry_test.go
@@ -210,7 +210,7 @@ func TestEntryWithIncorrectField(t *testing.T) {
 
 	fn := func() {}
 
-	e := &Entry{Logger: New()}
+	e := Entry{}
 	eWithFunc := e.WithFields(Fields{"func": fn})
 	eWithFuncPtr := e.WithFields(Fields{"funcPtr": &fn})
 


### PR DESCRIPTION
Effectively reverts #1047 to fix #1128, #1120, #1122 as many users are seeing deadlocks after updating to 1.5.0.

The potential reason being is that calling `WithFields` from within a Hook tries to acquire the same lock, which is already acquired by the hook

This will re-open #1046