### PR TITLE
entry: preserve explicitly set caller information

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -67,8 +67,13 @@ type Entry struct {
 	// is fired and reflects the level used for that log call.
 	Level Level
 
-	// Caller contains the calling method information when caller
-	// reporting is enabled.
+	// Caller contains the calling method information.
+	//
+	// When [Logger.ReportCaller] is enabled, Caller is populated automatically at
+	// log time if it is nil. Hooks and formatters may inspect Caller.
+	//
+	// Applications generally should not modify Caller unless they intentionally
+	// want to provide custom caller information.
 	Caller *runtime.Frame
 
 	// Message is the log message supplied to one of the logging methods
@@ -116,6 +121,7 @@ func (entry *Entry) dup() *Entry {
 	return &Entry{
 		Logger:  entry.Logger,
 		Time:    entry.Time,
+		Caller:  entry.Caller,
 		Context: entry.Context,
 		err:     entry.err,
 	}
@@ -282,7 +288,8 @@ func getCaller() *runtime.Frame {
 
 // HasCaller reports whether this Entry contains caller information.
 //
-// Caller is attached at log time if [Logger.ReportCaller] was enabled.
+// Caller may be set explicitly, or populated at log time when
+// [Logger.ReportCaller] is enabled.
 //
 // Deprecated: use [Entry.Caller] != nil instead.
 //
@@ -308,7 +315,8 @@ func (entry *Entry) log(level Level, msg string) {
 	bufPool := newEntry.getBufferPool()
 	logger.mu.Unlock()
 
-	if reportCaller {
+	// Preserve explicitly set caller information.
+	if reportCaller && newEntry.Caller == nil {
 		newEntry.Caller = getCaller()
 	}
 

--- a/entry_test.go
+++ b/entry_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -230,6 +232,58 @@ func TestEntryHooksPanic(t *testing.T) {
 
 	entry := logrus.NewEntry(logger)
 	entry.Info(badMessage)
+}
+
+// TestEntryDerivationPreservesCaller verifies that derived entries retain
+// explicitly set caller information.
+func TestEntryDerivationPreservesCaller(t *testing.T) {
+	entry := logrus.NewEntry(logrus.New())
+	entry.Caller = &runtime.Frame{
+		Function: "example.function",
+		File:     "example.go",
+		Line:     42,
+	}
+
+	tests := []struct {
+		doc    string
+		derive func(*logrus.Entry) *logrus.Entry
+	}{
+		{
+			doc:    "Dup",
+			derive: func(entry *logrus.Entry) *logrus.Entry { return entry.Dup() },
+		},
+		{
+			doc:    "WithContext",
+			derive: func(entry *logrus.Entry) *logrus.Entry { return entry.WithContext(context.Background()) },
+		},
+		{
+			doc:    "WithError",
+			derive: func(entry *logrus.Entry) *logrus.Entry { return entry.WithError(errors.New("boom")) },
+		},
+		{
+			doc:    "WithField",
+			derive: func(entry *logrus.Entry) *logrus.Entry { return entry.WithField("foo", "bar") },
+		},
+		{
+			doc:    "WithFields",
+			derive: func(entry *logrus.Entry) *logrus.Entry { return entry.WithFields(logrus.Fields{"foo": "bar"}) },
+		},
+		{
+			doc:    "WithTime",
+			derive: func(entry *logrus.Entry) *logrus.Entry { return entry.WithTime(time.Now()) },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			got := tc.derive(entry)
+
+			require.NotNil(t, got.Caller)
+			assert.Equal(t, "example.function", got.Caller.Function)
+			assert.Equal(t, "example.go", got.Caller.File)
+			assert.Equal(t, 42, got.Caller.Line)
+		})
+	}
 }
 
 func TestEntryWithIncorrectField(t *testing.T) {

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -80,6 +80,47 @@ func TestReportCallerWhenConfigured(t *testing.T) {
 	})
 }
 
+// TestReportCallerPreservesExistingCaller verifies that explicitly set caller
+// information is preserved regardless of whether automatic caller reporting is enabled.
+func TestReportCallerPreservesExistingCaller(t *testing.T) {
+	tests := []struct {
+		doc          string
+		reportCaller bool
+	}{
+		{doc: "disabled", reportCaller: false},
+		{doc: "enabled", reportCaller: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			var buffer bytes.Buffer
+
+			logger := &Logger{
+				Out:          &buffer,
+				Level:        InfoLevel,
+				Formatter:    &JSONFormatter{},
+				ReportCaller: tc.reportCaller,
+			}
+
+			entry := logger.WithField("foo", "bar")
+			entry.Caller = &runtime.Frame{
+				Function: "custom.function",
+				File:     "custom.go",
+				Line:     42,
+			}
+
+			entry.Info("test")
+
+			var fields Fields
+			err := json.Unmarshal(buffer.Bytes(), &fields)
+			require.NoError(t, err)
+
+			assert.Equal(t, "custom.function", fields["func"])
+			assert.Equal(t, "custom.go:42", fields["file"])
+		})
+	}
+}
+
 func logSomething(t *testing.T, message string) Fields {
 	var buffer bytes.Buffer
 	var fields Fields


### PR DESCRIPTION
- supersedes, closes https://github.com/sirupsen/logrus/pull/1251
- updates https://github.com/sirupsen/logrus/pull/1229/changes#r600109998
- fixes https://github.com/sirupsen/logrus/issues/1220
- fixes https://github.com/sirupsen/logrus/issues/1020
- related https://github.com/sirupsen/logrus/issues/972
- related https://github.com/sirupsen/logrus/pull/1215


Keep an Entry's existing Caller when caller reporting is enabled instead of always replacing it with the automatically detected caller.

Update the Caller and HasCaller documentation to describe that Caller may be set explicitly and is only populated automatically when nil.