### PR TITLE
Adds flag to disable quotes in TextFormatter

### DIFF
--- a/text_formatter.go
+++ b/text_formatter.go
@@ -37,6 +37,9 @@ type TextFormatter struct {
 	// Force quoting of all values
 	ForceQuote bool
 
+	// DisableQuote disables quoting for all values
+	DisableQuote bool
+
 	// Override coloring based on CLICOLOR and CLICOLOR_FORCE. - https://bixense.com/clicolors/
 	EnvironmentOverrideColors bool
 
@@ -291,6 +294,9 @@ func (f *TextFormatter) needsQuoting(text string) bool {
 	}
 	if f.QuoteEmptyFields && len(text) == 0 {
 		return true
+	}
+	if f.DisableQuote {
+		return false
 	}
 	for _, ch := range text {
 		if !((ch >= 'a' && ch <= 'z') ||

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -66,6 +66,14 @@ func TestQuoting(t *testing.T) {
 	checkQuoting(false, errors.New("invalid"))
 	checkQuoting(true, errors.New("invalid argument"))
 
+	// Test for quoting disabled
+	tf.DisableQuote = true
+	checkQuoting(false, "")
+	checkQuoting(false, "abcd")
+	checkQuoting(false, "foo\n\rbar")
+	checkQuoting(false, errors.New("invalid argument"))
+	tf.DisableQuote = false
+
 	// Test for quoting empty fields.
 	tf.QuoteEmptyFields = true
 	checkQuoting(true, "")

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -59,6 +59,7 @@ func TestQuoting(t *testing.T) {
 	checkQuoting(false, "foo@bar")
 	checkQuoting(false, "foobar^")
 	checkQuoting(false, "+/-_^@f.oobar")
+	checkQuoting(true, "foo\n\rbar")
 	checkQuoting(true, "foobar$")
 	checkQuoting(true, "&foobar")
 	checkQuoting(true, "x y")
@@ -66,25 +67,34 @@ func TestQuoting(t *testing.T) {
 	checkQuoting(false, errors.New("invalid"))
 	checkQuoting(true, errors.New("invalid argument"))
 
-	// Test for quoting disabled
-	tf.DisableQuote = true
-	checkQuoting(false, "")
-	checkQuoting(false, "abcd")
-	checkQuoting(false, "foo\n\rbar")
-	checkQuoting(false, errors.New("invalid argument"))
-	tf.DisableQuote = false
-
 	// Test for quoting empty fields.
 	tf.QuoteEmptyFields = true
 	checkQuoting(true, "")
 	checkQuoting(false, "abcd")
+	checkQuoting(true, "foo\n\rbar")
 	checkQuoting(true, errors.New("invalid argument"))
 
 	// Test forcing quotes.
 	tf.ForceQuote = true
 	checkQuoting(true, "")
 	checkQuoting(true, "abcd")
+	checkQuoting(true, "foo\n\rbar")
 	checkQuoting(true, errors.New("invalid argument"))
+
+	// Test forcing quotes when also disabling them.
+	tf.DisableQuote = true
+	checkQuoting(true, "")
+	checkQuoting(true, "abcd")
+	checkQuoting(true, "foo\n\rbar")
+	checkQuoting(true, errors.New("invalid argument"))
+
+	// Test disabling quotes
+	tf.ForceQuote = false
+	tf.QuoteEmptyFields = false
+	checkQuoting(false, "")
+	checkQuoting(false, "abcd")
+	checkQuoting(false, "foo\n\rbar")
+	checkQuoting(false, errors.New("invalid argument"))
 }
 
 func TestEscaping(t *testing.T) {


### PR DESCRIPTION
Relates to https://github.com/sirupsen/logrus/issues/654 and https://github.com/sirupsen/logrus/issues/608

In some cases, we don't want the log values to be quoted or escaped, so this is adding a simple flag in TextFormatter to disable quotes (which also disables escaping) in the field values.