### PR TITLE
feat: copy Caller to new entry if reportCaller is not set

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -236,6 +236,8 @@ func (entry *Entry) log(level Level, msg string) {
 
 	if reportCaller {
 		newEntry.Caller = getCaller()
+	} else {
+		newEntry.Caller = entry.Caller
 	}
 
 	newEntry.fireHooks()


### PR DESCRIPTION
Copy `Caller` to new entry if ReportCaller is not set when `log`.

There are some scenarios where users want to pass the caller by themself, for example, many libraries accept a logger interface and use it to output internal log(such as SQL exec log for [`Gorm`](https://github.com/go-gorm/gorm/blob/26dd4c980a62d47c990a05da9e5566bff3b2b00c/logger/logger.go#L52)), many users wrap logrus to the needed interface, but the caller got by logrus is inaccuracy in this case, and need to get the caller and pass it into Entry, just throwing caller away will  break wrapped loggers for these libraries.

Passing caller in `Entry` works util #1229 imported `Dup` to fix race condition issue.