### PR TITLE
add stub appveyor.yml to satisfy CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+# Minimal stub to satisfy AppVeyor CI
+version: 1.0.{build}
+image: windows
+shallow_clone: true
+
+branches:
+  only:
+    - main
+    - master
+
+build_script:
+  - echo "No-op build to satisfy AppVeyor CI"


### PR DESCRIPTION
We run CI on GitHub actions now, but the repository still expects AppVeyor to be present. Add a stub config to satisfy it.