### PR TITLE
hooks/slog: add package documentation and examples

### DIFF
--- a/hooks/slog/handler.go
+++ b/hooks/slog/handler.go
@@ -33,12 +33,6 @@ import (
 //
 // Mapping to [logrus.FatalLevel] or [logrus.PanicLevel] preserves the level
 // only; handling a record does not exit or panic.
-//
-// Example usage:
-//
-//	logger := logrus.New()
-//	slog.SetDefault(slog.New(NewHandler(logger)))
-//	slog.Info("hello", "key", "value")
 type Handler struct {
 	logger *logrus.Logger
 

--- a/hooks/slog/slog.go
+++ b/hooks/slog/slog.go
@@ -1,3 +1,8 @@
+// Package slog provides adapters between Logrus and log/slog.
+//
+// [Handler] forwards slog records to a Logrus logger, while [Hook] forwards
+// Logrus entries to a slog logger. They can be used independently to support
+// incremental migration between the two logging APIs.
 package slog
 
 import (
@@ -50,11 +55,6 @@ var _ logrus.Hook = (*Hook)(nil)
 // libraries that depend on different loggers.
 //
 // The provided logger must not be nil. NewHook panics if logger is nil.
-//
-// Example usage:
-//
-//	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
-//	hook := NewHook(logger)
 func NewHook(logger *slog.Logger) *Hook {
 	if logger == nil {
 		panic("cannot create hook from nil logger")

--- a/hooks/slog/slog_example_test.go
+++ b/hooks/slog/slog_example_test.go
@@ -1,0 +1,61 @@
+package slog_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
+)
+
+// ExampleNewHandler demonstrates using slog alongside an existing Logrus logger.
+func ExampleNewHandler() {
+	logger := logrus.New()
+	logger.SetOutput(os.Stdout)
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	})
+
+	slog.SetDefault(slog.New(lslog.NewHandler(logger)))
+
+	// Both slog and Logrus write through the same Logrus backend.
+	slog.Info("hello from slog", "source", "slog")
+	logger.WithField("source", "logrus").Info("hello from logrus")
+
+	// Output:
+	// level=info msg="hello from slog" source=slog
+	// level=info msg="hello from logrus" source=logrus
+}
+
+// ExampleNewHook demonstrates forwarding existing Logrus logging to an slog
+// logger, allowing applications to migrate their logging backend independently
+// from code that still uses Logrus.
+func ExampleNewHook() {
+	var slogOutput bytes.Buffer
+	slogger := slog.New(slog.NewTextHandler(&slogOutput, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return attr
+		},
+	}))
+
+	logger := logrus.New()
+	// Discard Logrus's own output; the hook forwards the entry to slog.
+	logger.SetOutput(io.Discard)
+	logger.AddHook(lslog.NewHook(slogger))
+
+	// Log through Logrus; the hook forwards this to slog.
+	logger.WithField("animal", "walrus").Info("hello from logrus")
+
+	// Show what was emitted by the slog handler.
+	fmt.Print(slogOutput.String())
+
+	// Output:
+	// level=INFO msg="hello from logrus" animal=walrus
+}


### PR DESCRIPTION
Add runnable (and tested) examples in the documentation;

<img width="837" height="782" alt="Screenshot 2026-08-12 at 17 33 29" src="https://github.com/user-attachments/assets/f32a06a9-0104-4a5d-98f4-63789991f3cf" />
