### PR TITLE
Add build tag to enable a successful build for zos

### DIFF
--- a/terminal_check_unix.go
+++ b/terminal_check_unix.go
@@ -1,4 +1,4 @@
-// +build linux aix
+// +build linux aix zos
 // +build !js
 
 package logrus


### PR DESCRIPTION
This change is to enable building logrus on zOS.  The change is not introducing any new features.  This means it would not break many people's projects.  The change is safe given that logrus is in maintenance mode.