### PR TITLE
fix race condition for SetFormatter and SetReportCaller

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -284,13 +284,13 @@ func (entry *Entry) fireHooks() {
 }
 
 func (entry *Entry) write() {
+	entry.Logger.mu.Lock()
+	defer entry.Logger.mu.Unlock()
 	serialized, err := entry.Logger.Formatter.Format(entry)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to obtain reader, %v\n", err)
 		return
 	}
-	entry.Logger.mu.Lock()
-	defer entry.Logger.mu.Unlock()
 	if _, err := entry.Logger.Out.Write(serialized); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)
 	}

--- a/entry_test.go
+++ b/entry_test.go
@@ -269,8 +269,31 @@ func TestEntryLogfLevel(t *testing.T) {
 func TestEntryReportCallerRace(t *testing.T) {
 	logger := New()
 	entry := NewEntry(logger)
+
+	// logging before SetReportCaller has the highest chance of causing a race condition
+	// to be detected, but doing it twice just to increase the likelyhood of detecting the race
+	go func() {
+		entry.Info("should not race")
+	}()
 	go func() {
 		logger.SetReportCaller(true)
+	}()
+	go func() {
+		entry.Info("should not race")
+	}()
+}
+
+func TestEntryFormatterRace(t *testing.T) {
+	logger := New()
+	entry := NewEntry(logger)
+
+	// logging before SetReportCaller has the highest chance of causing a race condition
+	// to be detected, but doing it twice just to increase the likelyhood of detecting the race
+	go func() {
+		entry.Info("should not race")
+	}()
+	go func() {
+		logger.SetFormatter(&TextFormatter{})
 	}()
 	go func() {
 		entry.Info("should not race")


### PR DESCRIPTION
Unfortunately https://github.com/sirupsen/logrus/issues/1233 didn't really fix the race condition, the test just wasn't triggering the race condition to be detected...

`*Entry.write` just needs a lock for the whole function.