### PR TITLE
Fix staticcheck issues

### DIFF
--- a/entry_test.go
+++ b/entry_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type contextKeyType string
+
 func TestEntryWithError(t *testing.T) {
 
 	assert := assert.New(t)
@@ -36,7 +38,8 @@ func TestEntryWithError(t *testing.T) {
 
 func TestEntryWithContext(t *testing.T) {
 	assert := assert.New(t)
-	ctx := context.WithValue(context.Background(), "foo", "bar")
+	var contextKey contextKeyType = "foo"
+	ctx := context.WithValue(context.Background(), contextKey, "bar")
 
 	assert.Equal(ctx, WithContext(ctx).Context)
 
@@ -56,11 +59,13 @@ func TestEntryWithContextCopiesData(t *testing.T) {
 	parentEntry := NewEntry(logger).WithField("parentKey", "parentValue")
 
 	// Create two children Entry objects from the parent in different contexts
-	ctx1 := context.WithValue(context.Background(), "foo", "bar")
+	var contextKey1 contextKeyType = "foo"
+	ctx1 := context.WithValue(context.Background(), contextKey1, "bar")
 	childEntry1 := parentEntry.WithContext(ctx1)
 	assert.Equal(ctx1, childEntry1.Context)
 
-	ctx2 := context.WithValue(context.Background(), "bar", "baz")
+	var contextKey2 contextKeyType = "bar"
+	ctx2 := context.WithValue(context.Background(), contextKey2, "baz")
 	childEntry2 := parentEntry.WithContext(ctx2)
 	assert.Equal(ctx2, childEntry2.Context)
 	assert.NotEqual(ctx1, ctx2)

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -544,8 +544,7 @@ func TestParseLevel(t *testing.T) {
 }
 
 func TestLevelString(t *testing.T) {
-	var loggerlevel Level
-	loggerlevel = 32000
+	var loggerlevel Level = 32000
 
 	_ = loggerlevel.String()
 }


### PR DESCRIPTION
This PR fixes the following go-staticcheck errors:

```sh
$ staticcheck
entry_test.go:39:49: should not use built-in type string as key for value; define your own type to avoid collisions (SA1029)
entry_test.go:59:50: should not use built-in type string as key for value; define your own type to avoid collisions (SA1029)
entry_test.go:63:50: should not use built-in type string as key for value; define your own type to avoid collisions (SA1029)
logrus_test.go:547:2: should merge variable declaration with assignment on next line (S1021)
```