### PR TITLE
Use text when shows the logrus output

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ plain text):
 With `log.SetFormatter(&log.JSONFormatter{})`, for easy parsing by logstash
 or Splunk:
 
-```json
+```text
 {"animal":"walrus","level":"info","msg":"A group of walrus emerges from the
 ocean","size":10,"time":"2014-03-10 19:57:38.562264131 -0400 EDT"}
 


### PR DESCRIPTION
Currently, the readme appears a red block as the syntax detecter thinks the JSON field is wrong:

![image](https://user-images.githubusercontent.com/52945328/174020633-4b74ce8e-36c8-498c-a7fe-5c13ba7f2995.png)
