### PR TITLE
add stub for haiku os

### DIFF
--- a/terminal_check_no_terminal.go
+++ b/terminal_check_no_terminal.go
@@ -1,4 +1,4 @@
-//go:build js || nacl || plan9 || wasi || wasip1 || tinygo
+//go:build js || nacl || plan9 || wasi || wasip1 || tinygo || haiku
 
 package logrus
 

--- a/terminal_check_notappengine.go
+++ b/terminal_check_notappengine.go
@@ -1,4 +1,4 @@
-//go:build !appengine && !js && !windows && !nacl && !plan9 && !wasi && !wasip1 && !tinygo
+//go:build !appengine && !js && !windows && !nacl && !plan9 && !wasi && !wasip1 && !tinygo && !haiku
 
 package logrus
 


### PR DESCRIPTION
Hi! this is part of an effort to get the [Forgejo actions runner](https://codeberg.org/soulphoenix/forgejo-runner-haiku) working on haiku os.

While haiku does have terminals, the `sys` go module currently doesn't support haiku, and so discerning what is a terminal is prohibitively difficult to do from go. Instead we assume that it is not running from a terminal.