### PR TITLE
Add optional formatter to writer hook

### DIFF
--- a/hooks/writer/writer.go
+++ b/hooks/writer/writer.go
@@ -10,15 +10,25 @@ import (
 type Hook struct {
 	Writer    io.Writer
 	LogLevels []log.Level
+	Formatter log.Formatter
 }
 
 // Fire will be called when some logging function is called with current hook
 // It will format log entry to string and write it to appropriate writer
 func (hook *Hook) Fire(entry *log.Entry) error {
-	line, err := entry.Bytes()
+	var line []byte
+	var err error
+
+	if hook.Formatter != nil {
+		line, err = hook.Formatter.Format(entry)
+	} else {
+		line, err = entry.Bytes()
+	}
+
 	if err != nil {
 		return err
 	}
+
 	_, err = hook.Writer.Write(line)
 	return err
 }

--- a/hooks/writer/writer_test.go
+++ b/hooks/writer/writer_test.go
@@ -36,3 +36,41 @@ func TestDifferentLevelsGoToDifferentWriters(t *testing.T) {
 	assert.Equal(t, a.String(), "level=warning msg=\"send to a\"\n")
 	assert.Equal(t, b.String(), "level=info msg=\"send to b\"\n")
 }
+
+func TestDifferentFormattersToDifferentWritter(t *testing.T) {
+	var a, b bytes.Buffer
+
+	log.SetOutput(ioutil.Discard) // Send all logs to nowhere by default
+
+	log.AddHook(&Hook{
+		Writer: &a,
+		LogLevels: []log.Level{
+			log.WarnLevel,
+		},
+		Formatter: &log.TextFormatter{
+			DisableTimestamp: true,
+			DisableColors:    true,
+			FieldMap: log.FieldMap{
+				log.FieldKeyLevel: "@level",
+				log.FieldKeyMsg:   "@message",
+			},
+		},
+	})
+	log.AddHook(&Hook{ // Send info and debug logs to stdout
+		Writer: &b,
+		LogLevels: []log.Level{
+			log.InfoLevel,
+		},
+		Formatter: &log.JSONFormatter{
+			DisableTimestamp: true,
+			FieldMap: log.FieldMap{
+				log.FieldKeyMsg: "message",
+			},
+		},
+	})
+	log.Warn("send to a")
+	log.Info("send to b")
+
+	assert.Equal(t, a.String(), "@level=warning @message=\"send to a\"\n")
+	assert.Equal(t, b.String(), "{\"level\":\"info\",\"message\":\"send to b\"}\n")
+}


### PR DESCRIPTION
The changes make `hooks.Writer` to accept optional `Formatter` which would be used to format the log entries before writing.