### PR TITLE
CI: upgrade actions/checkout, actions/setup-go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,12 +32,12 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Cross
         working-directory: ci
         run: go run mage.go -v -w ../ crossBuild
@@ -51,11 +51,11 @@ jobs:
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
     - name: Test
       run: go test -race -v ./...


### PR DESCRIPTION
1. Reorder actions to always call [`checkout`](https://github.com/actions/checkout) before [`setup-go`](https://github.com/actions/setup-go)
2. Upgrade `checkout`, `setup-go` to latest

See also #1425 which covers the Golangci-lint job.