### PR TITLE
fix: build against tinygo

### DIFF
--- a/terminal_check_bsd.go
+++ b/terminal_check_bsd.go
@@ -1,4 +1,4 @@
-//go:build darwin || dragonfly || freebsd || netbsd || openbsd || hurd
+//go:build (darwin || dragonfly || freebsd || netbsd || openbsd || hurd) && !tinygo
 
 package logrus
 

--- a/terminal_check_notappengine.go
+++ b/terminal_check_notappengine.go
@@ -1,4 +1,4 @@
-//go:build !appengine && !js && !windows && !nacl && !plan9 && !wasi && !wasip1
+//go:build !appengine && !js && !windows && !nacl && !plan9 && !wasi && !wasip1 && !tinygo
 
 package logrus
 

--- a/terminal_check_solaris.go
+++ b/terminal_check_solaris.go
@@ -1,4 +1,4 @@
-//go:build solaris
+//go:build solaris && !tinygo
 
 package logrus
 

--- a/terminal_check_tinygo.go
+++ b/terminal_check_tinygo.go
@@ -1,0 +1,7 @@
+//go:build tinygo
+
+package logrus
+
+func checkIfTerminal(_ any) bool {
+	return false
+}

--- a/terminal_check_unix.go
+++ b/terminal_check_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || aix || zos
+//go:build (linux || aix || zos) && !tinygo
 
 package logrus
 


### PR DESCRIPTION
Fixes the build against tinygo by removing the import to the unix syscalls package conditional on the tinygo build tag.

Fixes tinygo build ./