### PR TITLE
entry: extract invalid field check, and touch-up error-message

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -173,7 +174,21 @@ func (entry *Entry) WithContext(ctx context.Context) *Entry {
 
 // WithField adds a single field to the Entry.
 func (entry *Entry) WithField(key string, value any) *Entry {
-	return entry.WithFields(Fields{key: value})
+	dup := entry.dup()
+	dup.Data = maps.Clone(entry.Data)
+	if isInvalidField(value) {
+		if dup.err != "" {
+			dup.err += ", can not add field " + strconv.Quote(key)
+		} else {
+			dup.err = "can not add field " + strconv.Quote(key)
+		}
+		return dup
+	}
+	if dup.Data == nil {
+		dup.Data = make(Fields, 1)
+	}
+	dup.Data[key] = value
+	return dup
 }
 
 // WithFields adds a map of fields to the Entry.
@@ -183,25 +198,25 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	maps.Copy(dup.Data, entry.Data)
 
 	for k, v := range fields {
-		isErrField := false
-		if t := reflect.TypeOf(v); t != nil {
-			switch {
-			case t.Kind() == reflect.Func, t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Func:
-				isErrField = true
-			}
-		}
-		if isErrField {
-			tmp := fmt.Sprintf("can not add field %q", k)
+		if isInvalidField(v) {
 			if dup.err != "" {
-				dup.err += ", " + tmp
+				dup.err += ", can not add field " + strconv.Quote(k)
 			} else {
-				dup.err = tmp
+				dup.err = "can not add field " + strconv.Quote(k)
 			}
 		} else {
 			dup.Data[k] = v
 		}
 	}
 	return dup
+}
+
+func isInvalidField(v any) bool {
+	t := reflect.TypeOf(v)
+	if t == nil {
+		return false
+	}
+	return t.Kind() == reflect.Func || t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Func
 }
 
 // WithTime overrides the time of the Entry.

--- a/entry.go
+++ b/entry.go
@@ -178,9 +178,9 @@ func (entry *Entry) WithField(key string, value any) *Entry {
 	dup.Data = maps.Clone(entry.Data)
 	if isInvalidField(value) {
 		if dup.err != "" {
-			dup.err += ", can not add field " + strconv.Quote(key)
+			dup.err += ", skipping unsupported field " + strconv.Quote(key)
 		} else {
-			dup.err = "can not add field " + strconv.Quote(key)
+			dup.err = "skipping unsupported field " + strconv.Quote(key)
 		}
 		return dup
 	}
@@ -197,15 +197,15 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	dup.Data = make(Fields, len(entry.Data)+len(fields))
 	maps.Copy(dup.Data, entry.Data)
 
-	for k, v := range fields {
-		if isInvalidField(v) {
+	for key, value := range fields {
+		if isInvalidField(value) {
 			if dup.err != "" {
-				dup.err += ", can not add field " + strconv.Quote(k)
+				dup.err += ", skipping unsupported field " + strconv.Quote(key)
 			} else {
-				dup.err = "can not add field " + strconv.Quote(k)
+				dup.err = "skipping unsupported field " + strconv.Quote(key)
 			}
 		} else {
-			dup.Data[k] = v
+			dup.Data[key] = value
 		}
 	}
 	return dup

--- a/entry_test.go
+++ b/entry_test.go
@@ -242,20 +242,20 @@ func TestEntryWithIncorrectField(t *testing.T) {
 	eWithFunc := entry.WithFields(logrus.Fields{"func": fn})
 	eWithFuncPtr := entry.WithFields(logrus.Fields{"funcPtr": &fn})
 
-	assert.Equal(t, `can not add field "func"`, getErr(t, eWithFunc))
-	assert.Equal(t, `can not add field "funcPtr"`, getErr(t, eWithFuncPtr))
+	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, eWithFunc))
+	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, eWithFuncPtr))
 
 	eWithFunc = eWithFunc.WithField("not_a_func", "it is a string")
 	eWithFuncPtr = eWithFuncPtr.WithField("not_a_func", "it is a string")
 
-	assert.Equal(t, `can not add field "func"`, getErr(t, eWithFunc))
-	assert.Equal(t, `can not add field "funcPtr"`, getErr(t, eWithFuncPtr))
+	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, eWithFunc))
+	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, eWithFuncPtr))
 
 	eWithFunc = eWithFunc.WithTime(time.Now())
 	eWithFuncPtr = eWithFuncPtr.WithTime(time.Now())
 
-	assert.Equal(t, `can not add field "func"`, getErr(t, eWithFunc))
-	assert.Equal(t, `can not add field "funcPtr"`, getErr(t, eWithFuncPtr))
+	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, eWithFunc))
+	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, eWithFuncPtr))
 }
 
 func getErr(t *testing.T, e *logrus.Entry) string {


### PR DESCRIPTION
Move the check for unsupported function values into a small helper so it can be reused by both WithField and WithFields.

This allows WithField to handle a single field directly instead of creating a temporary Fields map and delegating to WithFields, while keeping the validation logic in one place.

Before/after:

                                         │  before.txt  │              after.txt              │
                                         │    sec/op    │   sec/op     vs base                │
    Entry_WithError                         117.8n ± 1%   118.5n ± 1%   +0.64% (p=0.012 n=10)
    Entry_WithField_Chain                  1107.5n ± 1%   630.8n ± 0%  -43.04% (p=0.000 n=10)
    Entry_WithFields/valid_fields_only      224.2n ± 0%   225.3n ± 1%   +0.49% (p=0.002 n=10)
    Entry_WithFields/contains_func          273.2n ± 1%   247.5n ± 1%   -9.44% (p=0.000 n=10)
    Entry_WithFields/contains_func_ptr      279.8n ± 2%   249.8n ± 1%  -10.74% (p=0.001 n=10)
    Entry_WithFields/mixed_valid_invalid    327.2n ± 1%   299.9n ± 1%   -8.36% (p=0.000 n=10)
    Entry_WithFields/larger_map             619.8n ± 3%   612.2n ± 1%   -1.23% (p=0.007 n=10)
    geomean                                 332.9n        294.3n       -11.61%

                                         │  before.txt  │               after.txt               │
                                         │     B/op     │     B/op      vs base                 │
    Entry_WithError                          448.0 ± 0%     448.0 ± 0%       ~ (p=1.000 n=10) ¹
    Entry_WithField_Chain                  2.188Ki ± 0%   2.188Ki ± 0%       ~ (p=1.000 n=10) ¹
    Entry_WithFields/valid_fields_only       448.0 ± 0%     448.0 ± 0%       ~ (p=1.000 n=10) ¹
    Entry_WithFields/contains_func           488.0 ± 0%     480.0 ± 0%  -1.64% (p=0.000 n=10)
    Entry_WithFields/contains_func_ptr       488.0 ± 0%     480.0 ± 0%  -1.64% (p=0.000 n=10)
    Entry_WithFields/mixed_valid_invalid     488.0 ± 0%     480.0 ± 0%  -1.64% (p=0.000 n=10)
    Entry_WithFields/larger_map            1.320Ki ± 0%   1.320Ki ± 0%       ~ (p=1.000 n=10) ¹
    geomean                                  684.8          680.0       -0.71%
    ¹ all samples are equal