### PR TITLE
Add in preprocessing hook to add additional key/value pairs

### DIFF
--- a/json_formatter.go
+++ b/json_formatter.go
@@ -49,6 +49,8 @@ type JSONFormatter struct {
 	// }
 	FieldMap FieldMap
 
+	PreprocessorHook func(Fields)
+
 	// CallerPrettyfier can be set by the user to modify the content
 	// of the function and file keys in the json data when ReportCaller is
 	// activated. If any of the returned value is the empty string the
@@ -106,6 +108,10 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		if fileVal != "" {
 			data[f.FieldMap.resolve(FieldKeyFile)] = fileVal
 		}
+	}
+
+	if f.PreprocessorHook != nil {
+		f.PreprocessorHook(data)
 	}
 
 	var b *bytes.Buffer

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -370,3 +370,21 @@ func TestJSONEnableHTMLEscape(t *testing.T) {
 		t.Error("Message should be HTML escaped", s)
 	}
 }
+
+func TestPreprocessorHook(t *testing.T) {
+	formatter := &JSONFormatter{}
+	formatter.PreprocessorHook = func(f Fields) {
+		f["testme"] = "hello"
+	}
+	b, err := formatter.Format(&Entry{Message: "My Message"})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"testme"`) {
+		t.Error("Message should contain key added by preprocessor hook")
+	}
+	if !strings.Contains(s, `"hello"`) {
+		t.Error("Message should contain value added by preprocessor hook")
+	}
+}


### PR DESCRIPTION
We need to add additional key/value pairs to the log message for our logging flow.  Namely we want to auto-add the app name.  Anyway, this is a generic preprocessing hook that allows any modification to the data right before it is shipped to the JSON formatter.