### PR TITLE
Improve how data > 64KB is logged

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"runtime"
+	"strings"
 )
 
 // Writer at INFO level. See WriterLevel for details.
@@ -54,14 +55,37 @@ func (entry *Entry) WriterLevel(level Level) *io.PipeWriter {
 	return writer
 }
 
+// writerScanner scans the input from the reader and writes it to the logger
 func (entry *Entry) writerScanner(reader *io.PipeReader, printFunc func(args ...interface{})) {
 	scanner := bufio.NewScanner(reader)
-	for scanner.Scan() {
-		printFunc(scanner.Text())
+
+	// Set the buffer size to the maximum token size to avoid buffer overflows
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), bufio.MaxScanTokenSize)
+
+	// Define a split function to split the input into chunks of up to 64KB
+	chunkSize := bufio.MaxScanTokenSize // 64KB
+	splitFunc := func(data []byte, atEOF bool) (int, []byte, error) {
+		if len(data) >= chunkSize {
+			return chunkSize, data[:chunkSize], nil
+		}
+
+		return bufio.ScanLines(data, atEOF)
 	}
+
+	// Use the custom split function to split the input
+	scanner.Split(splitFunc)
+
+	// Scan the input and write it to the logger using the specified print function
+	for scanner.Scan() {
+		printFunc(strings.TrimRight(scanner.Text(), "\r\n"))
+	}
+
+	// If there was an error while scanning the input, log an error
 	if err := scanner.Err(); err != nil {
 		entry.Errorf("Error while reading from Writer: %s", err)
 	}
+
+	// Close the reader when we are done
 	reader.Close()
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,10 +1,16 @@
 package logrus_test
 
 import (
+	"bufio"
+	"bytes"
 	"log"
 	"net/http"
+	"strings"
+	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleLogger_Writer_httpServer() {
@@ -31,4 +37,62 @@ func ExampleLogger_Writer_stdlib() {
 	// Note that `log` here references stdlib's log
 	// Not logrus imported under the name `log`.
 	log.SetOutput(logger.Writer())
+}
+
+func TestWriterSplitNewlines(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	logger := logrus.New()
+	logger.Formatter = &logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	}
+	logger.SetOutput(buf)
+	writer := logger.Writer()
+
+	const logNum = 10
+
+	for i := 0; i < logNum; i++ {
+		_, err := writer.Write([]byte("bar\nfoo\n"))
+		assert.NoError(t, err, "writer.Write failed")
+	}
+	writer.Close()
+	// Test is flaky because it writes in another goroutine,
+	// we need to make sure to wait a bit so all write are done.
+	time.Sleep(500 * time.Millisecond)
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.Len(t, lines, logNum*2, "logger printed incorrect number of lines")
+}
+
+func TestWriterSplitsMax64KB(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	logger := logrus.New()
+	logger.Formatter = &logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	}
+	logger.SetOutput(buf)
+	writer := logger.Writer()
+
+	// write more than 64KB
+	const bigWriteLen = bufio.MaxScanTokenSize + 100
+	output := make([]byte, bigWriteLen)
+	// lets not write zero bytes
+	for i := 0; i < bigWriteLen; i++ {
+		output[i] = 'A'
+	}
+
+	for i := 0; i < 3; i++ {
+		len, err := writer.Write(output)
+		assert.NoError(t, err, "writer.Write failed")
+		assert.Equal(t, bigWriteLen, len, "bytes written")
+	}
+	writer.Close()
+	// Test is flaky because it writes in another goroutine,
+	// we need to make sure to wait a bit so all write are done.
+	time.Sleep(500 * time.Millisecond)
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	// we should have 4 lines because we wrote more than 64 KB each time
+	assert.Len(t, lines, 4, "logger printed incorrect number of lines")
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -93,6 +93,6 @@ func TestWriterSplitsMax64KB(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	// we should have 4 lines because we wrote more than 64 KB each time
-	assert.Len(t, lines, 4, "logger printed incorrect number of lines")
+	// we should have 6 lines because we wrote more than 64 KB each time
+	assert.Len(t, lines, 6, "logger printed incorrect number of lines")
 }


### PR DESCRIPTION
This PR extends https://github.com/sirupsen/logrus/pull/1384 to support the desired approach of create new log lines when the log data is greater than 64KB.

The following is a decent test program that demonstrates this working:

```golang
package main

import (
	"bufio"
	"strings"
	"time"

	logrus "github.com/sirupsen/logrus"
)

func main() {
	output1 := strings.Repeat("A", bufio.MaxScanTokenSize) + "Z"
	output2 := strings.Repeat("B", bufio.MaxScanTokenSize) + "Z"

	logger := logrus.New()
	writer := logger.Writer()

	writer.Write([]byte("start"))
	writer.Write([]byte(output1))
	writer.Write([]byte(output2))
	writer.Write([]byte("end"))

	writer.Close()

	time.Sleep(500 * time.Millisecond)
}
```