### PR TITLE
gopherjs: fix build with js and solaris build tags

### DIFF
--- a/terminal_check_no_terminal.go
+++ b/terminal_check_no_terminal.go
@@ -1,4 +1,4 @@
-// +build js nacl plan9
+// +build js nacl plan9 gopherjs
 
 package logrus
 

--- a/terminal_check_solaris.go
+++ b/terminal_check_solaris.go
@@ -1,3 +1,5 @@
+//+build solaris
+
 package logrus
 
 import (


### PR DESCRIPTION
Fix the solaris build tag, and add the gopherjs tag to the terminal_check file.

This fixes the build with "gopherjs build -v"