### PR TITLE
CHANGELOG: add v1.10.0 release notes (unreleased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 1.10.0
+
+Fixes:
+  * Fix reentrant logging deadlocks in formatter paths.
+  * Fix race conditions in formatter and entry handling.
+  * Improve concurrency safety around formatter and hook access.
+
+Features:
+  * Basic `slog` hook for bridging Logrus entries to `log/slog`.
+
+Changed:
+  * Raise minimum supported Go version to 1.23.
+  * Improve TextFormatter performance and reduce allocations.
+  * Optimize Entry hot paths (including WithError and caller reporting).
+  * TextFormatter now renders `[]byte` values as raw/quoted strings instead of slice-of-ints.
+
+Performance:
+  * ~17% geomean runtime improvement and ~26% throughput increase overall.
+  * Significant allocation reductions across TextFormatter and Entry paths (large reductions in colored/text formatter cases).
+
+
 # 1.9.4
 
 Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.10.0 (unreleased)
+
+Fixes:
+  * Fix reentrant logging deadlocks in formatter paths.
+  * Fix race conditions in formatter and entry handling.
+  * Improve concurrency safety around formatter and hook access.
+
+Features:
+  * Basic `slog` hook for bridging Logrus entries to `log/slog`.
+  * Add minimal, composable logging interfaces for each log level. This enables
+    consumers to depend on narrower interfaces, making it easier to substitute
+    or adapt logging implementations.
+
+Changed:
+  * Raise minimum supported Go version to 1.23.
+  * Improve TextFormatter performance and reduce allocations.
+  * Optimize Entry hot paths (including WithError and caller reporting).
+  * TextFormatter now renders `[]byte` values as raw/quoted strings instead of slice-of-ints.
+
+Performance:
+  * ~17% geomean runtime improvement and ~26% throughput increase overall.
+  * Significant allocation reductions across TextFormatter and Entry paths (large reductions in colored/text formatter cases).
+
+
 ## 1.9.4
 
 Fixes:


### PR DESCRIPTION
Benchmarks (sampled at 8101d7eb512e40271e72d1d0051b87cbd31eb476)

<details>

```console
goos: darwin
goarch: arm64
pkg: github.com/sirupsen/logrus/benches
cpu: Apple M3 Pro
                                     │  v1.9.4.txt  │             master.txt              │
                                     │    sec/op    │   sec/op     vs base                │
Entry_WithError                        206.40n ± 2%   47.60n ± 2%  -76.94% (p=0.000 n=10)
Entry_WithField_Chain                   1.232µ ± 2%   1.169µ ± 2%   -5.11% (p=0.000 n=10)
Entry_WithFields/valid_fields_only      212.8n ± 1%   218.9n ± 1%   +2.84% (p=0.000 n=10)
Entry_WithFields/contains_func          261.5n ± 1%   264.5n ± 1%   +1.17% (p=0.000 n=10)
Entry_WithFields/contains_func_ptr      263.8n ± 1%   268.8n ± 1%   +1.91% (p=0.000 n=10)
Entry_WithFields/mixed_valid_invalid    309.3n ± 2%   317.8n ± 1%   +2.73% (p=0.000 n=10)
Entry_WithFields/larger_map             575.4n ± 0%   594.5n ± 1%   +3.31% (p=0.000 n=10)
Entry_ReportCaller_NoCaller             848.5n ± 1%   763.1n ± 1%  -10.06% (p=0.000 n=10)
Entry_ReportCaller_WithCaller           2.520µ ± 1%   2.423µ ± 1%   -3.83% (p=0.000 n=10)
Entry_ReportCaller_NoCaller_Depth4      849.9n ± 0%   763.2n ± 1%  -10.20% (p=0.000 n=10)
Entry_ReportCaller_WithCaller_Depth4    2.537µ ± 0%   2.446µ ± 1%   -3.61% (p=0.000 n=10)
ZeroTextFormatter                       392.5n ± 0%   323.4n ± 1%  -17.61% (p=0.000 n=10)
OneStringTextFormatter                  548.9n ± 2%   480.9n ± 1%  -12.38% (p=0.000 n=10)
OneNumericTextFormatter                 594.3n ± 0%   486.8n ± 1%  -18.09% (p=0.000 n=10)
OneBoolTextFormatter                    584.2n ± 0%   483.9n ± 1%  -17.18% (p=0.000 n=10)
NumericTextFormatter                    1.468µ ± 1%   1.102µ ± 1%  -24.93% (p=0.000 n=10)
BoolTextFormatter                      1249.5n ± 1%   942.9n ± 1%  -24.53% (p=0.000 n=10)
StringerTextFormatter                   1.773µ ± 1%   1.177µ ± 1%  -33.64% (p=0.000 n=10)
ErrorTextFormatter                      800.1n ± 0%   600.6n ± 1%  -24.95% (p=0.000 n=10)
SmallTextFormatter                      824.3n ± 1%   763.4n ± 1%   -7.39% (p=0.000 n=10)
LargeTextFormatter                      4.733µ ± 1%   4.144µ ± 1%  -12.44% (p=0.000 n=10)
SmallColoredTextFormatter              1119.0n ± 2%   722.3n ± 3%  -35.45% (p=0.000 n=10)
LargeColoredTextFormatter               6.854µ ± 1%   4.112µ ± 1%  -40.01% (p=0.000 n=10)
SmallJSONFormatter                      1.395µ ± 1%   1.407µ ± 1%   +0.82% (p=0.006 n=10)
LargeJSONFormatter                      7.098µ ± 1%   7.385µ ± 1%   +4.05% (p=0.000 n=10)
DummyLogger                             1.591µ ± 1%   1.375µ ± 1%  -13.58% (p=0.000 n=10)
DummyLoggerNoLock                       1.593µ ± 1%   1.369µ ± 1%  -14.09% (p=0.000 n=10)
LoggerLog/disabled_level                1.067n ± 1%   1.080n ± 8%   +1.17% (p=0.004 n=10)
LoggerLog/enabled_log                   193.8n ± 1%   131.8n ± 1%  -32.04% (p=0.000 n=10)
LoggerLog/enabled_logln                 246.4n ± 1%   132.6n ± 1%  -46.20% (p=0.000 n=10)
LoggerJSONFormatter                     1.879µ ± 1%   1.647µ ± 1%  -12.37% (p=0.000 n=10)
LoggerTextFormatter                     1.584µ ± 1%   1.255µ ± 7%  -20.75% (p=0.000 n=10)
geomean                                 740.9n        605.9n       -18.22%

                                     │   v1.9.4.txt   │                master.txt                 │
                                     │      B/op      │     B/op      vs base                     │
Entry_WithError                          448.0 ± 0%         0.0 ± 0%  -100.00% (p=0.000 n=10)
Entry_WithField_Chain                  2.188Ki ± 0%     2.078Ki ± 0%    -5.00% (p=0.000 n=10)
Entry_WithFields/valid_fields_only       448.0 ± 0%       448.0 ± 0%         ~ (p=1.000 n=10) ¹
Entry_WithFields/contains_func           488.0 ± 0%       488.0 ± 0%         ~ (p=1.000 n=10) ¹
Entry_WithFields/contains_func_ptr       488.0 ± 0%       488.0 ± 0%         ~ (p=1.000 n=10) ¹
Entry_WithFields/mixed_valid_invalid     488.0 ± 0%       488.0 ± 0%         ~ (p=1.000 n=10) ¹
Entry_WithFields/larger_map            1.320Ki ± 0%     1.320Ki ± 0%         ~ (p=1.000 n=10) ¹
Entry_ReportCaller_NoCaller              821.0 ± 0%       800.0 ± 0%    -2.56% (p=0.000 n=10)
Entry_ReportCaller_WithCaller          1.583Ki ± 0%     1.550Ki ± 0%    -2.10% (p=0.000 n=10)
Entry_ReportCaller_NoCaller_Depth4       821.0 ± 0%       800.0 ± 0%    -2.56% (p=0.000 n=10)
Entry_ReportCaller_WithCaller_Depth4   1.583Ki ± 0%     1.550Ki ± 0%    -2.10% (p=0.000 n=10)
ZeroTextFormatter                        272.0 ± 0%       232.0 ± 0%   -14.71% (p=0.000 n=10)
OneStringTextFormatter                   304.0 ± 0%       264.0 ± 0%   -13.16% (p=0.000 n=10)
OneNumericTextFormatter                  308.0 ± 0%       264.0 ± 0%   -14.29% (p=0.000 n=10)
OneBoolTextFormatter                     308.0 ± 0%       264.0 ± 0%   -14.29% (p=0.000 n=10)
NumericTextFormatter                     920.0 ± 0%       808.0 ± 0%   -12.17% (p=0.000 n=10)
BoolTextFormatter                        626.0 ± 0%       552.0 ± 0%   -11.82% (p=0.000 n=10)
StringerTextFormatter                    968.0 ± 0%       808.0 ± 0%   -16.53% (p=0.000 n=10)
ErrorTextFormatter                       472.0 ± 0%       424.0 ± 0%   -10.17% (p=0.000 n=10)
SmallTextFormatter                       528.0 ± 0%       488.0 ± 0%    -7.58% (p=0.000 n=10)
LargeTextFormatter                     3.773Ki ± 0%     3.156Ki ± 0%   -16.36% (p=0.000 n=10)
SmallColoredTextFormatter                600.0 ± 0%       392.0 ± 0%   -34.67% (p=0.000 n=10)
LargeColoredTextFormatter              4.406Ki ± 0%     2.859Ki ± 0%   -35.11% (p=0.000 n=10)
SmallJSONFormatter                     1.078Ki ± 0%     1.070Ki ± 0%    -0.72% (p=0.000 n=10)
LargeJSONFormatter                     5.086Ki ± 0%     5.078Ki ± 0%    -0.15% (p=0.000 n=10)
DummyLogger                              748.0 ± 0%       704.0 ± 0%    -5.88% (p=0.000 n=10)
DummyLoggerNoLock                        748.0 ± 0%       704.0 ± 0%    -5.88% (p=0.000 n=10)
LoggerLog/disabled_level                 0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10) ¹
LoggerLog/enabled_log                    212.0 ± 0%       208.0 ± 0%    -1.89% (p=0.000 n=10)
LoggerLog/enabled_logln                  240.0 ± 0%       208.0 ± 0%   -13.33% (p=0.000 n=10)
LoggerJSONFormatter                    2.156Ki ± 0%     2.125Ki ± 0%    -1.45% (p=0.000 n=10)
LoggerTextFormatter                    1.625Ki ± 0%     1.547Ki ± 0%    -4.81% (p=0.000 n=10)
geomean                                             ²                 ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                     │  v1.9.4.txt   │               master.txt                │
                                     │   allocs/op   │ allocs/op   vs base                     │
Entry_WithError                         3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
Entry_WithField_Chain                   15.00 ± 0%     14.00 ± 0%    -6.67% (p=0.000 n=10)
Entry_WithFields/valid_fields_only      3.000 ± 0%     3.000 ± 0%         ~ (p=1.000 n=10) ¹
Entry_WithFields/contains_func          5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=10) ¹
Entry_WithFields/contains_func_ptr      5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=10) ¹
Entry_WithFields/mixed_valid_invalid    5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=10) ¹
Entry_WithFields/larger_map             5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=10) ¹
Entry_ReportCaller_NoCaller             18.00 ± 0%     15.00 ± 0%   -16.67% (p=0.000 n=10)
Entry_ReportCaller_WithCaller           29.00 ± 0%     26.00 ± 0%   -10.34% (p=0.000 n=10)
Entry_ReportCaller_NoCaller_Depth4      18.00 ± 0%     15.00 ± 0%   -16.67% (p=0.000 n=10)
Entry_ReportCaller_WithCaller_Depth4    29.00 ± 0%     26.00 ± 0%   -10.34% (p=0.000 n=10)
ZeroTextFormatter                      10.000 ± 0%     7.000 ± 0%   -30.00% (p=0.000 n=10)
OneStringTextFormatter                 11.000 ± 0%     8.000 ± 0%   -27.27% (p=0.000 n=10)
OneNumericTextFormatter                12.000 ± 0%     8.000 ± 0%   -33.33% (p=0.000 n=10)
OneBoolTextFormatter                   12.000 ± 0%     8.000 ± 0%   -33.33% (p=0.000 n=10)
NumericTextFormatter                    19.00 ± 0%     10.00 ± 0%   -47.37% (p=0.000 n=10)
BoolTextFormatter                      18.000 ± 0%     9.000 ± 0%   -50.00% (p=0.000 n=10)
StringerTextFormatter                   22.00 ± 0%     10.00 ± 0%   -54.55% (p=0.000 n=10)
ErrorTextFormatter                     14.000 ± 0%     9.000 ± 0%   -35.71% (p=0.000 n=10)
SmallTextFormatter                     12.000 ± 0%     9.000 ± 0%   -25.00% (p=0.000 n=10)
LargeTextFormatter                      19.00 ± 0%     14.00 ± 0%   -26.32% (p=0.000 n=10)
SmallColoredTextFormatter              15.000 ± 0%     7.000 ± 0%   -53.33% (p=0.000 n=10)
LargeColoredTextFormatter               46.00 ± 0%     12.00 ± 0%   -73.91% (p=0.000 n=10)
SmallJSONFormatter                      25.00 ± 0%     23.00 ± 0%    -8.00% (p=0.000 n=10)
LargeJSONFormatter                      75.00 ± 0%     73.00 ± 0%    -2.67% (p=0.000 n=10)
DummyLogger                            13.000 ± 0%     9.000 ± 0%   -30.77% (p=0.000 n=10)
DummyLoggerNoLock                      13.000 ± 0%     9.000 ± 0%   -30.77% (p=0.000 n=10)
LoggerLog/disabled_level                0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
LoggerLog/enabled_log                   4.000 ± 0%     3.000 ± 0%   -25.00% (p=0.000 n=10)
LoggerLog/enabled_logln                 6.000 ± 0%     3.000 ± 0%   -50.00% (p=0.000 n=10)
LoggerJSONFormatter                     30.00 ± 0%     27.00 ± 0%   -10.00% (p=0.000 n=10)
LoggerTextFormatter                     21.00 ± 0%     16.00 ± 0%   -23.81% (p=0.000 n=10)
geomean                                            ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                          │  v1.9.4.txt  │              master.txt               │
                          │     B/s      │      B/s       vs base                │
ZeroTextFormatter           123.9Mi ± 0%    150.4Mi ± 1%  +21.38% (p=0.000 n=10)
OneStringTextFormatter      102.5Mi ± 2%    117.0Mi ± 1%  +14.13% (p=0.000 n=10)
OneNumericTextFormatter     89.86Mi ± 0%   109.71Mi ± 1%  +22.09% (p=0.000 n=10)
OneBoolTextFormatter        94.68Mi ± 0%   114.32Mi ± 1%  +20.75% (p=0.000 n=10)
NumericTextFormatter        85.76Mi ± 1%   114.21Mi ± 1%  +33.18% (p=0.000 n=10)
BoolTextFormatter           75.58Mi ± 1%   100.13Mi ± 1%  +32.49% (p=0.000 n=10)
StringerTextFormatter       75.30Mi ± 1%   113.50Mi ± 1%  +50.74% (p=0.000 n=10)
ErrorTextFormatter          79.85Mi ± 0%   106.39Mi ± 1%  +33.24% (p=0.000 n=10)
SmallTextFormatter          99.49Mi ± 1%   107.44Mi ± 1%   +7.98% (p=0.000 n=10)
LargeTextFormatter          57.63Mi ± 1%    65.82Mi ± 1%  +14.21% (p=0.000 n=10)
SmallColoredTextFormatter   122.7Mi ± 2%    190.1Mi ± 3%  +54.95% (p=0.000 n=10)
LargeColoredTextFormatter   77.92Mi ± 1%   129.90Mi ± 1%  +66.71% (p=0.000 n=10)
SmallJSONFormatter          77.93Mi ± 1%    77.29Mi ± 1%   -0.83% (p=0.005 n=10)
LargeJSONFormatter          55.09Mi ± 1%    52.94Mi ± 1%   -3.90% (p=0.000 n=10)
geomean                     84.78Mi         105.7Mi       +24.70%
```

</details>


And for the GitHub release notes;

-----

# Logrus v1.10.0

This release focuses on performance, concurrency correctness, and modern Go alignment.

## 🚀 Performance

Major improvements in `TextFormatter` and entry hot paths:

- ~17% geomean runtime improvement
- ~26% throughput increase
- Up to ~40% faster colored formatter output
- Large allocation reductions across text/colored formatter paths
- WithError path significantly faster and allocation-free

JSONFormatter performance remains largely unchanged.

## 🔒 Concurrency & Correctness

- Fix reentrant logging deadlocks (e.g. logging from within MarshalJSON / formatter code).
- Fix generic `Log` methods unexpectedly panicking when called with `PanicLevel`, contrary to their documented behavior.
- Eliminate race conditions in entry and formatter paths.
- Improve locking boundaries around formatter and hooks.

## ➕ Added

- Basic `slog` hook for bridging to Go’s `log/slog`.
- Add minimal, composable logging interfaces for each log level.

## ⚠️ Behavioral Changes

- Minimum Go version is now **1.23**.
- `TextFormatter` now renders `[]byte` as raw/quoted strings instead of numeric slices.  
  If you relied on the previous slice-of-ints output, convert explicitly before logging.
- `Entry.HasCaller` is now deprecated in favor of checking `Entry.Caller` directly. A `//go:fix inline` directive was added to allow updating existing uses automatically.
- Deprecated `MutexWrap`, which was unintentionally exposed as public API. It remains available as an alias for compatibility but should not be used directly.

---

v1.10 is primarily a performance and correctness release with no intentional public API changes.