### PR TITLE
format http.Request field in JSONFormatter

### DIFF
--- a/http_request_formater.go
+++ b/http_request_formater.go
@@ -1,0 +1,27 @@
+package logrus
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type httpRequestType struct {
+	URL        *url.URL
+	Method     string
+	Header     http.Header
+	RemoteAddr string
+	RequestURI string
+	Host       string
+}
+
+// Format http.Request to compatible type for json.Marshal
+func formatHTTPRequest(req *http.Request) httpRequestType {
+	return httpRequestType{
+		URL:        req.URL,
+		Method:     req.Method,
+		Header:     req.Header,
+		RemoteAddr: req.RemoteAddr,
+		RequestURI: req.RequestURI,
+		Host:       req.Host,
+	}
+}

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"runtime"
 )
 
@@ -61,6 +62,8 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	data := make(Fields, len(entry.Data)+4)
 	for k, v := range entry.Data {
 		switch v := v.(type) {
+		case *http.Request:
+			data[k] = formatHTTPRequest(v)
 		case error:
 			// Otherwise errors are ignored by `encoding/json`
 			// https://github.com/sirupsen/logrus/issues/137

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -1,9 +1,11 @@
 package logrus
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"runtime"
 	"strings"
 	"testing"
@@ -368,5 +370,16 @@ func TestJSONEnableHTMLEscape(t *testing.T) {
 	s := string(b)
 	if !(strings.Contains(s, "u0026") && strings.Contains(s, "u003e") && strings.Contains(s, "u003c")) {
 		t.Error("Message should be HTML escaped", s)
+	}
+}
+
+func TestJSONHttpRequest(t *testing.T) {
+	formatter := &JSONFormatter{}
+
+	req, _ := http.NewRequestWithContext(context.TODO(), "POST", "http://127.0.0.1?test=value", nil)
+
+	_, err := formatter.Format(WithField("request", req))
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
 	}
 }


### PR DESCRIPTION
Fix json.Marshal error while printing http.Request in field, using JSONFormatter
```
Failed to obtain reader, Failed to marshal fields to JSON, json: unsupported type: func()
```
Common pattern of usage logrus in web application is log messages with request context - but JSONFormatter can't marshal http.Request - and usage http.Request type in JSONFormatter is imposible - for usage logging, application must implement some formatter before adding http.Request field in logger
```go
package main

import (
	"net/http"

	log "github.com/sirupsen/logrus"
)

func main() {
	log.SetFormatter(&log.JSONFormatter{})

	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		log.WithField("request", r).Info("some info")
		// some logic
		w.Write([]byte("ok"))
	})
	http.ListenAndServe(":8080", nil)
}
```
I suggest use simple http.Request formatter before json marshaling - its will simplify usage logging in web apps