### PR TITLE
CI: upgrade golangci-lint to v1.56

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,15 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      # https://github.com/golangci/golangci-lint-action
+      - uses: golangci/golangci-lint-action@v4
         with:
           # must be specified without patch version
-          version: v1.46
+          version: v1.56
   cross:
     name: Cross
     timeout-minutes: 10


### PR DESCRIPTION
1. upgrade golangci-lint running in GitHub Actions
2. upgrade golangci-lint to v1.56.x

Note: issue in package `internal/testutils` reported by testifylint is fixed by #1424