### PR TITLE
Add slog.Handler writing to logrus.Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Fixes:
 Features:
 
   * Basic `slog` hook for bridging Logrus entries to `log/slog`.
+  * Add `slog.Handler` (`hooks/slog.NewHandler`) for bridging `log/slog` records
+    into a Logrus logger (levels, fields, groups, context, and time).
   * Add minimal, composable logging interfaces for each log level. This enables
     consumers to depend on narrower interfaces, making it easier to substitute
     or adapt logging implementations.

--- a/hooks/slog/handler.go
+++ b/hooks/slog/handler.go
@@ -1,0 +1,186 @@
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SlogLevelMapper maps a [slog.Level] to a [logrus.Level].
+//
+// To change the default level mapping, for instance to map custom slog levels
+// or to send [slog.LevelError] to [logrus.FatalLevel], set
+// [Handler.LevelMapper] to your own implementation of this function.
+type SlogLevelMapper func(slog.Level) logrus.Level
+
+// Handler is a [slog.Handler] that writes records to a [logrus.Logger].
+//
+// It is intended for bridging libraries or application code that log via slog
+// into an existing Logrus logger, for example during a gradual migration.
+//
+// Example usage:
+//
+//	logger := logrus.New()
+//	slog.SetDefault(slog.New(NewHandler(logger)))
+//	slog.Info("hello", "key", "value")
+type Handler struct {
+	logger *logrus.Logger
+
+	// LevelMapper maps slog levels to logrus levels.
+	// If nil, a default mapping is used (see [DefaultSlogLevelMapper]).
+	LevelMapper SlogLevelMapper
+
+	// fields holds attributes from prior WithAttrs calls, already resolved
+	// under the group prefix that applied when they were added.
+	fields logrus.Fields
+
+	// groups is the current group name stack for attributes added later.
+	groups []string
+}
+
+var _ slog.Handler = (*Handler)(nil)
+
+// NewHandler creates a [slog.Handler] that writes to the provided logrus Logger.
+// The provided logger must not be nil. NewHandler panics if logger is nil.
+func NewHandler(logger *logrus.Logger) *Handler {
+	if logger == nil {
+		panic("cannot create handler from nil logger")
+	}
+	return &Handler{
+		logger: logger,
+		fields: make(logrus.Fields),
+	}
+}
+
+// DefaultSlogLevelMapper is the default mapping from slog levels to logrus levels.
+//
+//	slog level >= Error  → ErrorLevel
+//	slog level >= Warn   → WarnLevel
+//	slog level >= Info   → InfoLevel
+//	slog level >= Debug  → DebugLevel
+//	otherwise            → TraceLevel
+func DefaultSlogLevelMapper(level slog.Level) logrus.Level {
+	switch {
+	case level >= slog.LevelError:
+		return logrus.ErrorLevel
+	case level >= slog.LevelWarn:
+		return logrus.WarnLevel
+	case level >= slog.LevelInfo:
+		return logrus.InfoLevel
+	case level >= slog.LevelDebug:
+		return logrus.DebugLevel
+	default:
+		return logrus.TraceLevel
+	}
+}
+
+func (h *Handler) toLogrusLevel(level slog.Level) logrus.Level {
+	if h.LevelMapper != nil {
+		return h.LevelMapper(level)
+	}
+	return DefaultSlogLevelMapper(level)
+}
+
+// Enabled reports whether the handler handles records at the given level.
+// It maps the slog level to a logrus level and consults the underlying logger.
+func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
+	return h.logger.IsLevelEnabled(h.toLogrusLevel(level))
+}
+
+// Handle converts the slog record into a logrus entry and logs it.
+// Record time, context, message, and attributes (including those from
+// WithAttrs/WithGroup) are preserved. Attributes are attached as logrus fields;
+// group names are joined with "." as a key prefix (similar to [slog.TextHandler]).
+func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+	level := h.toLogrusLevel(record.Level)
+
+	fields := maps.Clone(h.fields)
+	if fields == nil {
+		fields = make(logrus.Fields, record.NumAttrs())
+	}
+	record.Attrs(func(a slog.Attr) bool {
+		appendAttr(fields, h.groups, a)
+		return true
+	})
+
+	entry := logrus.NewEntry(h.logger).WithContext(ctx).WithTime(record.Time)
+	if len(fields) > 0 {
+		entry = entry.WithFields(fields)
+	}
+	entry.Log(level, record.Message)
+	return nil
+}
+
+// WithAttrs returns a new Handler whose attributes consist of h's attributes
+// followed by attrs.
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	h2 := h.clone()
+	h2.fields = maps.Clone(h.fields)
+	if h2.fields == nil {
+		h2.fields = make(logrus.Fields, len(attrs))
+	}
+	for _, a := range attrs {
+		appendAttr(h2.fields, h.groups, a)
+	}
+	return h2
+}
+
+// WithGroup returns a new Handler with a group appended to the receiver's
+// existing groups. All attributes added to the returned handler (via WithAttrs
+// or Handle) are nested under the combined group names.
+// If name is empty, WithGroup returns h unchanged.
+func (h *Handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	h2 := h.clone()
+	h2.groups = append(slices.Clip(h.groups), name)
+	return h2
+}
+
+func (h *Handler) clone() *Handler {
+	return &Handler{
+		logger:      h.logger,
+		LevelMapper: h.LevelMapper,
+		fields:      h.fields,
+		groups:      h.groups,
+	}
+}
+
+// appendAttr adds attr to fields, resolving it and applying group prefixes.
+// Group attributes are flattened with "."-separated keys.
+func appendAttr(fields logrus.Fields, groups []string, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return
+	}
+	if attr.Value.Kind() == slog.KindGroup {
+		gs := attr.Value.Group()
+		if len(gs) == 0 {
+			return
+		}
+		g := groups
+		if attr.Key != "" {
+			g = append(slices.Clip(groups), attr.Key)
+		}
+		for _, a := range gs {
+			appendAttr(fields, g, a)
+		}
+		return
+	}
+	if attr.Key == "" {
+		return
+	}
+	key := attr.Key
+	if len(groups) > 0 {
+		key = strings.Join(groups, ".") + "." + key
+	}
+	fields[key] = attr.Value.Any()
+}

--- a/hooks/slog/handler_test.go
+++ b/hooks/slog/handler_test.go
@@ -1,0 +1,305 @@
+package slog_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestHandler_basic(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s.Info("hello", "animal", "walrus")
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Level != logrus.InfoLevel {
+		t.Errorf("level: got %v, want %v", entry.Level, logrus.InfoLevel)
+	}
+	if entry.Message != "hello" {
+		t.Errorf("message: got %q, want %q", entry.Message, "hello")
+	}
+	if got, ok := entry.Data["animal"]; !ok || got != "walrus" {
+		t.Errorf("field animal: got %v (%v), want walrus", got, ok)
+	}
+}
+
+func TestHandler_levelMapping(t *testing.T) {
+	tests := []struct {
+		name      string
+		log       func(*slog.Logger)
+		wantLevel logrus.Level
+	}{
+		{
+			name:      "debug",
+			log:       func(s *slog.Logger) { s.Debug("d") },
+			wantLevel: logrus.DebugLevel,
+		},
+		{
+			name:      "info",
+			log:       func(s *slog.Logger) { s.Info("i") },
+			wantLevel: logrus.InfoLevel,
+		},
+		{
+			name:      "warn",
+			log:       func(s *slog.Logger) { s.Warn("w") },
+			wantLevel: logrus.WarnLevel,
+		},
+		{
+			name:      "error",
+			log:       func(s *slog.Logger) { s.Error("e") },
+			wantLevel: logrus.ErrorLevel,
+		},
+		{
+			name: "trace via low level",
+			log: func(s *slog.Logger) {
+				s.Log(context.Background(), slog.LevelDebug-4, "t")
+			},
+			wantLevel: logrus.TraceLevel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+			logger.SetLevel(logrus.TraceLevel)
+			s := slog.New(lslog.NewHandler(logger))
+			tt.log(s)
+			entry := hook.LastEntry()
+			if entry == nil {
+				t.Fatal("expected a log entry")
+			}
+			if entry.Level != tt.wantLevel {
+				t.Errorf("level: got %v, want %v", entry.Level, tt.wantLevel)
+			}
+		})
+	}
+}
+
+func TestHandler_customLevelMapper(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+
+	h := lslog.NewHandler(logger)
+	h.LevelMapper = func(slog.Level) logrus.Level {
+		return logrus.WarnLevel
+	}
+	s := slog.New(h)
+	s.Info("mapped")
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Level != logrus.WarnLevel {
+		t.Errorf("level: got %v, want %v", entry.Level, logrus.WarnLevel)
+	}
+}
+
+func TestHandler_enabledRespectsLogrusLevel(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.WarnLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s.Info("suppressed")
+	s.Warn("shown")
+
+	entries := hook.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Message != "shown" {
+		t.Errorf("message: got %q, want %q", entries[0].Message, "shown")
+	}
+}
+
+func TestHandler_withAttrsAndGroups(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s = s.With("root", 1)
+	s = s.WithGroup("req")
+	s = s.With("id", "abc")
+	s.Info("done", "status", 200)
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Message != "done" {
+		t.Errorf("message: got %q, want %q", entry.Message, "done")
+	}
+	// slog stores integer Attr values as int64.
+	want := map[string]any{
+		"root":       int64(1),
+		"req.id":     "abc",
+		"req.status": int64(200),
+	}
+	for k, v := range want {
+		got, ok := entry.Data[k]
+		if !ok {
+			t.Errorf("missing field %q", k)
+			continue
+		}
+		if got != v {
+			t.Errorf("field %q: got %v (%T), want %v (%T)", k, got, got, v, v)
+		}
+	}
+	if _, ok := entry.Data["id"]; ok {
+		t.Error("ungrouped key 'id' should not be present")
+	}
+}
+
+func TestHandler_inlineGroupAttr(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s.Info("msg", slog.Group("g", slog.Int("n", 3), slog.String("s", "x")))
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if got := entry.Data["g.n"]; got != int64(3) {
+		t.Errorf("g.n: got %v (%T), want int64(3)", got, got)
+	}
+	if got := entry.Data["g.s"]; got != "x" {
+		t.Errorf("g.s: got %v, want x", got)
+	}
+}
+
+func TestHandler_withEmptyGroupName(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	h := lslog.NewHandler(logger)
+	h2 := h.WithGroup("")
+	if h2 != h {
+		t.Error("WithGroup(\"\") should return the same handler")
+	}
+
+	s := slog.New(h)
+	s = s.WithGroup("")
+	s.Info("msg", "k", "v")
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if got := entry.Data["k"]; got != "v" {
+		t.Errorf("k: got %v, want v", got)
+	}
+}
+
+func TestHandler_contextAndTime(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "val")
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	h := lslog.NewHandler(logger)
+	s := slog.New(h)
+	s.LogAttrs(ctx, slog.LevelInfo, "timed", slog.Time("when", ts))
+
+	// Also log with an explicit record time via Handle path used by Logger.
+	// Logger sets record.Time itself; verify WithTime was applied by checking
+	// the entry is recent and context was stored.
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Context == nil {
+		t.Fatal("expected entry context to be set")
+	}
+	if got := entry.Context.Value(ctxKey{}); got != "val" {
+		t.Errorf("context value: got %v, want val", got)
+	}
+	if got := entry.Data["when"]; !got.(time.Time).Equal(ts) {
+		t.Errorf("when: got %v, want %v", got, ts)
+	}
+	if entry.Time.IsZero() {
+		t.Error("expected non-zero entry time")
+	}
+}
+
+func TestHandler_outputIntegration(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	})
+	logger.SetLevel(logrus.DebugLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s.With("chicken", "cluck").Error("error")
+
+	got := strings.TrimSpace(buf.String())
+	// TextFormatter field order is not guaranteed; check substrings.
+	for _, want := range []string{"level=error", "msg=error", "chicken=cluck"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output %q missing %q", got, want)
+		}
+	}
+}
+
+func TestHandler_nilLoggerPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for nil logger")
+		}
+	}()
+	_ = lslog.NewHandler(nil)
+}
+
+func TestDefaultSlogLevelMapper(t *testing.T) {
+	cases := []struct {
+		in   slog.Level
+		want logrus.Level
+	}{
+		{slog.LevelDebug - 1, logrus.TraceLevel},
+		{slog.LevelDebug, logrus.DebugLevel},
+		{slog.LevelInfo - 1, logrus.DebugLevel},
+		{slog.LevelInfo, logrus.InfoLevel},
+		{slog.LevelWarn - 1, logrus.InfoLevel},
+		{slog.LevelWarn, logrus.WarnLevel},
+		{slog.LevelError - 1, logrus.WarnLevel},
+		{slog.LevelError, logrus.ErrorLevel},
+		{slog.LevelError + 4, logrus.ErrorLevel},
+	}
+	for _, tc := range cases {
+		got := lslog.DefaultSlogLevelMapper(tc.in)
+		if got != tc.want {
+			t.Errorf("DefaultSlogLevelMapper(%v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestHandler_withAttrsEmpty(t *testing.T) {
+	logger := logrus.New()
+	logger.Out = io.Discard
+	h := lslog.NewHandler(logger)
+	if h.WithAttrs(nil) != h {
+		t.Error("WithAttrs(nil) should return same handler")
+	}
+	if h.WithAttrs([]slog.Attr{}) != h {
+		t.Error("WithAttrs(empty) should return same handler")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the remaining half of #1401: a `slog.Handler` that writes records into a `logrus.Logger`. The Logrus→slog hook already landed in #1407 (`hooks/slog`); this PR adds the reverse bridge in the same package.

```go
logger := logrus.New()
slog.SetDefault(slog.New(sloghook.NewHandler(logger)))
slog.Info("hello", "key", "value")
```

### Behavior

- **Levels**: default mapping Debug/Info/Warn/Error (and below-Debug → Trace); override with `Handler.LevelMapper`
- **Attributes**: attached as logrus fields; groups flattened with `.` key prefixes (same style as `slog.TextHandler`)
- **Context / time**: preserved via `WithContext` / `WithTime`
- **Enabled**: consults the underlying logger after level mapping
- **Go version**: `go.mod` is already 1.23, so no build tag / separate module is needed

### Tests

Coverage for level mapping, custom mapper, level filtering, `WithAttrs`/`WithGroup`, inline groups, context/time, and panic on nil logger.

Closes #1401