### PR TITLE
entry: deprecate Entry.HasCaller

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,3 +34,6 @@ linters:
           - gosec
           - musttag
           - noctx # TODO: enable once we switch to Go 1.24+.
+      - linters: # TODO: remove once golangci-lint is updated with https://github.com/golangci/golangci-lint/pull/6584
+          - gocheckcompilerdirectives
+        text: 'compiler directive unrecognized: //go:fix'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changed:
   * Improve TextFormatter performance and reduce allocations.
   * Optimize Entry hot paths (including WithError and caller reporting).
   * TextFormatter now renders `[]byte` values as raw/quoted strings instead of slice-of-ints.
+  * `Entry.HasCaller` is now deprecated in favor of checking `Entry.Caller` directly.
 
 Performance:
 

--- a/entry.go
+++ b/entry.go
@@ -270,8 +270,10 @@ func getCaller() *runtime.Frame {
 // HasCaller reports whether this Entry contains caller information.
 //
 // Caller is attached at log time if [Logger.ReportCaller] was enabled.
-// In most cases, it is preferable to check whether [Entry.Caller] is nil
-// directly.
+//
+// Deprecated: use [Entry.Caller] != nil instead.
+//
+//go:fix inline
 func (entry Entry) HasCaller() bool {
 	return entry.Caller != nil
 }


### PR DESCRIPTION
Deprecate Entry.HasCaller in favor of checking Entry.Caller directly.

HasCaller uses a value receiver, which copies the Entry unnecessarily for a simple nil check. Add a //go:fix inline directive so tooling can migrate callers to `Entry.Caller != nil` automatically, and clarify when caller information is normally attached.