### PR TITLE
Logrus fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
 package main
 
 import (
-  log "github.com/sirupsen/logrus"
+  log "github.com/nandosuk/logrus"
 )
 
 func main() {
@@ -130,7 +130,7 @@ func main() {
 ```
 
 Note that it's completely api-compatible with the stdlib logger, so you can
-replace your `log` imports everywhere with `log "github.com/sirupsen/logrus"`
+replace your `log` imports everywhere with `log "github.com/nandosuk/logrus"`
 and you'll now have the flexibility of Logrus. You can customize it all you
 want:
 
@@ -139,7 +139,7 @@ package main
 
 import (
   "os"
-  log "github.com/sirupsen/logrus"
+  log "github.com/nandosuk/logrus"
 )
 
 func init() {
@@ -190,7 +190,7 @@ package main
 
 import (
   "os"
-  "github.com/sirupsen/logrus"
+  "github.com/nandosuk/logrus"
 )
 
 // Create a new instance of the logger. You can have any number of instances.
@@ -265,9 +265,9 @@ Logrus comes with [built-in hooks](hooks/). Add those, or your custom hook, in
 
 ```go
 import (
-  log "github.com/sirupsen/logrus"
+  log "github.com/nandosuk/logrus"
   "gopkg.in/gemnasium/logrus-airbrake-hook.v2" // the package is named "airbrake"
-  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
+  logrus_syslog "github.com/nandosuk/logrus/hooks/syslog"
   "log/syslog"
 )
 
@@ -338,7 +338,7 @@ could do:
 
 ```go
 import (
-  log "github.com/sirupsen/logrus"
+  log "github.com/nandosuk/logrus"
 )
 
 init() {
@@ -460,8 +460,8 @@ Logrus has a built in facility for asserting the presence of log messages. This 
 
 ```go
 import(
-  "github.com/sirupsen/logrus"
-  "github.com/sirupsen/logrus/hooks/test"
+  "github.com/nandosuk/logrus"
+  "github.com/nandosuk/logrus/hooks/test"
   "github.com/stretchr/testify/assert"
   "testing"
 )

--- a/doc.go
+++ b/doc.go
@@ -7,7 +7,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
   package main
 
   import (
-    log "github.com/sirupsen/logrus"
+    log "github.com/nandosuk/logrus"
   )
 
   func main() {

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -3,7 +3,7 @@ package logrus_test
 import (
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 )
 
 func Example_basic() {

--- a/example_custom_caller_test.go
+++ b/example_custom_caller_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 )
 
 func ExampleJSONFormatter_CallerPrettyfier() {
@@ -24,5 +24,5 @@ func ExampleJSONFormatter_CallerPrettyfier() {
 	}
 	l.Info("example of custom format caller")
 	// Output:
-	// {"file":"example_custom_caller_test.go","func":"ExampleJSONFormatter_CallerPrettyfier","level":"info","msg":"example of custom format caller"}
+	// {"file":"example_custom_caller_test.go","func":"ExampleJSONFormatter_CallerPrettyfier","level":"INFO","msg":"example of custom format caller"}
 }

--- a/example_default_field_value_test.go
+++ b/example_default_field_value_test.go
@@ -3,7 +3,7 @@ package logrus_test
 import (
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 )
 
 type DefaultFieldHook struct {

--- a/example_function_test.go
+++ b/example_function_test.go
@@ -3,7 +3,7 @@ package logrus_test
 import (
 	"testing"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/nandosuk/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/example_global_hook_test.go
+++ b/example_global_hook_test.go
@@ -3,7 +3,7 @@ package logrus_test
 import (
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 )
 
 var (

--- a/example_hook_test.go
+++ b/example_hook_test.go
@@ -6,8 +6,8 @@ import (
 	"log/syslog"
 	"os"
 
-	"github.com/sirupsen/logrus"
-	slhooks "github.com/sirupsen/logrus/hooks/syslog"
+	"github.com/nandosuk/logrus"
+	slhooks "github.com/nandosuk/logrus/hooks/syslog"
 )
 
 // An example on how to use a hook

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sirupsen/logrus
+module github.com/nandosuk/logrus
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/hook_test.go
+++ b/hook_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/sirupsen/logrus"
-	. "github.com/sirupsen/logrus/internal/testutils"
+	. "github.com/nandosuk/logrus"
+	. "github.com/nandosuk/logrus/internal/testutils"
 )
 
 type TestHook struct {

--- a/hooks/syslog/README.md
+++ b/hooks/syslog/README.md
@@ -5,8 +5,8 @@
 ```go
 import (
   "log/syslog"
-  "github.com/sirupsen/logrus"
-  lSyslog "github.com/sirupsen/logrus/hooks/syslog"
+  "github.com/nandosuk/logrus"
+  lSyslog "github.com/nandosuk/logrus/hooks/syslog"
 )
 
 func main() {
@@ -24,8 +24,8 @@ If you want to connect to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "
 ```go
 import (
   "log/syslog"
-  "github.com/sirupsen/logrus"
-  lSyslog "github.com/sirupsen/logrus/hooks/syslog"
+  "github.com/nandosuk/logrus"
+  lSyslog "github.com/nandosuk/logrus/hooks/syslog"
 )
 
 func main() {

--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -7,7 +7,7 @@ import (
 	"log/syslog"
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 )
 
 // SyslogHook to send logs via syslog.

--- a/hooks/syslog/syslog_test.go
+++ b/hooks/syslog/syslog_test.go
@@ -6,7 +6,7 @@ import (
 	"log/syslog"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 )
 
 func TestLocalhostAddAndPrint(t *testing.T) {

--- a/hooks/test/test.go
+++ b/hooks/test/test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"sync"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 )
 
 // Hook is a hook designed for dealing with logs in test scenarios.

--- a/hooks/test/test_test.go
+++ b/hooks/test/test_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/hooks/writer/README.md
+++ b/hooks/writer/README.md
@@ -14,8 +14,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	log "github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/writer"
+	log "github.com/nandosuk/logrus"
+	"github.com/nandosuk/logrus/hooks/writer"
 )
 
 func main() {

--- a/hooks/writer/writer.go
+++ b/hooks/writer/writer.go
@@ -3,7 +3,7 @@ package writer
 import (
 	"io"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/nandosuk/logrus"
 )
 
 // Hook is a hook that writes logs of specified LogLevels to specified Writer

--- a/hooks/writer/writer_test.go
+++ b/hooks/writer/writer_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/nandosuk/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/sirupsen/logrus"
+	. "github.com/nandosuk/logrus"
 
 	"github.com/stretchr/testify/require"
 )

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 type fieldKey string
@@ -90,7 +91,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
 	}
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
-	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
+	data[f.FieldMap.resolve(FieldKeyLevel)] = strings.ToUpper(entry.Level.String())
 	if entry.HasCaller() {
 		funcVal := entry.Caller.Function
 		fileVal := fmt.Sprintf("%s:%d", entry.Caller.File, entry.Caller.Line)

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -199,7 +199,7 @@ func TestFieldsInNestedDictionary(t *testing.T) {
 	}
 
 	// with nested object, "level" shouldn't clash
-	if entry["level"] != "info" {
+	if entry["level"] != "INFO" {
 		t.Errorf("Expected 'level' field to contain 'info'")
 	}
 }

--- a/level_test.go
+++ b/level_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 	"github.com/stretchr/testify/require"
 )
 

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/sirupsen/logrus"
-	. "github.com/sirupsen/logrus/internal/testutils"
+	. "github.com/nandosuk/logrus"
+	. "github.com/nandosuk/logrus/internal/testutils"
 )
 
 // TestReportCaller verifies that when ReportCaller is set, the 'func' field
@@ -29,7 +29,7 @@ func TestReportCallerWhenConfigured(t *testing.T) {
 		log.Print("testNoCaller")
 	}, func(fields Fields) {
 		assert.Equal(t, "testNoCaller", fields["msg"])
-		assert.Equal(t, "info", fields["level"])
+		assert.Equal(t, "INFO", fields["level"])
 		assert.Equal(t, nil, fields["func"])
 	})
 
@@ -38,9 +38,9 @@ func TestReportCallerWhenConfigured(t *testing.T) {
 		log.Print("testWithCaller")
 	}, func(fields Fields) {
 		assert.Equal(t, "testWithCaller", fields["msg"])
-		assert.Equal(t, "info", fields["level"])
+		assert.Equal(t, "INFO", fields["level"])
 		assert.Equal(t,
-			"github.com/sirupsen/logrus_test.TestReportCallerWhenConfigured.func3", fields[FieldKeyFunc])
+			"github.com/nandosuk/logrus_test.TestReportCallerWhenConfigured.func3", fields[FieldKeyFunc])
 	})
 
 	LogAndAssertJSON(t, func(log *Logger) {
@@ -92,7 +92,7 @@ func TestReportCallerHelperDirect(t *testing.T) {
 	fields := logSomething(t, "direct")
 
 	assert.Equal(t, "direct", fields["msg"])
-	assert.Equal(t, "info", fields["level"])
+	assert.Equal(t, "INFO", fields["level"])
 	assert.Regexp(t, "github.com/.*/logrus_test.logSomething", fields["func"])
 }
 
@@ -102,7 +102,7 @@ func TestReportCallerHelperViaPointer(t *testing.T) {
 	fields := fptr(t, "via pointer")
 
 	assert.Equal(t, "via pointer", fields["msg"])
-	assert.Equal(t, "info", fields["level"])
+	assert.Equal(t, "INFO", fields["level"])
 	assert.Regexp(t, "github.com/.*/logrus_test.logSomething", fields["func"])
 }
 
@@ -111,7 +111,7 @@ func TestPrint(t *testing.T) {
 		log.Print("test")
 	}, func(fields Fields) {
 		assert.Equal(t, "test", fields["msg"])
-		assert.Equal(t, "info", fields["level"])
+		assert.Equal(t, "INFO", fields["level"])
 	})
 }
 
@@ -120,7 +120,7 @@ func TestInfo(t *testing.T) {
 		log.Info("test")
 	}, func(fields Fields) {
 		assert.Equal(t, "test", fields["msg"])
-		assert.Equal(t, "info", fields["level"])
+		assert.Equal(t, "INFO", fields["level"])
 	})
 }
 
@@ -129,7 +129,7 @@ func TestWarn(t *testing.T) {
 		log.Warn("test")
 	}, func(fields Fields) {
 		assert.Equal(t, "test", fields["msg"])
-		assert.Equal(t, "warning", fields["level"])
+		assert.Equal(t, "WARNING", fields["level"])
 	})
 }
 
@@ -138,7 +138,7 @@ func TestLog(t *testing.T) {
 		log.Log(WarnLevel, "test")
 	}, func(fields Fields) {
 		assert.Equal(t, "test", fields["msg"])
-		assert.Equal(t, "warning", fields["level"])
+		assert.Equal(t, "WARNING", fields["level"])
 	})
 }
 
@@ -249,7 +249,7 @@ func TestUserSuppliedLevelFieldHasPrefix(t *testing.T) {
 	LogAndAssertJSON(t, func(log *Logger) {
 		log.WithField("level", 1).Info("test")
 	}, func(fields Fields) {
-		assert.Equal(t, "info", fields["level"])
+		assert.Equal(t, "INFO", fields["level"])
 		assert.Equal(t, 1.0, fields["fields.level"]) // JSON has floats only
 	})
 }
@@ -379,7 +379,7 @@ func TestNestedLoggingReportsCorrectCaller(t *testing.T) {
 	assert.Equal(t, "looks delicious", fields["msg"])
 	assert.Equal(t, "eating raw fish", fields["context"])
 	assert.Equal(t,
-		"github.com/sirupsen/logrus_test.TestNestedLoggingReportsCorrectCaller", fields["func"])
+		"github.com/nandosuk/logrus_test.TestNestedLoggingReportsCorrectCaller", fields["func"])
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	assert.Equal(t, filepath.ToSlash(fmt.Sprintf("%s/logrus_test.go:%d", cwd, line-1)), filepath.ToSlash(fields["file"].(string)))
@@ -410,7 +410,7 @@ func TestNestedLoggingReportsCorrectCaller(t *testing.T) {
 	assert.Equal(t, "The hardest workin' man in show business", fields["msg"])
 	assert.Nil(t, fields["fields.msg"], "should not have prefixed previous `msg` entry")
 	assert.Equal(t,
-		"github.com/sirupsen/logrus_test.TestNestedLoggingReportsCorrectCaller", fields["func"])
+		"github.com/nandosuk/logrus_test.TestNestedLoggingReportsCorrectCaller", fields["func"])
 	require.NoError(t, err)
 	assert.Equal(t, filepath.ToSlash(fmt.Sprintf("%s/logrus_test.go:%d", cwd, line-1)), filepath.ToSlash(fields["file"].(string)))
 
@@ -666,7 +666,7 @@ func TestEntryWriter(t *testing.T) {
 	err = json.Unmarshal(bs, &fields)
 	assert.Nil(t, err)
 	assert.Equal(t, fields["foo"], "bar")
-	assert.Equal(t, fields["level"], "warning")
+	assert.Equal(t, fields["level"], "WARNING")
 }
 
 func TestLogLevelEnabled(t *testing.T) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
+	"github.com/nandosuk/logrus"
 )
 
 func ExampleLogger_Writer_httpServer() {


### PR DESCRIPTION
- replace sirupsen links with nandosuk
- capitalise logging level value, e.g. "info" -> "INFO"
- replace tests to now use capitalisations