### PR TITLE
hooks/test: fix incorrect use of math/rand

### DIFF
--- a/hooks/test/test_test.go
+++ b/hooks/test/test_test.go
@@ -41,8 +41,8 @@ func TestAllHooks(t *testing.T) {
 
 func TestLoggingWithHooksRace(t *testing.T) {
 
-	rand.Seed(time.Now().Unix())
-	unlocker := rand.Int() % 100
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	unlocker := r.Intn(100)
 
 	assert := assert.New(t)
 	logger, hook := NewNullLogger()


### PR DESCRIPTION
Fix incorrect uses of [`math/rand`](https://pkg.go.dev/math/rand):
- do not call [`rand.Seed()`](https://pkg.go.dev/math/rand#Seed) (deprecated since Go 1.20) in a test as it affects the global pseudo-random number generator and might affect other tests (or Logrus itself). Instead, use a local instance of a number generator.
- seed with [`time.Now().UnixNano()`](https://pkg.go.dev/time#Time.UnixNano) instead of [`time.Now().Unix()`](https://pkg.go.dev/time#Time.Unix) for more randomness
- use [`rand.Intn(100)`](https://pkg.go.dev/math/rand#Rand.Intn) instead of [`rand.Int() % 100`](https://pkg.go.dev/math/rand#Rand.Int)