### PR TITLE
support using with tinygo

### DIFF
--- a/terminal_check_bsd.go
+++ b/terminal_check_bsd.go
@@ -1,5 +1,6 @@
+//go:build (darwin || dragonfly || freebsd || netbsd || openbsd) && (!js || !tinygo)
 // +build darwin dragonfly freebsd netbsd openbsd
-// +build !js
+// +build !js !tinygo
 
 package logrus
 

--- a/terminal_check_js.go
+++ b/terminal_check_js.go
@@ -1,4 +1,5 @@
-// +build js
+//go:build js || tinygo
+// +build js tinygo
 
 package logrus
 

--- a/terminal_check_no_terminal.go
+++ b/terminal_check_no_terminal.go
@@ -1,4 +1,5 @@
-// +build js nacl plan9
+//go:build js || nacl || plan9 || tinygo
+// +build js nacl plan9 tinygo
 
 package logrus
 

--- a/terminal_check_notappengine.go
+++ b/terminal_check_notappengine.go
@@ -1,4 +1,5 @@
-// +build !appengine,!js,!windows,!nacl,!plan9
+//go:build !appengine && !js && !windows && !nacl && !plan9 && !tinygo
+// +build !appengine,!js,!windows,!nacl,!plan9,!tinygo
 
 package logrus
 

--- a/terminal_check_unix.go
+++ b/terminal_check_unix.go
@@ -1,5 +1,6 @@
+//go:build (linux || aix || zos) && (!js || !tinygo)
 // +build linux aix zos
-// +build !js
+// +build !js !tinygo
 
 package logrus
 

--- a/terminal_check_windows.go
+++ b/terminal_check_windows.go
@@ -1,4 +1,5 @@
-// +build !appengine,!js,windows
+//go:build !appengine && !js && !tinygo && windows
+// +build !appengine,!js,!tinygo,windows
 
 package logrus
 


### PR DESCRIPTION
hello

I am using `logrus` in a `golang wasm project` ([code here](https://github.com/rajatjindal/goodfirstissue/tree/wasm6)) and when trying to build it using `tinygo`, I am running into following issue:

```
$) tinygo build -target=wasi -gc=leaking -no-debug --tags 'tinygo' -o main.wasm main.go
wasm-ld: error: /var/folders/5r/6y6fr12x1dq6qnt74zn4_1wm0000gn/T/tinygo159344941/main.o: undefined symbol: golang.org/x/sys/unix.Syscall
error: failed to link /var/folders/5r/6y6fr12x1dq6qnt74zn4_1wm0000gn/T/tinygo159344941/main: exit status 1
Error: Build command for component goodfirstissue failed with status Exited(1)
```

I ran into a similar problem using [mattn/go-isatty](https://github.com/mattn/go-isatty), which is apparently fixed by a [similar PR](https://github.com/mattn/go-isatty/pull/74) 

therefore I am submitting this PR for `logurs` to allow us to use it with `tinygo` in a similar fashion.

Kindly let me know if this makes sense. I am happy to answer or implement any feedback that you might have.

Regards
Rajat Jindal
