### PR TITLE
Entry.WithFields(): copy the original entry (rebase 536)

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -104,13 +104,9 @@ func NewEntry(logger *Logger) *Entry {
 // Data is cloned to avoid mutating the original entry. Other fields
 // (Logger, Time, Context, etc.) are copied by value.
 func (entry *Entry) Dup() *Entry {
-	return &Entry{
-		Logger:  entry.Logger,
-		Data:    maps.Clone(entry.Data),
-		Time:    entry.Time,
-		Context: entry.Context,
-		err:     entry.err,
-	}
+	newEntry := *entry
+	newEntry.Data = maps.Clone(entry.Data)
+	return &newEntry
 }
 
 // Bytes returns the bytes representation of this entry from the formatter.
@@ -151,24 +147,17 @@ func (entry *Entry) WithError(err error) *Entry {
 	maps.Copy(data, entry.Data)
 	data[ErrorKey] = err
 
-	return &Entry{
-		Logger:  entry.Logger,
-		Data:    data,
-		Time:    entry.Time,
-		Context: entry.Context,
-		err:     entry.err,
-	}
+	newEntry := *entry
+	newEntry.Data = data
+	return &newEntry
 }
 
 // WithContext adds a context to the Entry.
 func (entry *Entry) WithContext(ctx context.Context) *Entry {
-	return &Entry{
-		Logger:  entry.Logger,
-		Data:    maps.Clone(entry.Data),
-		Time:    entry.Time,
-		Context: ctx,
-		err:     entry.err,
-	}
+	newEntry := *entry
+	newEntry.Data = maps.Clone(entry.Data)
+	newEntry.Context = ctx
+	return &newEntry
 }
 
 // WithField adds a single field to the Entry.
@@ -209,13 +198,10 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 
 // WithTime overrides the time of the Entry.
 func (entry *Entry) WithTime(t time.Time) *Entry {
-	return &Entry{
-		Logger:  entry.Logger,
-		Data:    maps.Clone(entry.Data),
-		Time:    t,
-		Context: entry.Context,
-		err:     entry.err,
-	}
+	newEntry := *entry
+	newEntry.Data = maps.Clone(entry.Data)
+	newEntry.Time = t
+	return &newEntry
 }
 
 // getPackageName reduces a fully qualified function name to the package name

--- a/entry.go
+++ b/entry.go
@@ -200,7 +200,11 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 			data[k] = v
 		}
 	}
-	return &Entry{Logger: entry.Logger, Data: data, Time: entry.Time, err: fieldErr, Context: entry.Context}
+	// shallow copy
+	newentry := *entry
+	newentry.Data = data
+	newentry.err = fieldErr
+	return &newentry
 }
 
 // WithTime overrides the time of the Entry.

--- a/entry_test.go
+++ b/entry_test.go
@@ -247,6 +247,7 @@ func TestEntryWithFields(t *testing.T) {
 	// Check everything but Data is still the same
 	assert.Equal(t, entry1.Logger, entry2.Logger)
 	assert.Equal(t, entry1.Time, entry2.Time)
+	assert.Equal(t, entry1.Level, entry2.Level)
 	assert.Equal(t, entry1.Message, entry2.Message)
 	assert.Equal(t, entry1.Buffer, entry2.Buffer)
 
@@ -257,6 +258,7 @@ func TestEntryWithFields(t *testing.T) {
 	// Check everything but Data is still the same
 	assert.Equal(t, entry1.Logger, entry3.Logger)
 	assert.Equal(t, entry1.Time, entry3.Time)
+	assert.Equal(t, entry1.Level, entry3.Level)
 	assert.Equal(t, entry1.Message, entry3.Message)
 	assert.Equal(t, entry1.Buffer, entry3.Buffer)
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -232,6 +232,35 @@ func TestEntryHooksPanic(t *testing.T) {
 	entry.Info(badMessage)
 }
 
+func TestEntryWithFields(t *testing.T) {
+	entry1 := &logrus.Entry{
+		Logger: logrus.StandardLogger(),
+		Time:   time.Now(),
+		Level:  logrus.InfoLevel,
+	}
+
+	entry2 := entry1.WithFields(logrus.Fields{
+		"key1": "value1",
+		"key2": "value2",
+	})
+
+	// Check everything but Data is still the same
+	assert.Equal(t, entry1.Logger, entry2.Logger)
+	assert.Equal(t, entry1.Time, entry2.Time)
+	assert.Equal(t, entry1.Message, entry2.Message)
+	assert.Equal(t, entry1.Buffer, entry2.Buffer)
+
+	entry3 := entry2.WithFields(logrus.Fields{
+		"key3": "value4",
+		"key4": "value4",
+	})
+	// Check everything but Data is still the same
+	assert.Equal(t, entry1.Logger, entry3.Logger)
+	assert.Equal(t, entry1.Time, entry3.Time)
+	assert.Equal(t, entry1.Message, entry3.Message)
+	assert.Equal(t, entry1.Buffer, entry3.Buffer)
+}
+
 func TestEntryWithIncorrectField(t *testing.T) {
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.JSONFormatter{})


### PR DESCRIPTION
- rebase of https://github.com/sirupsen/logrus/pull/536

Copy the original entry and only modify the `Data` member with the new set of fields. So that calling several times `WithFields()` on an already logged entry (e.g. in a formatter) avoids an incorrecly initialized `Entry` structure.