### PR TITLE
fix text_formatter.go's bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sirupsen/logrus
+module github.com/amone-bit/logrus
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -246,7 +246,14 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 
 	levelText := strings.ToUpper(entry.Level.String())
 	if !f.DisableLevelTruncation && !f.PadLevelText {
-		levelText = levelText[0:4]
+		switch entry.Level {
+		case logrus.DebugLevel, logrus.TraceLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel:
+			levelText = levelText[0:5]
+		case logrus.WarnLevel, logrus.InfoLevel:
+			levelText = levelText[0:4]
+		default:
+			levelText = "UNKNOWN"
+		}
 	}
 	if f.PadLevelText {
 		// Generates the format string used in the next line, for example "%-6s" or "%-7s".

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -247,9 +247,9 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 	levelText := strings.ToUpper(entry.Level.String())
 	if !f.DisableLevelTruncation && !f.PadLevelText {
 		switch entry.Level {
-		case DebugLevel, TraceLevel, ErrorLevel, FatalLevel, PanicLevel:
+		case logrus.DebugLevel, logrus.TraceLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel:
 			levelText = levelText[0:5]
-		case WarnLevel, InfoLevel:
+		case logrus.WarnLevel, logrus.InfoLevel:
 			levelText = levelText[0:4]
 		default:
 			levelText = "UNKNOWN"

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -247,9 +247,9 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 	levelText := strings.ToUpper(entry.Level.String())
 	if !f.DisableLevelTruncation && !f.PadLevelText {
 		switch entry.Level {
-		case logrus.DebugLevel, logrus.TraceLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel:
+		case DebugLevel, TraceLevel, ErrorLevel, FatalLevel, PanicLevel:
 			levelText = levelText[0:5]
-		case logrus.WarnLevel, logrus.InfoLevel:
+		case WarnLevel, InfoLevel:
 			levelText = levelText[0:4]
 		default:
 			levelText = "UNKNOWN"


### PR DESCRIPTION
There is a BUG. when TextFormatter's ForceColors field is true and if log level letter length is five, it will only display the first four letter.EX. ERROR will display ERRO.

![image](https://github.com/sirupsen/logrus/assets/62925104/7946112b-09d2-46aa-9eca-2971f8356410)
