### PR TITLE
Add instructions to use different log levels for local and syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the last thing you want from your Logging library (again...).
 
 This does not mean Logrus is dead. Logrus will continue to be maintained for
 security, (backwards compatible) bug fixes, and performance (where we are
-limited by the interface). 
+limited by the interface).
 
 I believe Logrus' biggest contribution is to have played a part in today's
 widespread use of structured logging in Golang. There doesn't seem to be a
@@ -99,7 +99,7 @@ time="2015-03-26T01:27:38-04:00" level=fatal method=github.com/sirupsen/arcticcr
 ```
 Note that this does add measurable overhead - the cost will depend on the version of Go, but is
 between 20 and 40% in recent tests with 1.6 and 1.7.  You can validate this in your
-environment via benchmarks: 
+environment via benchmarks:
 ```
 go test -bench=.*CallerTracing
 ```
@@ -316,6 +316,8 @@ log.SetLevel(log.InfoLevel)
 
 It may be useful to set `log.Level = logrus.DebugLevel` in a debug or verbose
 environment if your application has that.
+
+Note: If you want different log levels for global (`log.SetLevel(...)`) and syslog logging, please check the [syslog hook README](hooks/syslog/README.md#different-log-levels-for-local-and-remote-logging).
 
 #### Entries
 

--- a/hooks/syslog/README.md
+++ b/hooks/syslog/README.md
@@ -37,3 +37,45 @@ func main() {
   }
 }
 ```
+
+### Different log levels for local and remote logging
+
+By default `NewSyslogHook()` sends logs through the hook for all log levels. If you want to have
+different log levels between local logging and syslog logging (i.e. respect the `priority` argument
+passed to `NewSyslogHook()`), you need to implement the `logrus_syslog.SyslogHook` interface
+overriding `Levels()` to return only the log levels you're interested on.
+
+The following example shows how to log at **DEBUG** level for local logging and **WARN** level for
+syslog logging:
+
+```go
+package main
+
+import (
+	"log/syslog"
+
+	log "github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+type customHook struct {
+	*logrus_syslog.SyslogHook
+}
+
+func (h *customHook) Levels() []log.Level {
+	return []log.Level{log.WarnLevel}
+}
+
+func main() {
+	log.SetLevel(log.DebugLevel)
+
+	hook, err := logrus_syslog.NewSyslogHook("tcp", "localhost:5140", syslog.LOG_WARNING, "myTag")
+	if err != nil {
+		panic(err)
+	}
+
+	log.AddHook(&customHook{hook})
+
+	//...
+}
+```


### PR DESCRIPTION
This PR adds instructions to the syslog readme about how to send different log levels to local logging (`log.SetLevel`) and syslog hook.

The related issue #1369 explains the issue. I didn't change the hook behaviour to avoid disrupting users implementations. Adding instructions to the readme seems a fair solution to help people having the same issue I had.

fixes #1369