### PR TITLE
logrus: deprecate MutexWrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changed:
   * Optimize Entry hot paths (including WithError and caller reporting).
   * TextFormatter now renders `[]byte` values as raw/quoted strings instead of slice-of-ints.
   * `Entry.HasCaller` is now deprecated in favor of checking `Entry.Caller` directly.
+  * Deprecated `MutexWrap`, which was unintentionally exposed as public API.
+    It remains available as an alias for compatibility but should not be used
+    directly.
 
 Performance:
 

--- a/logger.go
+++ b/logger.go
@@ -42,7 +42,7 @@ type Logger struct {
 	Level Level
 
 	// Used to sync writing to the log. Locking is enabled by Default
-	mu MutexWrap
+	mu mutexWrap
 
 	// Reusable empty entry
 	entryPool sync.Pool
@@ -55,24 +55,29 @@ type Logger struct {
 	BufferPool BufferPool
 }
 
-type MutexWrap struct {
+// MutexWrap is the mutex implementation used by [Logger].
+//
+// Deprecated: MutexWrap is an implementation detail of Logger and should not be used directly.
+type MutexWrap = mutexWrap
+
+type mutexWrap struct {
 	lock     sync.Mutex
 	disabled bool
 }
 
-func (mw *MutexWrap) Lock() {
+func (mw *mutexWrap) Lock() {
 	if !mw.disabled {
 		mw.lock.Lock()
 	}
 }
 
-func (mw *MutexWrap) Unlock() {
+func (mw *mutexWrap) Unlock() {
 	if !mw.disabled {
 		mw.lock.Unlock()
 	}
 }
 
-func (mw *MutexWrap) Disable() {
+func (mw *mutexWrap) Disable() {
 	mw.disabled = true
 }
 


### PR DESCRIPTION
- relates to https://github.com/sirupsen/logrus/pull/370

MutexWrap was introduced as an implementation detail for Logger.SetNoLock, but was exported as part of the package API.

Make the underlying implementation private and keep MutexWrap as a deprecated alias for compatibility.

updates bc35b026f0f9469fbd784f9066e936722d144c27