### PR TITLE
testutils: fix testify usage (report by testifylint)

### DIFF
--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/sirupsen/logrus"
-
 	"github.com/stretchr/testify/require"
+
+	. "github.com/sirupsen/logrus"
 )
 
 func LogAndAssertJSON(t *testing.T, log func(*Logger), assertions func(fields Fields)) {
@@ -23,7 +23,7 @@ func LogAndAssertJSON(t *testing.T, log func(*Logger), assertions func(fields Fi
 	log(logger)
 
 	err := json.Unmarshal(buffer.Bytes(), &fields)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	assertions(fields)
 }


### PR DESCRIPTION
Use `require.NoError(t, err)` instead of `require.Nil(t, err)` as suggested by testifylint.

```console
$ golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a on 2024-02-15T12:52:06Z
$ golangci-lint run ./internal/testutils
internal/testutils/testutils.go:26:2: error-nil: use require.NoError (testifylint)
	require.Nil(t, err)
	^
```