### PR TITLE
entry: centralize entry duplication

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -104,9 +104,16 @@ func NewEntry(logger *Logger) *Entry {
 // Data is cloned to avoid mutating the original entry. Other fields
 // (Logger, Time, Context, etc.) are copied by value.
 func (entry *Entry) Dup() *Entry {
+	dup := entry.dup()
+	dup.Data = maps.Clone(entry.Data)
+	return dup
+}
+
+// dup copies the entry fields shared by derived entries except Data, which
+// callers must copy or initialize as appropriate for their use.
+func (entry *Entry) dup() *Entry {
 	return &Entry{
 		Logger:  entry.Logger,
-		Data:    maps.Clone(entry.Data),
 		Time:    entry.Time,
 		Context: entry.Context,
 		err:     entry.err,
@@ -147,28 +154,21 @@ func (entry *Entry) String() (string, error) {
 func (entry *Entry) WithError(err error) *Entry {
 	// Avoid reflection work in WithFields; we know the type is an error;
 	// copy the entry data and set the ErrorKey directly.
-	data := make(Fields, len(entry.Data)+1)
-	maps.Copy(data, entry.Data)
-	data[ErrorKey] = err
-
-	return &Entry{
-		Logger:  entry.Logger,
-		Data:    data,
-		Time:    entry.Time,
-		Context: entry.Context,
-		err:     entry.err,
+	dup := entry.dup()
+	dup.Data = maps.Clone(entry.Data)
+	if dup.Data == nil {
+		dup.Data = make(Fields, 1)
 	}
+	dup.Data[ErrorKey] = err
+	return dup
 }
 
 // WithContext adds a context to the Entry.
 func (entry *Entry) WithContext(ctx context.Context) *Entry {
-	return &Entry{
-		Logger:  entry.Logger,
-		Data:    maps.Clone(entry.Data),
-		Time:    entry.Time,
-		Context: ctx,
-		err:     entry.err,
-	}
+	dup := entry.dup()
+	dup.Data = maps.Clone(entry.Data)
+	dup.Context = ctx
+	return dup
 }
 
 // WithField adds a single field to the Entry.
@@ -178,9 +178,10 @@ func (entry *Entry) WithField(key string, value any) *Entry {
 
 // WithFields adds a map of fields to the Entry.
 func (entry *Entry) WithFields(fields Fields) *Entry {
-	data := make(Fields, len(entry.Data)+len(fields))
-	maps.Copy(data, entry.Data)
-	fieldErr := entry.err
+	dup := entry.dup()
+	dup.Data = make(Fields, len(entry.Data)+len(fields))
+	maps.Copy(dup.Data, entry.Data)
+
 	for k, v := range fields {
 		isErrField := false
 		if t := reflect.TypeOf(v); t != nil {
@@ -191,27 +192,24 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 		}
 		if isErrField {
 			tmp := fmt.Sprintf("can not add field %q", k)
-			if fieldErr != "" {
-				fieldErr += ", " + tmp
+			if dup.err != "" {
+				dup.err += ", " + tmp
 			} else {
-				fieldErr = tmp
+				dup.err = tmp
 			}
 		} else {
-			data[k] = v
+			dup.Data[k] = v
 		}
 	}
-	return &Entry{Logger: entry.Logger, Data: data, Time: entry.Time, err: fieldErr, Context: entry.Context}
+	return dup
 }
 
 // WithTime overrides the time of the Entry.
 func (entry *Entry) WithTime(t time.Time) *Entry {
-	return &Entry{
-		Logger:  entry.Logger,
-		Data:    maps.Clone(entry.Data),
-		Time:    t,
-		Context: entry.Context,
-		err:     entry.err,
-	}
+	dup := entry.dup()
+	dup.Data = maps.Clone(entry.Data)
+	dup.Time = t
+	return dup
 }
 
 // getPackageName reduces a fully qualified function name to the package name
@@ -279,8 +277,8 @@ func (entry Entry) HasCaller() bool {
 }
 
 func (entry *Entry) log(level Level, msg string) {
-	newEntry := entry.Dup()
-	logger := newEntry.Logger
+	newEntry := entry.dup()
+	newEntry.Data = maps.Clone(entry.Data)
 
 	if newEntry.Time.IsZero() {
 		newEntry.Time = time.Now()
@@ -289,6 +287,7 @@ func (entry *Entry) log(level Level, msg string) {
 	newEntry.Level = level
 	newEntry.Message = msg
 
+	logger := newEntry.Logger
 	logger.mu.Lock()
 	reportCaller := logger.ReportCaller
 	bufPool := newEntry.getBufferPool()


### PR DESCRIPTION
- supersedes, closes https://github.com/sirupsen/logrus/pull/1542
- supersedes, closes https://github.com/sirupsen/logrus/pull/536

Add an internal dup helper for copying the common Entry state used when deriving or logging entries.

Use the helper in Dup, WithError, WithContext, WithFields, WithTime, and log, while retaining the specialized Data allocation used by field-adding methods.


Benchmarks;

```console
                                     │ before.txt  │              after.txt              │
                                     │   sec/op    │   sec/op     vs base                │
Entry_WithError                        144.7n ± 0%   117.9n ± 1%  -18.56% (p=0.000 n=10)
Entry_WithField_Chain                  1.199µ ± 1%   1.107µ ± 1%   -7.68% (p=0.000 n=10)
Entry_WithFields/valid_fields_only     219.1n ± 1%   222.2n ± 1%   +1.39% (p=0.003 n=10)
Entry_WithFields/contains_func         268.6n ± 1%   268.9n ± 1%        ~ (p=0.987 n=10)
Entry_WithFields/contains_func_ptr     268.1n ± 1%   270.8n ± 1%   +1.01% (p=0.002 n=10)
Entry_WithFields/mixed_valid_invalid   320.9n ± 1%   320.5n ± 1%        ~ (p=1.000 n=10)
Entry_WithFields/larger_map            600.1n ± 1%   594.2n ± 1%   -0.97% (p=0.001 n=10)
geomean                                340.2n        327.3n        -3.79%

                                     │  before.txt  │               after.txt               │
                                     │     B/op     │     B/op      vs base                 │
Entry_WithError                          448.0 ± 0%     448.0 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithField_Chain                  2.188Ki ± 0%   2.188Ki ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/valid_fields_only       448.0 ± 0%     448.0 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/contains_func           488.0 ± 0%     488.0 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/contains_func_ptr       488.0 ± 0%     488.0 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/mixed_valid_invalid     488.0 ± 0%     488.0 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/larger_map            1.320Ki ± 0%   1.320Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                  684.8          684.8       +0.00%
¹ all samples are equal

                                     │ before.txt │              after.txt              │
                                     │ allocs/op  │ allocs/op   vs base                 │
Entry_WithError                        3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithField_Chain                  15.00 ± 0%   15.00 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/valid_fields_only     3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/contains_func         5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/contains_func_ptr     5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/mixed_valid_invalid   5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
Entry_WithFields/larger_map            5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                5.055        5.055       +0.00%
¹ all samples are equal
```
