### PR TITLE
hooks/slog: preserve extended Logrus levels

### DIFF
--- a/hooks/slog/slog.go
+++ b/hooks/slog/slog.go
@@ -7,7 +7,32 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Hook sends logs to slog.
+// slog levels corresponding to Logrus levels.
+const (
+	slogLevelTrace = slog.LevelDebug - 4
+	slogLevelDebug = slog.LevelDebug
+	slogLevelInfo  = slog.LevelInfo
+	slogLevelWarn  = slog.LevelWarn
+	slogLevelError = slog.LevelError
+	slogLevelFatal = slog.LevelError + 2
+	slogLevelPanic = slog.LevelError + 4
+)
+
+// Hook sends Logrus entries to slog.
+//
+// By default, Logrus levels map to their corresponding slog levels. Trace,
+// Fatal, and Panic use custom slog levels below Debug and above Error,
+// respectively, preserving their relative severity:
+//
+//   - [logrus.TraceLevel] -> [slog.LevelDebug] - 4
+//   - [logrus.DebugLevel] -> [slog.LevelDebug]
+//   - [logrus.InfoLevel] -> [slog.LevelInfo]
+//   - [logrus.WarnLevel] -> [slog.LevelWarn]
+//   - [logrus.ErrorLevel] -> [slog.LevelError]
+//   - [logrus.FatalLevel] -> [slog.LevelError] + 2
+//   - [logrus.PanicLevel] -> [slog.LevelError] + 4
+//
+// Set [Hook.LevelMapper] to customize this mapping.
 type Hook struct {
 	logger *slog.Logger
 
@@ -39,22 +64,29 @@ func NewHook(logger *slog.Logger) *Hook {
 	}
 }
 
+// toSlogLevel maps a Logrus level using LevelMapper or the default mapping.
 func (h *Hook) toSlogLevel(level logrus.Level) slog.Leveler {
 	if h.LevelMapper != nil {
 		return h.LevelMapper(level)
 	}
 	switch level {
-	case logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel:
-		return slog.LevelError
+	case logrus.PanicLevel:
+		return slogLevelPanic
+	case logrus.FatalLevel:
+		return slogLevelFatal
+	case logrus.ErrorLevel:
+		return slogLevelError
 	case logrus.WarnLevel:
-		return slog.LevelWarn
+		return slogLevelWarn
 	case logrus.InfoLevel:
-		return slog.LevelInfo
-	case logrus.DebugLevel, logrus.TraceLevel:
-		return slog.LevelDebug
+		return slogLevelInfo
+	case logrus.DebugLevel:
+		return slogLevelDebug
+	case logrus.TraceLevel:
+		return slogLevelTrace
 	default:
 		// Treat all unknown levels as errors
-		return slog.LevelError
+		return slogLevelError
 	}
 }
 

--- a/hooks/slog/slog_test.go
+++ b/hooks/slog/slog_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	lslog "github.com/sirupsen/logrus/hooks/slog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHook(t *testing.T) {
@@ -164,5 +166,44 @@ func TestHook_source(t *testing.T) {
 	wantRE := regexp.MustCompile(`source=.*hooks[\\/]+slog[\\/]+slog_test\.go:\d+`)
 	if !wantRE.MatchString(got) {
 		t.Errorf("expected log to contain source attribute matching %q, got: %s", wantRE.String(), got)
+	}
+}
+
+func TestHookLevelMapping(t *testing.T) {
+	tests := []struct {
+		level logrus.Level
+		want  string
+	}{
+		{level: logrus.PanicLevel, want: "ERROR+4"},
+		{level: logrus.FatalLevel, want: "ERROR+2"},
+		{level: logrus.ErrorLevel, want: "ERROR"},
+		{level: logrus.WarnLevel, want: "WARN"},
+		{level: logrus.InfoLevel, want: "INFO"},
+		{level: logrus.DebugLevel, want: "DEBUG"},
+		{level: logrus.TraceLevel, want: "DEBUG-4"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.level.String(), func(t *testing.T) {
+			var buf bytes.Buffer
+			hook := lslog.NewHook(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+				Level: slog.LevelDebug - 4, // slogLevelTrace
+				ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+					if attr.Key == slog.TimeKey {
+						return slog.Attr{}
+					}
+					return attr
+				},
+			})))
+
+			logger := logrus.New()
+			logger.SetOutput(io.Discard)
+			entry := logrus.NewEntry(logger)
+			entry.Level = tc.level
+			entry.Message = "message"
+
+			require.NoError(t, hook.Fire(entry))
+			assert.Contains(t, buf.String(), "level="+tc.want+" ")
+		})
 	}
 }

--- a/hooks/slog/slog_test.go
+++ b/hooks/slog/slog_test.go
@@ -16,7 +16,7 @@ import (
 	lslog "github.com/sirupsen/logrus/hooks/slog"
 )
 
-func TestSlogHook(t *testing.T) {
+func TestHook(t *testing.T) {
 	tests := []struct {
 		name   string
 		mapper func(logrus.Level) slog.Leveler
@@ -111,7 +111,7 @@ func (h *errorHandler) WithGroup(string) slog.Handler {
 	return h
 }
 
-func TestSlogHook_error_propagates(t *testing.T) {
+func TestHook_error_propagates(t *testing.T) {
 	stderr := os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -138,7 +138,7 @@ func TestSlogHook_error_propagates(t *testing.T) {
 	}
 }
 
-func TestSlogHook_source(t *testing.T) {
+func TestHook_source(t *testing.T) {
 	if runtime.Compiler == "tinygo" {
 		// TinyGo currently (v0.41.1) doesn't support `runtime.Caller`;
 		// https://tinygo.org/docs/reference/lang-support/stdlib/#logslog


### PR DESCRIPTION
- relates to / follow-up to https://github.com/sirupsen/logrus/pull/1407
- relates to https://github.com/sirupsen/logrus/issues/1401


### hooks/slog: rename tests to match implementation

updates d37a1efbcece94ad50f908ea8be317b73e58fcff

### hooks/slog: preserve extended Logrus levels

Map Trace, Fatal, and Panic to custom slog levels instead of collapsing them
into Debug and Error, preserving their relative severity and allowing the
mapping to round-trip through the slog Handler.

The slog hook has not been included in a released version yet, so this mapping
can still be adjusted without a compatibility concern.

updates 4e3d3133d57894562639ccc807bcb1d7fd3466fc
