### PR TITLE
Exposed Lock functionality/controls

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -68,6 +68,10 @@ func (mw *MutexWrap) Unlock() {
 	}
 }
 
+func (mw *MutexWrap) Enable() {
+	mw.disabled = false
+}
+
 func (mw *MutexWrap) Disable() {
 	mw.disabled = true
 }
@@ -345,6 +349,18 @@ func (logger *Logger) Exit(code int) {
 		logger.ExitFunc = os.Exit
 	}
 	logger.ExitFunc(code)
+}
+func (logger *Logger) Lock() {
+	logger.mu.Lock()
+}
+func (logger *Logger) Unlock() {
+	logger.mu.Unlock()
+}
+
+// When an implementer is manipulating the logger concurrently, the
+// implementer should call `SetYesLock` to enable the locking mechanism
+func (logger *Logger) SetYesLock() {
+	logger.mu.Enable()
 }
 
 //When file is opened with appending mode, it's safe to


### PR DESCRIPTION
When implementers are managing multiple applications within a single service, multiple logrus instances are used. These services can have different subset configurations such as Minimum level assignment.