### PR TITLE
Optimize single-string Log and Logln calls

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -366,6 +366,12 @@ func (entry *Entry) write() {
 // or exit. For that behavior, use [Entry.Panic] or [Entry.Fatal].
 func (entry *Entry) Log(level Level, args ...any) {
 	if entry.Logger.IsLevelEnabled(level) {
+		if len(args) == 1 {
+			if v, ok := args[0].(string); ok {
+				entry.log(level, v)
+				return
+			}
+		}
 		entry.log(level, fmt.Sprint(args...))
 	}
 }
@@ -456,7 +462,7 @@ func (entry *Entry) Panicf(format string, args ...any) {
 
 func (entry *Entry) Logln(level Level, args ...any) {
 	if entry.Logger.IsLevelEnabled(level) {
-		entry.Log(level, entry.sprintlnn(args...))
+		entry.log(level, entry.sprintlnn(args...))
 	}
 }
 
@@ -502,6 +508,11 @@ func (entry *Entry) Panicln(args ...any) {
 // their type. Instead of vendoring the Sprintln implementation to spare a
 // string allocation, we do the simplest thing.
 func (entry *Entry) sprintlnn(args ...any) string {
+	if len(args) == 1 {
+		if v, ok := args[0].(string); ok {
+			return v
+		}
+	}
 	msg := fmt.Sprintln(args...)
 	return msg[:len(msg)-1]
 }

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -60,6 +60,40 @@ func doLoggerBenchmarkNoLock(b *testing.B, out *os.File, formatter logrus.Format
 	})
 }
 
+type nopFormatter struct{}
+
+func (nopFormatter) Format(*logrus.Entry) ([]byte, error) {
+	return nil, nil
+}
+
+func BenchmarkLoggerLog(b *testing.B) {
+	logger := logrus.New()
+	logger.SetFormatter(nopFormatter{})
+	logger.SetLevel(logrus.InfoLevel)
+	logger.SetOutput(io.Discard)
+
+	b.ReportAllocs()
+
+	b.Run("disabled_level", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			logger.Log(logrus.DebugLevel, "test")
+		}
+	})
+	b.Run("enabled_log", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			logger.Log(logrus.WarnLevel, "test")
+		}
+	})
+	b.Run("enabled_logln", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			logger.Logln(logrus.WarnLevel, "test")
+		}
+	})
+}
+
 func BenchmarkLoggerJSONFormatter(b *testing.B) {
 	doLoggerBenchmarkWithFormatter(b, &logrus.JSONFormatter{})
 }


### PR DESCRIPTION
### add BenchmarkLoggerLog

### Optimize single-string Log and Logln calls

Avoid fmt.Sprint/fmt.Sprintln for the common case where a logging call
receives a single string argument. This preserves formatting semantics while
removing allocations from enabled Logger.Log and Logger.Logln calls.

For Entry.Logln, we can also skip Entry.Log as intermediate, as we don't
have to re-check if the log-level is enabled, and we already have a formatted
string.

    go test -run='^$' -bench='BenchmarkLoggerLog' -benchmem -count=10 -cpu=1 > after.txt
    benchstat before.txt after.txt
    goos: darwin
    goarch: arm64
    pkg: github.com/sirupsen/logrus
    cpu: Apple M3 Pro
                             │ before.txt  │              after.txt              │
                             │   sec/op    │   sec/op     vs base                │
    LoggerLog/disabled_level   1.072n ± 1%   1.075n ± 5%        ~ (p=0.631 n=10)
    LoggerLog/enabled_log      173.0n ± 1%   135.0n ± 0%  -21.97% (p=0.000 n=10)
    LoggerLog/enabled_logln    226.1n ± 1%   135.7n ± 0%  -39.97% (p=0.000 n=10)
    geomean                    34.74n        27.00n       -22.26%
    
                             │  before.txt  │              after.txt               │
                             │     B/op     │    B/op     vs base                  │
    LoggerLog/disabled_level   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
    LoggerLog/enabled_log      212.0 ± 0%     208.0 ± 0%   -1.89% (p=0.000 n=10)
    LoggerLog/enabled_logln    240.0 ± 0%     208.0 ± 0%  -13.33% (p=0.000 n=10)
    geomean                               ²                -5.26%                ²
    ¹ all samples are equal
    ² summaries must be >0 to compute geomean
    
                             │  before.txt  │              after.txt               │
                             │  allocs/op   │ allocs/op   vs base                  │
    LoggerLog/disabled_level   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
    LoggerLog/enabled_log      4.000 ± 0%     3.000 ± 0%  -25.00% (p=0.000 n=10)
    LoggerLog/enabled_logln    6.000 ± 0%     3.000 ± 0%  -50.00% (p=0.000 n=10)
    geomean                               ²               -27.89%                ²
    ¹ all samples are equal
    ² summaries must be >0 to compute geomean
