### PR TITLE
fix: run all hooks for a level even when one fails

### DIFF
--- a/hook_test.go
+++ b/hook_test.go
@@ -259,3 +259,36 @@ func TestHookFireOrder(t *testing.T) {
 	}
 	require.Equal(t, []string{"first hook", "second hook", "third hook"}, checkers)
 }
+
+type hookWithError struct {
+	fire func() error
+}
+
+func (h *hookWithError) Levels() []Level {
+	return AllLevels
+}
+
+func (h *hookWithError) Fire(*Entry) error {
+	return h.fire()
+}
+
+func TestHookFireContinuesAfterError(t *testing.T) {
+	checkers := []string{}
+	h := LevelHooks{}
+	h.Add(&hookWithError{fire: func() error {
+		checkers = append(checkers, "first hook")
+		return nil
+	}})
+	h.Add(&hookWithError{fire: func() error {
+		checkers = append(checkers, "second hook")
+		return assert.AnError
+	}})
+	h.Add(&hookWithError{fire: func() error {
+		checkers = append(checkers, "third hook")
+		return nil
+	}})
+
+	err := h.Fire(InfoLevel, &Entry{})
+	require.Error(t, err)
+	require.Equal(t, []string{"first hook", "second hook", "third hook"}, checkers)
+}

--- a/hooks.go
+++ b/hooks.go
@@ -1,5 +1,7 @@
 package logrus
 
+import "errors"
+
 // Hook describes hooks to be fired when logging on the logging levels returned from
 // [Hook.Levels] on your implementation of the interface. Note that this is not
 // fired in a goroutine or a channel with workers, you should handle such
@@ -24,11 +26,12 @@ func (hooks LevelHooks) Add(hook Hook) {
 // Fire all the hooks for the passed level. Used by `entry.log` to fire
 // appropriate hooks for a log entry.
 func (hooks LevelHooks) Fire(level Level, entry *Entry) error {
+	var errs []error
 	for _, hook := range hooks[level] {
 		if err := hook.Fire(entry); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
## Summary

`LevelHooks.Fire` now invokes every registered hook for the level and returns a combined error via `errors.Join`, instead of stopping after the first hook failure.

## Tests

- `TestHookFireContinuesAfterError` verifies later hooks still run when an earlier hook errors.

Fixes #408