### PR TITLE
fix: fire all level hooks even if one returns an error

### DIFF
--- a/hook_test.go
+++ b/hook_test.go
@@ -1,6 +1,7 @@
 package logrus_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -258,4 +259,28 @@ func TestHookFireOrder(t *testing.T) {
 		t.Error("unexpected error:", err)
 	}
 	require.Equal(t, []string{"first hook", "second hook", "third hook"}, checkers)
+}
+
+type errorHook struct {
+	name  string
+	fired *[]string
+	err   error
+}
+
+func (h *errorHook) Levels() []Level { return AllLevels }
+func (h *errorHook) Fire(entry *Entry) error {
+	*h.fired = append(*h.fired, h.name)
+	return h.err
+}
+
+func TestHookFireContinuesAfterError(t *testing.T) {
+	// Regression for #408: an error from one hook must not prevent later hooks.
+	var fired []string
+	hooks := LevelHooks{}
+	hooks.Add(&errorHook{name: "first", fired: &fired, err: errors.New("boom")})
+	hooks.Add(&errorHook{name: "second", fired: &fired, err: nil})
+
+	err := hooks.Fire(InfoLevel, &Entry{})
+	assert.Error(t, err)
+	assert.Equal(t, []string{"first", "second"}, fired)
 }

--- a/hooks.go
+++ b/hooks.go
@@ -1,5 +1,7 @@
 package logrus
 
+import "errors"
+
 // Hook describes hooks to be fired when logging on the logging levels returned from
 // [Hook.Levels] on your implementation of the interface. Note that this is not
 // fired in a goroutine or a channel with workers, you should handle such
@@ -24,11 +26,14 @@ func (hooks LevelHooks) Add(hook Hook) {
 // Fire all the hooks for the passed level. Used by `entry.log` to fire
 // appropriate hooks for a log entry.
 func (hooks LevelHooks) Fire(level Level, entry *Entry) error {
+	// Fire every registered hook for the level. Collect errors instead of
+	// stopping at the first failure so a broken hook cannot silence the rest
+	// (#408). Doc comment: "Fire all the hooks for the passed level."
+	var errs []error
 	for _, hook := range hooks[level] {
 		if err := hook.Fire(entry); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-
-	return nil
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
## Summary

`LevelHooks.Fire` returned on the first hook error, so later hooks for that level never ran. That contradicts the method doc comment ("Fire all the hooks for the passed level") and matches #408.

## Fix

Always invoke every registered hook for the level and aggregate errors with `errors.Join`.

## Tests

```text
go test . -count=1 -run 'TestHook'
# ok
```

Fixes #408
