### PR TITLE
fix: preserve metadata in Entry.Dup

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -108,6 +108,10 @@ func (entry *Entry) Dup() *Entry {
 		Logger:  entry.Logger,
 		Data:    maps.Clone(entry.Data),
 		Time:    entry.Time,
+		Level:   entry.Level,
+		Caller:  entry.Caller,
+		Message: entry.Message,
+		Buffer:  entry.Buffer,
 		Context: entry.Context,
 		err:     entry.err,
 	}

--- a/entry_test.go
+++ b/entry_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -126,6 +127,39 @@ func TestEntryWithTimeCopiesData(t *testing.T) {
 	val, exists = parentEntry.Data["childKey"]
 	assert.False(exists)
 	assert.Empty(val)
+}
+
+func TestEntryDupCopiesMetadata(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	buffer := bytes.NewBufferString("buffered")
+	caller := &runtime.Frame{Function: "example.fn", File: "example.go", Line: 42}
+	ctx := context.WithValue(context.Background(), contextKeyType("dup"), "value")
+
+	original := logrus.NewEntry(logger)
+	original.Data["animal"] = "walrus"
+	original.Time = time.Unix(1700000000, 0)
+	original.Level = logrus.WarnLevel
+	original.Caller = caller
+	original.Message = "duplicated"
+	original.Buffer = buffer
+	original.Context = ctx
+
+	dup := original.Dup()
+
+	require.NotSame(t, original, dup)
+	assert.Equal(t, original.Logger, dup.Logger)
+	assert.Equal(t, original.Time, dup.Time)
+	assert.Equal(t, original.Level, dup.Level)
+	assert.Equal(t, original.Caller, dup.Caller)
+	assert.Equal(t, original.Message, dup.Message)
+	assert.Equal(t, original.Buffer, dup.Buffer)
+	assert.Equal(t, original.Context, dup.Context)
+	assert.Equal(t, original.Data, dup.Data)
+
+	dup.Data["animal"] = "otter"
+	assert.Equal(t, "walrus", original.Data["animal"])
 }
 
 func TestEntryPanicln(t *testing.T) {


### PR DESCRIPTION

**Repo:** sirupsen/logrus (⭐ 24000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +38/-0

## What
This change fixes `Entry.Dup()` so it preserves the full entry metadata when cloning an entry. In addition to cloning `Data`, `Logger`, `Time`, `Context`, and internal error state, the duplicate now also keeps `Level`, `Caller`, `Message`, and `Buffer`. A regression test was added to verify that those fields are copied while the `Data` map remains independently cloned.

## Why
`Entry.Dup()` is a public API intended to produce a reusable copy of an entry for further modification. Its implementation and documentation had drifted: the method claimed to copy the entry's other metadata by value, but it silently dropped key fields that affect formatting and log output. That can lead to incomplete or surprising duplicated entries for callers that rely on `Dup()` outside the narrow internal path.

## Testing
Formatted the touched Go files with `gofmt -w entry.go entry_test.go`.
Attempted `GOCACHE=/tmp/sirupsen-logrus-gocache GOMODCACHE=/tmp/sirupsen-logrus-gomodcache go test -run '^TestEntryDupCopiesMetadata$' ./...`, but the environment is offline and the repo does not vendor test dependencies, so Go could not fetch `github.com/stretchr/testify` and `golang.org/x/sys`.

## Risk
Low - the behavior now matches the method's documented contract, and the change only affects the `Entry.Dup()` copy path with a targeted regression test.
