### PR TITLE
update changelog with v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.7.0
+Fixes:
+  * the dependency toward a windows terminal library has been removed
+
+Features:
+  * a new buffer pool management API has been added
+  * a set of `<LogLevel>Fn()` functions have been added
+
 # 1.6.0
 Fixes:
   * end of line cleanup


### PR DESCRIPTION
related to https://github.com/sirupsen/logrus/issues/1181

Thanks for releasing [v1.7.0](https://github.com/sirupsen/logrus/releases/tag/v1.7.0), but it looks that CHANGELOG doesn't have the v1.7.0 section.
This pull request fixes it.
