### PR TITLE
Remove dead panic in Entry.Panic

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -317,7 +317,6 @@ func (entry *Entry) Fatal(args ...interface{}) {
 
 func (entry *Entry) Panic(args ...interface{}) {
 	entry.Log(PanicLevel, args...)
-	panic(fmt.Sprint(args...))
 }
 
 // Entry Printf family functions

--- a/entry_test.go
+++ b/entry_test.go
@@ -167,6 +167,28 @@ func TestEntryPanicf(t *testing.T) {
 	entry.WithField("err", errBoom).Panicf("kaboom %v", true)
 }
 
+func TestEntryPanic(t *testing.T) {
+	errBoom := fmt.Errorf("boom again")
+
+	defer func() {
+		p := recover()
+		assert.NotNil(t, p)
+
+		switch pVal := p.(type) {
+		case *Entry:
+			assert.Equal(t, "kaboom", pVal.Message)
+			assert.Equal(t, errBoom, pVal.Data["err"])
+		default:
+			t.Fatalf("want type *Entry, got %T: %#v", pVal, pVal)
+		}
+	}()
+
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	entry := NewEntry(logger)
+	entry.WithField("err", errBoom).Panic("kaboom")
+}
+
 const (
 	badMessage   = "this is going to panic"
 	panicMessage = "this is broken"


### PR DESCRIPTION
[Entry.log itself panics][0] when the log level is set to PanicLevel, (and
PanicLevel is always eneabled) so this second panic will never be reached.

[0]: https://github.com/sirupsen/logrus/blob/8ae478eb8a850a54ea4915a2b572f377de1f9c7e/entry.go#L253

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sirupsen/logrus/1212)
<!-- Reviewable:end -->
