### PR TITLE
Add slog.Handler writing to logrus.Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Fixes:
 Features:
 
   * Basic `slog` hook for bridging Logrus entries to `log/slog`.
+  * Add `slog.Handler` (`hooks/slog.NewHandler`) for bridging `log/slog` records
+    into a Logrus logger (levels, fields, groups, context, and time).
   * Add minimal, composable logging interfaces for each log level. This enables
     consumers to depend on narrower interfaces, making it easier to substitute
     or adapt logging implementations.

--- a/hooks/slog/handler.go
+++ b/hooks/slog/handler.go
@@ -1,0 +1,209 @@
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Handler is a [slog.Handler] that writes records to a [logrus.Logger].
+//
+// It is intended for bridging libraries or application code that log via slog
+// into an existing Logrus logger, for example during a gradual migration.
+//
+// By default, slog levels map to their corresponding Logrus levels. Trace,
+// Fatal, and Panic use custom slog levels below Debug and above Error,
+// respectively, preserving their relative severity:
+//
+//   - [slog.LevelDebug] - 4 -> [logrus.TraceLevel]
+//   - [slog.LevelDebug] -> [logrus.DebugLevel]
+//   - [slog.LevelInfo] -> [logrus.InfoLevel]
+//   - [slog.LevelWarn] -> [logrus.WarnLevel]
+//   - [slog.LevelError] -> [logrus.ErrorLevel]
+//   - [slog.LevelError] + 2 -> [logrus.FatalLevel]
+//   - [slog.LevelError] + 4 -> [logrus.PanicLevel]
+//
+// Levels between these boundaries map to the next lower Logrus severity.
+// Levels below Debug map to [logrus.TraceLevel], and levels above Panic map
+// to [logrus.PanicLevel].
+//
+// Mapping to [logrus.FatalLevel] or [logrus.PanicLevel] preserves the level
+// only; handling a record does not exit or panic.
+//
+// Example usage:
+//
+//	logger := logrus.New()
+//	slog.SetDefault(slog.New(NewHandler(logger)))
+//	slog.Info("hello", "key", "value")
+type Handler struct {
+	logger *logrus.Logger
+
+	// LevelMapper maps slog levels to Logrus levels. If nil, the default
+	// mapping is used. Set it to customize level mapping, for example to map
+	// custom slog levels to specific Logrus levels.
+	LevelMapper func(slog.Level) logrus.Level
+
+	// fields holds attributes from prior WithAttrs calls, already resolved
+	// under the group prefix that applied when they were added.
+	fields logrus.Fields
+
+	// groups is the current group name stack for attributes added later.
+	groups []string
+}
+
+var _ slog.Handler = (*Handler)(nil)
+
+// NewHandler creates a [slog.Handler] that writes to the provided
+// [logrus.Logger].
+//
+// The provided logger must not be nil. NewHandler panics if logger is nil.
+func NewHandler(logger *logrus.Logger) *Handler {
+	if logger == nil {
+		panic("cannot create handler from nil logger")
+	}
+	return &Handler{
+		logger: logger,
+	}
+}
+
+// toLogrusLevel maps a slog level using LevelMapper or the default mapping.
+func (h *Handler) toLogrusLevel(level slog.Level) logrus.Level {
+	if h.LevelMapper != nil {
+		return h.LevelMapper(level)
+	}
+	switch {
+	case level >= slogLevelPanic:
+		return logrus.PanicLevel
+	case level >= slogLevelFatal:
+		return logrus.FatalLevel
+	case level >= slogLevelError:
+		return logrus.ErrorLevel
+	case level >= slogLevelWarn:
+		return logrus.WarnLevel
+	case level >= slogLevelInfo:
+		return logrus.InfoLevel
+	case level >= slogLevelDebug:
+		return logrus.DebugLevel
+	case level >= slogLevelTrace:
+		return logrus.TraceLevel
+	default:
+		return logrus.TraceLevel
+	}
+}
+
+// Enabled reports whether the handler handles records at the given level.
+// It maps the slog level to a logrus level and consults the underlying logger.
+func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
+	return h.logger.IsLevelEnabled(h.toLogrusLevel(level))
+}
+
+// Handle converts the slog record into a logrus entry and logs it.
+// Record time, context, message, and attributes (including those from
+// [Handler.WithAttrs]/[Handler.WithGroup]) are preserved. Attributes are
+// attached as logrus fields; group names are joined with "." as a key prefix
+// (similar to [slog.TextHandler]).
+func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+	level := h.toLogrusLevel(record.Level)
+	if !h.logger.IsLevelEnabled(level) {
+		return nil
+	}
+
+	entry := &logrus.Entry{
+		Logger:  h.logger,
+		Data:    h.fields,
+		Time:    record.Time,
+		Context: ctx,
+	}
+
+	if n := record.NumAttrs(); n > 0 {
+		// Clone before mutating the handler's fields.
+		entry.Data = maps.Clone(h.fields)
+		if entry.Data == nil {
+			entry.Data = make(logrus.Fields, n)
+		}
+		record.Attrs(func(a slog.Attr) bool {
+			appendAttr(entry.Data, h.groups, a)
+			return true
+		})
+	}
+
+	entry.Log(level, record.Message)
+	return nil
+}
+
+// WithAttrs returns a new Handler whose attributes consist of h's attributes
+// followed by attrs.
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	h2 := h.clone()
+	h2.fields = maps.Clone(h.fields)
+	if h2.fields == nil {
+		h2.fields = make(logrus.Fields, len(attrs))
+	}
+	for _, a := range attrs {
+		appendAttr(h2.fields, h.groups, a)
+	}
+	return h2
+}
+
+// WithGroup returns a new Handler with a group appended to the receiver's
+// existing groups. All attributes added to the returned handler (via WithAttrs
+// or Handle) are nested under the combined group names.
+// If name is empty, WithGroup returns h unchanged.
+func (h *Handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	h2 := h.clone()
+	h2.groups = append(slices.Clip(h.groups), name)
+	return h2
+}
+
+// clone returns a shallow copy of h. Callers must clone fields or groups
+// before modifying them.
+func (h *Handler) clone() *Handler {
+	return &Handler{
+		logger:      h.logger,
+		LevelMapper: h.LevelMapper,
+		fields:      h.fields,
+		groups:      h.groups,
+	}
+}
+
+// appendAttr adds attr to fields, resolving it and applying group prefixes.
+// Group attributes are flattened with "."-separated keys.
+func appendAttr(fields logrus.Fields, groups []string, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return
+	}
+	if attr.Value.Kind() == slog.KindGroup {
+		gs := attr.Value.Group()
+		if len(gs) == 0 {
+			return
+		}
+		g := groups
+		if attr.Key != "" {
+			g = append(slices.Clip(groups), attr.Key)
+		}
+		for _, a := range gs {
+			appendAttr(fields, g, a)
+		}
+		return
+	}
+
+	key := attr.Key
+	if len(groups) > 0 {
+		key = strings.Join(groups, ".")
+		if attr.Key != "" {
+			key += "." + attr.Key
+		}
+	}
+	fields[key] = attr.Value.Any()
+}

--- a/hooks/slog/handler_test.go
+++ b/hooks/slog/handler_test.go
@@ -1,0 +1,383 @@
+package slog_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandler_basic(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s.Info("hello", "animal", "walrus")
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Level != logrus.InfoLevel {
+		t.Errorf("level: got %v, want %v", entry.Level, logrus.InfoLevel)
+	}
+	if entry.Message != "hello" {
+		t.Errorf("message: got %q, want %q", entry.Message, "hello")
+	}
+	if got, ok := entry.Data["animal"]; !ok || got != "walrus" {
+		t.Errorf("field animal: got %v (%v), want walrus", got, ok)
+	}
+}
+
+func TestHandler_levelMapping(t *testing.T) {
+	tests := []struct {
+		name      string
+		log       func(*slog.Logger)
+		wantLevel logrus.Level
+	}{
+		{
+			name:      "debug",
+			log:       func(s *slog.Logger) { s.Debug("d") },
+			wantLevel: logrus.DebugLevel,
+		},
+		{
+			name:      "info",
+			log:       func(s *slog.Logger) { s.Info("i") },
+			wantLevel: logrus.InfoLevel,
+		},
+		{
+			name:      "warn",
+			log:       func(s *slog.Logger) { s.Warn("w") },
+			wantLevel: logrus.WarnLevel,
+		},
+		{
+			name:      "error",
+			log:       func(s *slog.Logger) { s.Error("e") },
+			wantLevel: logrus.ErrorLevel,
+		},
+		{
+			name: "trace",
+			log: func(s *slog.Logger) {
+				s.Log(context.Background(), slog.LevelDebug-4, "t")
+			},
+			wantLevel: logrus.TraceLevel,
+		},
+		{
+			name: "fatal",
+			log: func(s *slog.Logger) {
+				s.Log(context.Background(), slog.LevelError+2, "f")
+			},
+			wantLevel: logrus.FatalLevel,
+		},
+		{
+			name: "panic",
+			log: func(s *slog.Logger) {
+				s.Log(context.Background(), slog.LevelError+4, "p")
+			},
+			wantLevel: logrus.PanicLevel,
+		},
+		{
+			name: "below trace",
+			log: func(s *slog.Logger) {
+				s.Log(context.Background(), slog.LevelDebug-5, "t")
+			},
+			wantLevel: logrus.TraceLevel,
+		},
+		{
+			name: "between debug and info",
+			log: func(s *slog.Logger) {
+				s.Log(context.Background(), slog.LevelInfo-1, "d")
+			},
+			wantLevel: logrus.DebugLevel,
+		},
+		{
+			name: "between info and warn",
+			log: func(s *slog.Logger) {
+				s.Log(context.Background(), slog.LevelWarn-1, "i")
+			},
+			wantLevel: logrus.InfoLevel,
+		},
+		{
+			name: "between warn and error",
+			log: func(s *slog.Logger) {
+				s.Log(context.Background(), slog.LevelError-1, "w")
+			},
+			wantLevel: logrus.WarnLevel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+			logger.SetLevel(logrus.TraceLevel)
+			s := slog.New(lslog.NewHandler(logger))
+			tt.log(s)
+			entry := hook.LastEntry()
+			if entry == nil {
+				t.Fatal("expected a log entry")
+			}
+			if entry.Level != tt.wantLevel {
+				t.Errorf("level: got %v, want %v", entry.Level, tt.wantLevel)
+			}
+		})
+	}
+}
+
+func TestHandler_customLevelMapper(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+
+	h := lslog.NewHandler(logger)
+	h.LevelMapper = func(slog.Level) logrus.Level {
+		return logrus.WarnLevel
+	}
+	s := slog.New(h)
+	s.Info("mapped")
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Level != logrus.WarnLevel {
+		t.Errorf("level: got %v, want %v", entry.Level, logrus.WarnLevel)
+	}
+}
+
+func TestHandler_enabledRespectsLogrusLevel(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.WarnLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s.Info("suppressed")
+	s.Warn("shown")
+
+	entries := hook.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Message != "shown" {
+		t.Errorf("message: got %q, want %q", entries[0].Message, "shown")
+	}
+}
+
+func TestHandler_withAttrsAndGroups(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s = s.With("root", 1)
+	s = s.WithGroup("req")
+	s = s.With("id", "abc")
+	s.Info("done", "status", 200)
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Message != "done" {
+		t.Errorf("message: got %q, want %q", entry.Message, "done")
+	}
+	// slog stores integer Attr values as int64.
+	want := map[string]any{
+		"root":       int64(1),
+		"req.id":     "abc",
+		"req.status": int64(200),
+	}
+	for k, v := range want {
+		got, ok := entry.Data[k]
+		if !ok {
+			t.Errorf("missing field %q", k)
+			continue
+		}
+		if got != v {
+			t.Errorf("field %q: got %v (%T), want %v (%T)", k, got, got, v, v)
+		}
+	}
+	if _, ok := entry.Data["id"]; ok {
+		t.Error("ungrouped key 'id' should not be present")
+	}
+}
+
+func TestHandler_groupAttrs(t *testing.T) {
+	tests := []struct {
+		doc   string
+		attrs []any
+		want  logrus.Fields
+	}{
+		{
+			doc: "group",
+			attrs: []any{
+				slog.Group("g", slog.Int("n", 3), slog.String("s", "x")),
+			},
+			want: logrus.Fields{
+				"g.n": int64(3),
+				"g.s": "x",
+			},
+		},
+		{
+			doc: "empty key",
+			attrs: []any{
+				slog.Any("", "value"),
+			},
+			want: logrus.Fields{
+				"": "value",
+			},
+		},
+		{
+			doc: "empty key in group",
+			attrs: []any{
+				slog.Group("group", slog.Any("", "value")),
+			},
+			want: logrus.Fields{
+				"group": "value",
+			},
+		},
+		{
+			doc: "inline group",
+			attrs: []any{
+				slog.Group("", slog.String("key", "value")),
+			},
+			want: logrus.Fields{
+				"key": "value",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+			logger.SetLevel(logrus.DebugLevel)
+
+			s := slog.New(lslog.NewHandler(logger))
+			s.Info("msg", tc.attrs...)
+
+			entry := hook.LastEntry()
+			require.NotNil(t, entry)
+			assert.Equal(t, tc.want, entry.Data)
+		})
+	}
+}
+
+func TestHandler_withEmptyGroupName(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	h := lslog.NewHandler(logger)
+	h2 := h.WithGroup("")
+	if h2 != h {
+		t.Error(`WithGroup("") should return the same handler`)
+	}
+
+	s := slog.New(h)
+	s = s.WithGroup("")
+	s.Info("msg", "k", "v")
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if got := entry.Data["k"]; got != "v" {
+		t.Errorf("k: got %v, want v", got)
+	}
+}
+
+func TestHandler_contextAndTime(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "val")
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	h := lslog.NewHandler(logger)
+	s := slog.New(h)
+	s.LogAttrs(ctx, slog.LevelInfo, "timed", slog.Time("when", ts))
+
+	// Also log with an explicit record time via Handle path used by Logger.
+	// Logger sets record.Time itself; verify WithTime was applied by checking
+	// the entry is recent and context was stored.
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Context == nil {
+		t.Fatal("expected entry context to be set")
+	}
+	if got := entry.Context.Value(ctxKey{}); got != "val" {
+		t.Errorf("context value: got %v, want val", got)
+	}
+	if got := entry.Data["when"]; !got.(time.Time).Equal(ts) {
+		t.Errorf("when: got %v, want %v", got, ts)
+	}
+	if entry.Time.IsZero() {
+		t.Error("expected non-zero entry time")
+	}
+}
+
+func TestHandler_outputIntegration(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	})
+	logger.SetLevel(logrus.DebugLevel)
+
+	s := slog.New(lslog.NewHandler(logger))
+	s.With("chicken", "cluck").Error("error")
+
+	got := strings.TrimSpace(buf.String())
+	// TextFormatter field order is not guaranteed; check substrings.
+	for _, want := range []string{"level=error", "msg=error", "chicken=cluck"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output %q missing %q", got, want)
+		}
+	}
+}
+
+func TestHandler_nilLoggerPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for nil logger")
+		}
+	}()
+	_ = lslog.NewHandler(nil)
+}
+
+func TestHandler_withAttrsEmpty(t *testing.T) {
+	logger := logrus.New()
+	logger.Out = io.Discard
+	h := lslog.NewHandler(logger)
+	if h.WithAttrs(nil) != h {
+		t.Error("WithAttrs(nil) should return same handler")
+	}
+	if h.WithAttrs([]slog.Attr{}) != h {
+		t.Error("WithAttrs(empty) should return same handler")
+	}
+}
+
+// TestHandler_PreservesRecordTime verifies that Handle preserves the timestamp
+// carried by the slog record.
+func TestHandler_PreservesRecordTime(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	h := lslog.NewHandler(logger)
+
+	ts := time.Date(2026, 8, 12, 12, 34, 56, 789, time.UTC)
+	record := slog.NewRecord(ts, slog.LevelInfo, "hello", 0)
+
+	require.NoError(t, h.Handle(context.Background(), record))
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+	assert.Equal(t, ts, entry.Time)
+}


### PR DESCRIPTION
Other half of #1401: slog.Handler that writes into a logrus.Logger. Reverse of the hook from #1407.

```go
logger := logrus.New()
slog.SetDefault(slog.New(sloghook.NewHandler(logger)))
slog.Info("hello", "key", "value")
```

- levels: Debug/Info/Warn/Error by default, below Debug → Trace (override via `Handler.LevelMapper`)
- attrs → logrus fields; groups flattened with `.` (same idea as slog.TextHandler)
- keeps context + record time
- Enabled() follows the underlying logger level

tests for mapping, custom mapper, level filter, WithAttrs/WithGroup, inline groups, ctx/time, nil logger panic.

Closes #1401

(same patch as #1551 — closed that one by mistake, reopening here)