### PR TITLE
entry: don't panic when using Log with PanicLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Fixes:
 
   * Fix reentrant logging deadlocks in formatter paths.
   * Fix race conditions in formatter and entry handling.
+  * Fix generic `Log`, `Logf`, `Logln`, and `LogFn` methods unexpectedly
+    panicking when called with `PanicLevel`. Use the corresponding `Panic`
+    methods when panic behavior is desired.
   * Improve concurrency safety around formatter and hook access.
 
 Features:

--- a/entry.go
+++ b/entry.go
@@ -298,7 +298,33 @@ func (entry Entry) HasCaller() bool {
 	return entry.Caller != nil
 }
 
-func (entry *Entry) log(level Level, msg string) {
+func (entry *Entry) logArgs(level Level, panicAfter bool, args ...any) {
+	entry.log(level, panicAfter, sprint(args...))
+}
+
+func (entry *Entry) logf(level Level, panicAfter bool, format string, args ...any) {
+	entry.log(level, panicAfter, fmt.Sprintf(format, args...))
+}
+
+// logln uses Sprintln for multiple arguments to preserve Println-style
+// spacing between args, then trims the trailing newline.
+func (entry *Entry) logln(level Level, panicAfter bool, args ...any) {
+	if len(args) <= 1 {
+		entry.log(level, panicAfter, sprint(args...))
+		return
+	}
+	msg := fmt.Sprintln(args...)
+	msg = msg[:len(msg)-1] // Trim the newline added by Sprintln; logging adds its own.
+	entry.log(level, panicAfter, msg)
+}
+
+// log writes msg at level. If panicAfter is true, it panics with the fully
+// populated entry after hooks and output have completed.
+//
+// The explicit flag keeps panic behavior limited to Panic, Panicf, and
+// Panicln while avoiding a return value used only as the panic value.
+// See #1283 and commits f96066e and 5f8c666.
+func (entry *Entry) log(level Level, panicAfter bool, msg string) {
 	newEntry := entry.dup()
 	newEntry.Data = maps.Clone(entry.Data)
 
@@ -337,10 +363,9 @@ func (entry *Entry) log(level Level, msg string) {
 	newEntry.write()
 	newEntry.Buffer = nil
 
-	// To avoid Entry#log() returning a value that only would make sense for
-	// panic() to use in Entry#Panic(), we avoid the allocation by checking
-	// directly here.
-	if level <= PanicLevel {
+	// Panic here so the panic value contains the fully populated entry without
+	// requiring log to return it to the caller.
+	if panicAfter {
 		panic(newEntry)
 	}
 }
@@ -386,17 +411,13 @@ func (entry *Entry) write() {
 
 // Log logs a message at the specified level.
 //
-// Note: using Log with [PanicLevel] or [FatalLevel] does not trigger a panic
-// or exit. For that behavior, use [Entry.Panic] or [Entry.Fatal].
+// Using Log with [PanicLevel] or [FatalLevel] intentionally does not
+// trigger a panic or exit. Log treats the level as logging severity only;
+// use [Entry.Panic] or [Entry.Fatal] when those side effects are desired.
 func (entry *Entry) Log(level Level, args ...any) {
+	const panicAfter = false
 	if entry.Logger.IsLevelEnabled(level) {
-		if len(args) == 1 {
-			if v, ok := args[0].(string); ok {
-				entry.log(level, v)
-				return
-			}
-		}
-		entry.log(level, fmt.Sprint(args...))
+		entry.logArgs(level, panicAfter, args...)
 	}
 }
 
@@ -434,14 +455,23 @@ func (entry *Entry) Fatal(args ...any) {
 }
 
 func (entry *Entry) Panic(args ...any) {
-	entry.Log(PanicLevel, args...)
+	const panicAfter = true
+	if entry.Logger.IsLevelEnabled(PanicLevel) {
+		entry.logArgs(PanicLevel, panicAfter, args...)
+	}
 }
 
 // Entry Printf family functions
 
+// Logf logs a formatted message at the specified level.
+//
+// Using Logf with [PanicLevel] or [FatalLevel] intentionally does not
+// trigger a panic or exit. Logf treats the level as logging severity only;
+// use [Entry.Panicf] or [Entry.Fatalf] when those side effects are desired.
 func (entry *Entry) Logf(level Level, format string, args ...any) {
+	const panicAfter = false
 	if entry.Logger.IsLevelEnabled(level) {
-		entry.Log(level, fmt.Sprintf(format, args...))
+		entry.logf(level, panicAfter, format, args...)
 	}
 }
 
@@ -479,14 +509,23 @@ func (entry *Entry) Fatalf(format string, args ...any) {
 }
 
 func (entry *Entry) Panicf(format string, args ...any) {
-	entry.Logf(PanicLevel, format, args...)
+	const panicAfter = true
+	if entry.Logger.IsLevelEnabled(PanicLevel) {
+		entry.logf(PanicLevel, panicAfter, format, args...)
+	}
 }
 
 // Entry Println family functions
 
+// Logln logs a message at the specified level with Println-style spacing.
+//
+// Using Logln with [PanicLevel] or [FatalLevel] intentionally does not
+// trigger a panic or exit. Logln treats the level as logging severity only;
+// use [Entry.Panicln] or [Entry.Fatalln] when those side effects are desired.
 func (entry *Entry) Logln(level Level, args ...any) {
+	const panicAfter = false
 	if entry.Logger.IsLevelEnabled(level) {
-		entry.log(level, entry.sprintlnn(args...))
+		entry.logln(level, panicAfter, args...)
 	}
 }
 
@@ -524,19 +563,21 @@ func (entry *Entry) Fatalln(args ...any) {
 }
 
 func (entry *Entry) Panicln(args ...any) {
-	entry.Logln(PanicLevel, args...)
+	const panicAfter = true
+	if entry.Logger.IsLevelEnabled(PanicLevel) {
+		entry.logln(PanicLevel, panicAfter, args...)
+	}
 }
 
-// sprintlnn => Sprint no newline. This is to get the behavior of
-// fmt.Sprintln where spaces are always added between operands, regardless of
-// their type. Instead of vendoring the Sprintln implementation to spare a
-// string allocation, we do the simplest thing.
-func (entry *Entry) sprintlnn(args ...any) string {
-	if len(args) == 1 {
-		if v, ok := args[0].(string); ok {
-			return v
+// sprint is fmt.Sprint with fast paths for zero or one string argument.
+func sprint(args ...any) string {
+	switch len(args) {
+	case 0:
+		return ""
+	case 1:
+		if msg, ok := args[0].(string); ok {
+			return msg
 		}
 	}
-	msg := fmt.Sprintln(args...)
-	return msg[:len(msg)-1]
+	return fmt.Sprint(args...)
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -128,6 +129,51 @@ func TestEntryWithTimeCopiesData(t *testing.T) {
 	val, exists = parentEntry.Data["childKey"]
 	assert.False(exists)
 	assert.Empty(val)
+}
+
+// TestEntryLogPanicLevelDoesNotPanic verifies that generic Log methods treat
+// PanicLevel as severity only and do not trigger panic behavior.
+//
+// Regression and related history:
+//   - https://github.com/sirupsen/logrus/pull/65
+//   - https://github.com/sirupsen/logrus/pull/1283
+func TestEntryLogPanicLevelDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		doc  string
+		log  func(*logrus.Entry)
+		want string
+	}{
+		{
+			doc:  "Log",
+			log:  func(e *logrus.Entry) { e.Log(logrus.PanicLevel, "kaboom") },
+			want: "kaboom",
+		},
+		{
+			doc:  "Logf",
+			log:  func(e *logrus.Entry) { e.Logf(logrus.PanicLevel, "kaboom %d", 42) },
+			want: "kaboom 42",
+		},
+		{
+			doc:  "Logln",
+			log:  func(e *logrus.Entry) { e.Logln(logrus.PanicLevel, "kaboom", 42) },
+			want: "kaboom 42",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+
+			require.NotPanics(t, func() {
+				tc.log(logrus.NewEntry(logger))
+			})
+
+			got := hook.LastEntry()
+			require.NotNil(t, got)
+			assert.Equal(t, logrus.PanicLevel, got.Level)
+			assert.Equal(t, tc.want, got.Message)
+		})
+	}
 }
 
 func TestEntryPanicln(t *testing.T) {

--- a/logger.go
+++ b/logger.go
@@ -157,6 +157,11 @@ func (logger *Logger) WithTime(t time.Time) *Entry {
 	return entry.WithTime(t)
 }
 
+// Logf logs a formatted message at the specified level.
+//
+// Using Logf with [PanicLevel] or [FatalLevel] intentionally does not
+// trigger a panic or exit. Logf treats the level as logging severity only;
+// use [Logger.Panicf] or [Logger.Fatalf] when those side effects are desired.
 func (logger *Logger) Logf(level Level, format string, args ...any) {
 	if logger.IsLevelEnabled(level) {
 		entry := logger.newEntry()
@@ -201,13 +206,18 @@ func (logger *Logger) Fatalf(format string, args ...any) {
 }
 
 func (logger *Logger) Panicf(format string, args ...any) {
-	logger.Logf(PanicLevel, format, args...)
+	if logger.IsLevelEnabled(PanicLevel) {
+		entry := logger.newEntry()
+		defer logger.releaseEntry(entry)
+		entry.Panicf(format, args...)
+	}
 }
 
 // Log logs a message at the specified level.
 //
-// Note: using Log with [PanicLevel] or [FatalLevel] does not trigger a panic
-// or exit. For that behavior, use [Logger.Panic] or [Logger.Fatal].
+// Using Log with [PanicLevel] or [FatalLevel] intentionally does not
+// trigger a panic or exit. Log treats the level as logging severity only;
+// use [Logger.Panic] or [Logger.Fatal] when those side effects are desired.
 func (logger *Logger) Log(level Level, args ...any) {
 	if logger.IsLevelEnabled(level) {
 		entry := logger.newEntry()
@@ -216,6 +226,11 @@ func (logger *Logger) Log(level Level, args ...any) {
 	}
 }
 
+// LogFn logs a message returned by fn at the specified level.
+//
+// Using LogFn with [PanicLevel] or [FatalLevel] intentionally does not
+// trigger a panic or exit. LogFn treats the level as logging severity only;
+// use [Logger.PanicFn] or [Logger.FatalFn] when those side effects are desired.
 func (logger *Logger) LogFn(level Level, fn LogFunction) {
 	if logger.IsLevelEnabled(level) {
 		entry := logger.newEntry()
@@ -260,7 +275,11 @@ func (logger *Logger) Fatal(args ...any) {
 }
 
 func (logger *Logger) Panic(args ...any) {
-	logger.Log(PanicLevel, args...)
+	if logger.IsLevelEnabled(PanicLevel) {
+		entry := logger.newEntry()
+		defer logger.releaseEntry(entry)
+		entry.Panic(args...)
+	}
 }
 
 func (logger *Logger) TraceFn(fn LogFunction) {
@@ -299,9 +318,18 @@ func (logger *Logger) FatalFn(fn LogFunction) {
 }
 
 func (logger *Logger) PanicFn(fn LogFunction) {
-	logger.LogFn(PanicLevel, fn)
+	if logger.IsLevelEnabled(PanicLevel) {
+		entry := logger.newEntry()
+		defer logger.releaseEntry(entry)
+		entry.Panic(fn()...)
+	}
 }
 
+// Logln logs a message at the specified level with Println-style spacing.
+//
+// Using Logln with [PanicLevel] or [FatalLevel] intentionally does not
+// trigger a panic or exit. Logln treats the level as logging severity only;
+// use [Logger.Panicln] or [Logger.Fatalln] when those side effects are desired.
 func (logger *Logger) Logln(level Level, args ...any) {
 	if logger.IsLevelEnabled(level) {
 		entry := logger.newEntry()
@@ -346,7 +374,11 @@ func (logger *Logger) Fatalln(args ...any) {
 }
 
 func (logger *Logger) Panicln(args ...any) {
-	logger.Logln(PanicLevel, args...)
+	if logger.IsLevelEnabled(PanicLevel) {
+		entry := logger.newEntry()
+		defer logger.releaseEntry(entry)
+		entry.Panicln(args...)
+	}
 }
 
 func (logger *Logger) Exit(code int) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWarningAndWarninglnFormatting(t *testing.T) {
@@ -57,4 +59,56 @@ func TestLogger_SetBufferPool(t *testing.T) {
 
 	assert.Equal(t, 1, pool.get, "Logger.SetBufferPool(): The BufferPool.Get() must be called")
 	assert.Len(t, pool.buffers, 1, "Logger.SetBufferPool(): The BufferPool.Put() must be called")
+}
+
+// TestLoggerLogPanicLevelDoesNotPanic verifies that generic Log methods treat
+// PanicLevel as severity only and do not trigger panic behavior.
+//
+// Regression and related history:
+//   - https://github.com/sirupsen/logrus/pull/65
+//   - https://github.com/sirupsen/logrus/pull/1283
+func TestLoggerLogPanicLevelDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		doc  string
+		log  func(*logrus.Logger)
+		want string
+	}{
+		{
+			doc:  "Log",
+			log:  func(logger *logrus.Logger) { logger.Log(logrus.PanicLevel, "boom") },
+			want: "boom",
+		},
+		{
+			doc:  "Logf",
+			log:  func(logger *logrus.Logger) { logger.Logf(logrus.PanicLevel, "boom %d", 42) },
+			want: "boom 42",
+		},
+		{
+			doc:  "Logln",
+			log:  func(logger *logrus.Logger) { logger.Logln(logrus.PanicLevel, "boom", 42) },
+			want: "boom 42",
+		},
+		{
+			doc: "LogFn",
+			log: func(logger *logrus.Logger) {
+				logger.LogFn(logrus.PanicLevel, func() []any { return []any{"boom", 42} })
+			},
+			want: "boom42",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+
+			require.NotPanics(t, func() {
+				tc.log(logger)
+			})
+
+			got := hook.LastEntry()
+			require.NotNil(t, got)
+			assert.Equal(t, logrus.PanicLevel, got.Level)
+			assert.Equal(t, tc.want, got.Message)
+		})
+	}
 }


### PR DESCRIPTION
relates to:

- regression https://github.com/sirupsen/logrus/pull/65
- https://github.com/sirupsen/logrus/pull/1283
- https://github.com/sirupsen/logrus/pull/226
- https://github.com/sirupsen/logrus/pull/695

Generic Log methods treat their level as logging severity and intentionally do not apply the side effects of the corresponding Panic or Fatal methods.

Commit f96066e moved the panic from Entry.Panic into Entry.log as an optimization, so that Entry.log no longer needed to return the formatted message solely for use as the panic value. As a side effect, this caused Entry.Log(PanicLevel, ...) to panic as well.

Commit 5f8c666 later documented the intended distinction between the generic Log methods and the dedicated Panic and Fatal methods, but the Entry implementation remained inconsistent with that contract.

Pass the intended panic behavior explicitly through the internal logging helpers, so that only Panic, Panicf, and Panicln panic after logging. Keep the panic in Entry.log so that it uses the fully populated *Entry as the panic value without requiring the normal logging path to return it.

Also consolidate the argument formatting used by the Entry logging methods and document the same behavior for Logf and Logln.

This preserves the *Entry panic value established by 35f12fb and does not change the panic-safe locking introduced by 977e033.

Regression introduced in f96066e.