### PR TITLE
add ModifyEntryFields func to JSONFormatter to add/remove fields before log encoding

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -54,6 +54,10 @@ type JSONFormatter struct {
 
 	// PrettyPrint will indent all json logs
 	PrettyPrint bool
+
+	// ModifyEntryFields is called to allow adding/removing entry fields before encoding.
+	// This is done after data fields are copied so it is goroutine safe.
+	ModifyEntryFields func(data Fields)
 }
 
 // Format renders a single log entry
@@ -68,6 +72,12 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		default:
 			data[k] = v
 		}
+	}
+
+	// If ModifyEntryFields is set then call it to potentially add/modify the entry fields.
+	if f.ModifyEntryFields != nil {
+		// Maps are passed by reference so it can add/remove fields.
+		f.ModifyEntryFields(data)
 	}
 
 	if f.DataKey != "" {


### PR DESCRIPTION
	- allows adding/removing entry fields after copying but before encoding as JSON

This is a workaround for https://github.com/sirupsen/logrus/issues/1217 and other data race related issues. It is one of the most performant options but is not generic in that it doesn't solve all the Data fields concurrency issues. It simply sidesteps it by modifying fields after they are copied but before encoding.

This is the second solution and can be implemented on a formatter by formatter basis for now. It is likely more performant than the updated `FireAndMutate` modified hook api which would still require copying entries.

This should solve the most general case of people using JSON formatting and needing to add/remove fields on some or all entries.