### PR TITLE
reduce the list of cross build target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/ci/magefile.go
+++ b/ci/magefile.go
@@ -1,5 +1,4 @@
 //go:build mage
-// +build mage
 
 package main
 

--- a/ci/magefile.go
+++ b/ci/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main
@@ -7,13 +8,34 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sort"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 )
 
+func intersect(a, b []string) []string {
+	sort.Strings(a)
+	sort.Strings(b)
+
+	res := make([]string, 0, func() int {
+		if len(a) < len(b) {
+			return len(a)
+		}
+		return len(b)
+	}())
+
+	for _, v := range a {
+		idx := sort.SearchStrings(b, v)
+		if idx < len(b) && b[idx] == v {
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
 // getBuildMatrix returns the build matrix from the current version of the go compiler
-func getBuildMatrix() (map[string][]string, error) {
+func getFullBuildMatrix() (map[string][]string, error) {
 	jsonData, err := sh.Output("go", "tool", "dist", "list", "-json")
 	if err != nil {
 		return nil, err
@@ -36,6 +58,31 @@ func getBuildMatrix() (map[string][]string, error) {
 	}
 
 	return matrix, nil
+}
+
+func getBuildMatrix() (map[string][]string, error) {
+	minimalMatrix := map[string][]string{
+		"linux":   []string{"amd64"},
+		"darwin":  []string{"amd64", "arm64"},
+		"freebsd": []string{"amd64"},
+		"js":      []string{"wasm"},
+		"solaris": []string{"amd64"},
+		"windows": []string{"amd64", "arm64"},
+	}
+
+	fullMatrix, err := getFullBuildMatrix()
+	if err != nil {
+		return nil, err
+	}
+
+	for os, arches := range minimalMatrix {
+		if fullV, ok := fullMatrix[os]; !ok {
+			delete(minimalMatrix, os)
+		} else {
+			minimalMatrix[os] = intersect(arches, fullV)
+		}
+	}
+	return minimalMatrix, nil
 }
 
 func CrossBuild() error {


### PR DESCRIPTION
The build time is too long when cross build for all os/arch pair supported by the compiler.
The cross build has been reduced to what seems to be the most important targets.