### PR TITLE
hooks/slog: rename SlogHook to Hook

### DIFF
--- a/hooks/slog/slog.go
+++ b/hooks/slog/slog.go
@@ -7,8 +7,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// SlogHook sends logs to slog.
-type SlogHook struct {
+// Hook sends logs to slog.
+type Hook struct {
 	logger *slog.Logger
 
 	// LevelMapper maps Logrus levels to slog levels. If nil, the default
@@ -17,29 +17,29 @@ type SlogHook struct {
 	LevelMapper func(logrus.Level) slog.Leveler
 }
 
-var _ logrus.Hook = (*SlogHook)(nil)
+var _ logrus.Hook = (*Hook)(nil)
 
-// NewSlogHook creates a hook that sends logs to an existing slog Logger.
+// NewHook creates a hook that sends logs to an existing slog Logger.
 // This hook is intended to be used during transition from Logrus to slog,
 // or as a shim between different parts of your application or different
 // libraries that depend on different loggers.
 //
-// The provided logger must not be nil. NewSlogHook panics if logger is nil.
+// The provided logger must not be nil. NewHook panics if logger is nil.
 //
 // Example usage:
 //
 //	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
-//	hook := NewSlogHook(logger)
-func NewSlogHook(logger *slog.Logger) *SlogHook {
+//	hook := NewHook(logger)
+func NewHook(logger *slog.Logger) *Hook {
 	if logger == nil {
 		panic("cannot create hook from nil logger")
 	}
-	return &SlogHook{
+	return &Hook{
 		logger: logger,
 	}
 }
 
-func (h *SlogHook) toSlogLevel(level logrus.Level) slog.Leveler {
+func (h *Hook) toSlogLevel(level logrus.Level) slog.Leveler {
 	if h.LevelMapper != nil {
 		return h.LevelMapper(level)
 	}
@@ -60,7 +60,7 @@ func (h *SlogHook) toSlogLevel(level logrus.Level) slog.Leveler {
 
 // Levels always returns all levels, since slog allows controlling level
 // enabling based on context.
-func (h *SlogHook) Levels() []logrus.Level {
+func (h *Hook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
@@ -68,7 +68,7 @@ func (h *SlogHook) Levels() []logrus.Level {
 // Handler, mapping it to a slog.Record. Time and caller information are
 // preserved when available, and Entry.Data is converted to attributes.
 // If Entry.Context is nil, context.Background() is used.
-func (h *SlogHook) Fire(entry *logrus.Entry) error {
+func (h *Hook) Fire(entry *logrus.Entry) error {
 	ctx := entry.Context
 	if ctx == nil {
 		ctx = context.Background()

--- a/hooks/slog/slog_test.go
+++ b/hooks/slog/slog_test.go
@@ -73,7 +73,7 @@ func TestSlogHook(t *testing.T) {
 			}))
 			log := logrus.New()
 			log.Out = io.Discard
-			hook := lslog.NewSlogHook(slogLogger)
+			hook := lslog.NewHook(slogLogger)
 			hook.LevelMapper = tt.mapper
 			log.AddHook(hook)
 			tt.fn(log)
@@ -125,7 +125,7 @@ func TestSlogHook_error_propagates(t *testing.T) {
 	slogLogger := slog.New(&errorHandler{})
 	log := logrus.New()
 	log.SetOutput(io.Discard)
-	log.AddHook(lslog.NewSlogHook(slogLogger))
+	log.AddHook(lslog.NewHook(slogLogger))
 	log.WithField("key", "value").Error("test error")
 
 	// Restore stderr before closing the pipe writer to avoid leaving os.Stderr
@@ -158,7 +158,7 @@ func TestSlogHook_source(t *testing.T) {
 	log := logrus.New()
 	log.Out = io.Discard
 	log.ReportCaller = true
-	log.AddHook(lslog.NewSlogHook(slogLogger))
+	log.AddHook(lslog.NewHook(slogLogger))
 	log.Info("info with source")
 	got := strings.TrimSpace(buf.String())
 	wantRE := regexp.MustCompile(`source=.*hooks[\\/]+slog[\\/]+slog_test\.go:\d+`)


### PR DESCRIPTION
- relates to / follow-up to https://github.com/sirupsen/logrus/pull/1407
- relates to https://github.com/sirupsen/logrus/issues/1401

Rename SlogHook to Hook and NewSlogHook to NewHook to avoid repeating the package name in the public API.

The slog hook has not been included in a released version yet, so these names can still be adjusted without a deprecation cycle.

updates 4e3d3133d57894562639ccc807bcb1d7fd3466fc