### PR TITLE
add redactrus as Third part logging formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Third party logging formatters:
 * [`nested-logrus-formatter`](https://github.com/antonfisher/nested-logrus-formatter). Converts logrus fields to a nested structure.
 * [`powerful-logrus-formatter`](https://github.com/zput/zxcTool). get fileName, log's line number and the latest function's name when print log; Sava log to files.
 * [`caption-json-formatter`](https://github.com/nolleh/caption_json_formatter). logrus's message json formatter with human-readable caption added.
+* [`redactrus`](https://github.com/ibreakthecloud/redactrus). Redacts sensitive information like password, apikeys, email, etc. from logs.
 
 You can define your formatter by implementing the `Formatter` interface,
 requiring a `Format` method. `Format` takes an `*Entry`. `entry.Data` is a


### PR DESCRIPTION
This PR updates README with one more third party logging formatter.

https://github.com/ibreakthecloud/redactrus

`redactrus` redacts sensitive information in logs.