### PR TITLE
hooks/slog: remove LevelMapper type

### DIFF
--- a/hooks/slog/slog.go
+++ b/hooks/slog/slog.go
@@ -7,17 +7,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// LevelMapper maps a [logrus.Level] to a [slog.Leveler].
-//
-// To change the default level mapping, for instance to allow mapping to custom
-// or dynamic slog levels in your application, set [SlogHook.LevelMapper]
-// to your own implementation of this function.
-type LevelMapper func(logrus.Level) slog.Leveler
-
 // SlogHook sends logs to slog.
 type SlogHook struct {
-	logger      *slog.Logger
-	LevelMapper LevelMapper
+	logger *slog.Logger
+
+	// LevelMapper maps Logrus levels to slog levels. If nil, the default
+	// mapping is used. Set it to customize level mapping, for example to
+	// support custom or dynamic slog levels.
+	LevelMapper func(logrus.Level) slog.Leveler
 }
 
 var _ logrus.Hook = (*SlogHook)(nil)

--- a/hooks/slog/slog_test.go
+++ b/hooks/slog/slog_test.go
@@ -19,7 +19,7 @@ import (
 func TestSlogHook(t *testing.T) {
 	tests := []struct {
 		name   string
-		mapper lslog.LevelMapper
+		mapper func(logrus.Level) slog.Leveler
 		fn     func(*logrus.Logger)
 		want   []string
 	}{


### PR DESCRIPTION
- relates to / follow-up to https://github.com/sirupsen/logrus/pull/1407
- relates to https://github.com/sirupsen/logrus/issues/1401

Use a plain function field for SlogHook.LevelMapper instead of exposing a separate named function type.

The slog hook has not been included in a released version yet, so this API can still be adjusted without a deprecation cycle.

updates 8011284fadc315067c23e8cfc19bef11e130051c