### PR TITLE
fix: return error when Format is called with a nil Entry

### DIFF
--- a/formatter_nil_test.go
+++ b/formatter_nil_test.go
@@ -1,0 +1,22 @@
+package logrus
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTextFormatterNilEntry(t *testing.T) {
+	f := &TextFormatter{DisableColors: true}
+	_, err := f.Format(nil)
+	if err == nil || !strings.Contains(err.Error(), "nil Entry") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestJSONFormatterNilEntry(t *testing.T) {
+	f := &JSONFormatter{}
+	_, err := f.Format(nil)
+	if err == nil || !strings.Contains(err.Error(), "nil Entry") {
+		t.Fatalf("got %v", err)
+	}
+}

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"errors"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -62,6 +63,9 @@ type JSONFormatter struct {
 
 // Format renders a single log entry
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
+	if entry == nil {
+		return nil, errors.New("logrus: Format called with nil Entry")
+	}
 	caller := entry.Caller
 	data := make(Fields, len(entry.Data)+defaultFields)
 	for k, v := range entry.Data {

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"errors"
 	"bytes"
 	"fmt"
 	"maps"
@@ -140,6 +141,9 @@ func (f *TextFormatter) isColored(isTerminal bool) bool {
 
 // Format renders a single log entry
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
+	if entry == nil {
+		return nil, errors.New("logrus: Format called with nil Entry")
+	}
 	data := make(Fields, len(entry.Data))
 	maps.Copy(data, entry.Data)
 	isColored := f.isColored(f.isTerminal(entry))


### PR DESCRIPTION
## Summary
`TextFormatter.Format(nil)` and `JSONFormatter.Format(nil)` paniced.

Return `logrus: Format called with nil Entry` instead.

## Test plan
- [x] `go test .`
- [x] Unit tests for both formatters