### PR TITLE
update comment

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -16,9 +16,12 @@ const (
 // The Formatter interface is used to implement a custom Formatter. It takes an
 // `Entry`. It exposes all the fields, including the default ones:
 //
-// * `entry.Data["msg"]`. The message passed from Info, Warn, Error ..
-// * `entry.Data["time"]`. The timestamp.
-// * `entry.Data["level"]. The level the entry was logged at.
+// * DOES NOT WORK `entry.Data["msg"]`. The message passed from Info, Warn, Error ..
+// * entry.Message
+// * DOES NOT WORK `entry.Data["time"]`. The timestamp.
+// * entry.Time
+// * DOES NOT WORK `entry.Data["level"]. The level the entry was logged at.
+// * entry.Level
 //
 // Any additional fields added with `WithField` or `WithFields` are also in
 // `entry.Data`. Format is expected to return an array of bytes which are then


### PR DESCRIPTION
A custom log formatter doesn't work with this info from [formatter.go](https://github.com/sirupsen/logrus/blob/master/formatter.go). Used entry.Time, entry.Level, entry.Message instead.
```
// * `entry.Data["msg"]`. The message passed from Info, Warn, Error ..
// * `entry.Data["time"]`. The timestamp.
// * `entry.Data["level"]. The level the entry was logged at.
```