### PR TITLE
remove unnecessary _tinygo.go variant 

### DIFF
--- a/terminal_check_no_terminal.go
+++ b/terminal_check_no_terminal.go
@@ -1,4 +1,4 @@
-//go:build js || nacl || plan9 || wasi || wasip1
+//go:build js || nacl || plan9 || wasi || wasip1 || tinygo
 
 package logrus
 

--- a/terminal_check_tinygo.go
+++ b/terminal_check_tinygo.go
@@ -1,7 +1,0 @@
-//go:build tinygo
-
-package logrus
-
-func checkIfTerminal(_ any) bool {
-	return false
-}


### PR DESCRIPTION
This PR fixes the changes I made in #1528 to add support for tinygo.

Include TinyGo in the `terminal_check_no_terminal.go` build tag and remove the separate TinyGo-only duplicate. This avoids TinyGo builds selecting both the TinyGo and JS no-terminal files for wasm targets.
