### PR TITLE
Add WithCaller and WithCallerAt for overriding the caller detection

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -105,7 +105,7 @@ func (entry *Entry) WithContext(ctx context.Context) *Entry {
 	for k, v := range entry.Data {
 		dataCopy[k] = v
 	}
-	return &Entry{Logger: entry.Logger, Data: dataCopy, Time: entry.Time, err: entry.err, Context: ctx}
+	return &Entry{Logger: entry.Logger, Data: dataCopy, Time: entry.Time, err: entry.err, Context: ctx, Caller: entry.Caller}
 }
 
 // Add a single field to the Entry.
@@ -139,7 +139,7 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 			data[k] = v
 		}
 	}
-	return &Entry{Logger: entry.Logger, Data: data, Time: entry.Time, err: fieldErr, Context: entry.Context}
+	return &Entry{Logger: entry.Logger, Data: data, Time: entry.Time, err: fieldErr, Context: entry.Context, Caller: entry.Caller}
 }
 
 // Overrides the time of the Entry.
@@ -148,7 +148,46 @@ func (entry *Entry) WithTime(t time.Time) *Entry {
 	for k, v := range entry.Data {
 		dataCopy[k] = v
 	}
-	return &Entry{Logger: entry.Logger, Data: dataCopy, Time: t, err: entry.err, Context: entry.Context}
+	return &Entry{Logger: entry.Logger, Data: dataCopy, Time: t, err: entry.err, Context: entry.Context, Caller: entry.Caller}
+}
+
+// Overrides the caller frame of the Entry.
+//
+// This method works regardless of whether ReportCaller is enabled or not.
+func (entry *Entry) WithCaller(frame *runtime.Frame) *Entry {
+	dataCopy := make(Fields, len(entry.Data))
+	for k, v := range entry.Data {
+		dataCopy[k] = v
+	}
+	return &Entry{Logger: entry.Logger, Data: dataCopy, Time: entry.Time, err: entry.err, Context: entry.Context, Caller: frame}
+}
+
+// Overrides the caller frame of the Entry,
+// finding the frame at the given calldepth.
+// A calldepth of 0 asks to fetch the frame
+// that calls WithCallerAt.
+//
+// If ReportCaller is disabled on this entry's logger,
+// returns an exact copy of entry.
+func (entry *Entry) WithCallerAt(calldepth int) *Entry {
+	entry.Logger.mu.Lock()
+	if !entry.Logger.ReportCaller {
+		entry.Logger.mu.Unlock()
+
+		dataCopy := make(Fields, len(entry.Data))
+		for k, v := range entry.Data {
+			dataCopy[k] = v
+		}
+		return &Entry{Logger: entry.Logger, Data: dataCopy, Time: entry.Time, err: entry.err, Context: entry.Context, Caller: entry.Caller}
+	}
+
+	defer entry.Logger.mu.Unlock()
+
+	pcs := []uintptr{0}
+	depth := runtime.Callers(calldepth+2, pcs)
+	frames := runtime.CallersFrames(pcs[:depth])
+	frame, _ := frames.Next()
+	return entry.WithCaller(&frame)
 }
 
 // getPackageName reduces a fully qualified function name to the package name
@@ -227,7 +266,7 @@ func (entry Entry) log(level Level, msg string) {
 	entry.Level = level
 	entry.Message = msg
 	entry.Logger.mu.Lock()
-	if entry.Logger.ReportCaller {
+	if entry.Logger.ReportCaller && entry.Caller == nil {
 		entry.Caller = getCaller()
 	}
 	entry.Logger.mu.Unlock()

--- a/entry_test.go
+++ b/entry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -121,6 +122,27 @@ func TestEntryWithTimeCopiesData(t *testing.T) {
 	val, exists = parentEntry.Data["childKey"]
 	assert.False(exists)
 	assert.Empty(val)
+}
+
+func TestEntryWithCallerAt(t *testing.T) {
+	assert := assert.New(t)
+
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+
+	entry := func() *Entry {
+		return logger.WithCallerAt(0)
+	}()
+	assert.Equal(logger, entry.Logger)
+	assert.Nil(entry.Caller, "WithCallerAt shouldn't look when ReportCaller == false")
+
+	logger.SetReportCaller(true)
+	entry = func() *Entry {
+		return logger.WithCallerAt(1)
+	}()
+	assert.Equal(logger, entry.Logger)
+	assert.NotNil(entry.Caller)
+	assert.True(strings.HasSuffix(entry.Caller.Function, ".TestEntryWithCallerAt"))
 }
 
 func TestEntryPanicln(t *testing.T) {


### PR DESCRIPTION
Seems like there's already a few PRs along these lines (e.g. #973, #1175)... but I forgot to check for those before implementing this 😅

Anyway, I think this approach should be more flexible and useful. I don't think the other approaches would _quite_ work for my purposes... or at least, they'd be incredibly awkward.

The new methods `Event.WithCaller`, `Logger.WithCaller` allow for setting the caller with an existing frame, and exists mostly as a Just-In-Case™. The other new methods `Event.WithCallerAt`, `Logger.WithCallerAt` are the main source of interest (at least for me), and make it simple to log a message attached to the caller of the function that needs to log. For example:

```go
func DoSomething() error {
  // ...
  handleResult(result, err)
}

func handleResult(result string, err error) {
  if err != nil {
    // ...
    logger.WithCallerAt(1, err) // The error happened in the calling function
  }

  // ...
}
```