### PR TITLE
Add WASI wasip1 support

### DIFF
--- a/terminal_check_wasip1.go
+++ b/terminal_check_wasip1.go
@@ -1,0 +1,8 @@
+//go:build wasip1
+// +build wasip1
+
+package logrus
+
+func isTerminal(fd int) bool {
+	return false
+}


### PR DESCRIPTION
Fix building when the new `wasip1` port is being used.
This is a new target that will be introduced by go 1.21.

For more details https://github.com/golang/go/issues/58141
