### PR TITLE
fix: trim surrounding space in ParseLevel

### DIFF
--- a/logrus.go
+++ b/logrus.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 )
 
 // Fields type, used to pass to [WithFields].
@@ -38,7 +39,7 @@ func (level Level) String() string {
 
 // ParseLevel takes a string level and returns the Logrus log level constant.
 func ParseLevel(lvl string) (Level, error) {
-	return parseLevel([]byte(lvl))
+	return parseLevel([]byte(strings.TrimSpace(lvl)))
 }
 
 func parseLevel(b []byte) (Level, error) {

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -792,3 +792,14 @@ func TestSetReportCallerRace(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestParseLevelTrimSpace(t *testing.T) {
+	l, err := ParseLevel(" info ")
+	if err != nil || l != InfoLevel {
+		t.Fatalf("got %v %v", l, err)
+	}
+	l, err = ParseLevel("\twarn\n")
+	if err != nil || l != WarnLevel {
+		t.Fatalf("got %v %v", l, err)
+	}
+}


### PR DESCRIPTION
## What

`ParseLevel` trims surrounding whitespace before matching the level name.

## Why

Levels often come from env vars or config (`LOG_LEVEL= info `). Extra space should not make a valid name fail.

## Test

- `TestParseLevelTrimSpace`