### PR TITLE
hooks/slog: add HandlerOptions and source reporting

### DIFF
--- a/hooks/slog/handler.go
+++ b/hooks/slog/handler.go
@@ -4,11 +4,25 @@ import (
 	"context"
 	"log/slog"
 	"maps"
+	"runtime"
 	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
+
+// HandlerOptions are options for a [Handler].
+// A zero HandlerOptions consists entirely of default values.
+type HandlerOptions struct {
+	// AddSource causes the handler to include the source code position
+	// of the log statement in the Logrus entry.
+	AddSource bool
+
+	// LevelMapper maps slog levels to Logrus levels. If nil, the default
+	// mapping is used. Set it to customize level mapping, for example to map
+	// custom slog levels to specific Logrus levels.
+	LevelMapper func(slog.Level) logrus.Level
+}
 
 // Handler is a [slog.Handler] that writes records to a [logrus.Logger].
 //
@@ -35,11 +49,7 @@ import (
 // only; handling a record does not exit or panic.
 type Handler struct {
 	logger *logrus.Logger
-
-	// LevelMapper maps slog levels to Logrus levels. If nil, the default
-	// mapping is used. Set it to customize level mapping, for example to map
-	// custom slog levels to specific Logrus levels.
-	LevelMapper func(slog.Level) logrus.Level
+	opts   HandlerOptions
 
 	// fields holds attributes from prior WithAttrs calls, already resolved
 	// under the group prefix that applied when they were added.
@@ -55,19 +65,24 @@ var _ slog.Handler = (*Handler)(nil)
 // [logrus.Logger].
 //
 // The provided logger must not be nil. NewHandler panics if logger is nil.
-func NewHandler(logger *logrus.Logger) *Handler {
+// If opts is nil, the default options are used.
+func NewHandler(logger *logrus.Logger, opts *HandlerOptions) *Handler {
 	if logger == nil {
 		panic("cannot create handler from nil logger")
 	}
+	if opts == nil {
+		opts = &HandlerOptions{}
+	}
 	return &Handler{
 		logger: logger,
+		opts:   *opts,
 	}
 }
 
 // toLogrusLevel maps a slog level using LevelMapper or the default mapping.
 func (h *Handler) toLogrusLevel(level slog.Level) logrus.Level {
-	if h.LevelMapper != nil {
-		return h.LevelMapper(level)
+	if h.opts.LevelMapper != nil {
+		return h.opts.LevelMapper(level)
 	}
 	switch {
 	case level >= slogLevelPanic:
@@ -111,6 +126,15 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 		Data:    h.fields,
 		Time:    record.Time,
 		Context: ctx,
+	}
+
+	if h.opts.AddSource && record.PC != 0 {
+		// Preserve the caller selected by slog instead of rediscovering it
+		// through Logrus's caller stack filtering.
+		//
+		// Record.PC is a return PC; resolve it with CallersFrames.
+		frame, _ := runtime.CallersFrames([]uintptr{record.PC}).Next()
+		entry.Caller = &frame
 	}
 
 	if n := record.NumAttrs(); n > 0 {
@@ -163,10 +187,10 @@ func (h *Handler) WithGroup(name string) slog.Handler {
 // before modifying them.
 func (h *Handler) clone() *Handler {
 	return &Handler{
-		logger:      h.logger,
-		LevelMapper: h.LevelMapper,
-		fields:      h.fields,
-		groups:      h.groups,
+		logger: h.logger,
+		opts:   h.opts,
+		fields: h.fields,
+		groups: h.groups,
 	}
 }
 

--- a/hooks/slog/handler_test.go
+++ b/hooks/slog/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -20,7 +21,7 @@ func TestHandler_basic(t *testing.T) {
 	logger, hook := test.NewNullLogger()
 	logger.SetLevel(logrus.TraceLevel)
 
-	s := slog.New(lslog.NewHandler(logger))
+	s := slog.New(lslog.NewHandler(logger, nil))
 	s.Info("hello", "animal", "walrus")
 
 	entry := hook.LastEntry()
@@ -119,7 +120,7 @@ func TestHandler_levelMapping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, hook := test.NewNullLogger()
 			logger.SetLevel(logrus.TraceLevel)
-			s := slog.New(lslog.NewHandler(logger))
+			s := slog.New(lslog.NewHandler(logger, nil))
 			tt.log(s)
 			entry := hook.LastEntry()
 			if entry == nil {
@@ -136,11 +137,9 @@ func TestHandler_customLevelMapper(t *testing.T) {
 	logger, hook := test.NewNullLogger()
 	logger.SetLevel(logrus.TraceLevel)
 
-	h := lslog.NewHandler(logger)
-	h.LevelMapper = func(slog.Level) logrus.Level {
-		return logrus.WarnLevel
-	}
-	s := slog.New(h)
+	s := slog.New(lslog.NewHandler(logger, &lslog.HandlerOptions{
+		LevelMapper: func(slog.Level) logrus.Level { return logrus.WarnLevel },
+	}))
 	s.Info("mapped")
 
 	entry := hook.LastEntry()
@@ -156,7 +155,7 @@ func TestHandler_enabledRespectsLogrusLevel(t *testing.T) {
 	logger, hook := test.NewNullLogger()
 	logger.SetLevel(logrus.WarnLevel)
 
-	s := slog.New(lslog.NewHandler(logger))
+	s := slog.New(lslog.NewHandler(logger, nil))
 	s.Info("suppressed")
 	s.Warn("shown")
 
@@ -173,7 +172,7 @@ func TestHandler_withAttrsAndGroups(t *testing.T) {
 	logger, hook := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
 
-	s := slog.New(lslog.NewHandler(logger))
+	s := slog.New(lslog.NewHandler(logger, nil))
 	s = s.With("root", 1)
 	s = s.WithGroup("req")
 	s = s.With("id", "abc")
@@ -257,7 +256,7 @@ func TestHandler_groupAttrs(t *testing.T) {
 			logger, hook := test.NewNullLogger()
 			logger.SetLevel(logrus.DebugLevel)
 
-			s := slog.New(lslog.NewHandler(logger))
+			s := slog.New(lslog.NewHandler(logger, nil))
 			s.Info("msg", tc.attrs...)
 
 			entry := hook.LastEntry()
@@ -271,7 +270,7 @@ func TestHandler_withEmptyGroupName(t *testing.T) {
 	logger, hook := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
 
-	h := lslog.NewHandler(logger)
+	h := lslog.NewHandler(logger, nil)
 	h2 := h.WithGroup("")
 	if h2 != h {
 		t.Error(`WithGroup("") should return the same handler`)
@@ -298,7 +297,7 @@ func TestHandler_contextAndTime(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxKey{}, "val")
 	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 
-	h := lslog.NewHandler(logger)
+	h := lslog.NewHandler(logger, nil)
 	s := slog.New(h)
 	s.LogAttrs(ctx, slog.LevelInfo, "timed", slog.Time("when", ts))
 
@@ -333,7 +332,7 @@ func TestHandler_outputIntegration(t *testing.T) {
 	})
 	logger.SetLevel(logrus.DebugLevel)
 
-	s := slog.New(lslog.NewHandler(logger))
+	s := slog.New(lslog.NewHandler(logger, nil))
 	s.With("chicken", "cluck").Error("error")
 
 	got := strings.TrimSpace(buf.String())
@@ -351,13 +350,13 @@ func TestHandler_nilLoggerPanics(t *testing.T) {
 			t.Error("expected panic for nil logger")
 		}
 	}()
-	_ = lslog.NewHandler(nil)
+	_ = lslog.NewHandler(nil, nil)
 }
 
 func TestHandler_withAttrsEmpty(t *testing.T) {
 	logger := logrus.New()
 	logger.Out = io.Discard
-	h := lslog.NewHandler(logger)
+	h := lslog.NewHandler(logger, nil)
 	if h.WithAttrs(nil) != h {
 		t.Error("WithAttrs(nil) should return same handler")
 	}
@@ -370,7 +369,7 @@ func TestHandler_withAttrsEmpty(t *testing.T) {
 // carried by the slog record.
 func TestHandler_PreservesRecordTime(t *testing.T) {
 	logger, hook := test.NewNullLogger()
-	h := lslog.NewHandler(logger)
+	h := lslog.NewHandler(logger, nil)
 
 	ts := time.Date(2026, 8, 12, 12, 34, 56, 789, time.UTC)
 	record := slog.NewRecord(ts, slog.LevelInfo, "hello", 0)
@@ -380,4 +379,37 @@ func TestHandler_PreservesRecordTime(t *testing.T) {
 	entry := hook.LastEntry()
 	require.NotNil(t, entry)
 	assert.Equal(t, ts, entry.Time)
+}
+
+// TestHandler_PreservesRecordCaller verifies that Handle preserves caller
+// information carried by the slog record.
+func TestHandler_PreservesRecordCaller(t *testing.T) {
+	if runtime.Compiler == "tinygo" {
+		// TinyGo currently (v0.41.1) doesn't support `runtime.Caller`;
+		// https://tinygo.org/docs/reference/lang-support/stdlib/#logslog
+		t.Log("SKIP: TinyGo does not support runtime.Caller") // no t.Skip on tinygo
+		return
+	}
+
+	logger, hook := test.NewNullLogger()
+	logger.SetReportCaller(true)
+
+	h := lslog.NewHandler(logger, &lslog.HandlerOptions{
+		AddSource: true,
+	})
+
+	var pcs [1]uintptr
+	runtime.Callers(1, pcs[:])
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "hello", pcs[0])
+	require.NoError(t, h.Handle(context.Background(), record))
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+	require.NotNil(t, entry.Caller)
+
+	want, _ := runtime.CallersFrames(pcs[:]).Next()
+	assert.Equal(t, want.Function, entry.Caller.Function)
+	assert.Equal(t, want.File, entry.Caller.File)
+	assert.Equal(t, want.Line, entry.Caller.Line)
 }

--- a/hooks/slog/slog_example_test.go
+++ b/hooks/slog/slog_example_test.go
@@ -2,6 +2,7 @@ package slog_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -20,7 +21,7 @@ func ExampleNewHandler() {
 		DisableTimestamp: true,
 	})
 
-	slog.SetDefault(slog.New(lslog.NewHandler(logger)))
+	slog.SetDefault(slog.New(lslog.NewHandler(logger, nil)))
 
 	// Both slog and Logrus write through the same Logrus backend.
 	slog.Info("hello from slog", "source", "slog")
@@ -29,6 +30,39 @@ func ExampleNewHandler() {
 	// Output:
 	// level=info msg="hello from slog" source=slog
 	// level=info msg="hello from logrus" source=logrus
+}
+
+// ExampleNewHandler_options demonstrates configuring source reporting and
+// custom slog-to-Logrus level mapping.
+//
+// Logrus writes to stderr by default, so the example has no stdout output.
+// The log output will look similar to:
+//
+//	time="2026-01-02T03:04:05Z" level=info msg="regular info" func=github.com/sirupsen/logrus/hooks/slog_test.ExampleNewHandler_options file="/src/hooks/slog/slog_example_test.go:62" animal=walrus
+//	time="2026-01-02T03:04:06Z" level=warning msg="custom level" func=github.com/sirupsen/logrus/hooks/slog_test.ExampleNewHandler_options file="/src/hooks/slog/slog_example_test.go:63" animal=walrus
+func ExampleNewHandler_options() {
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableColors: true,
+	})
+
+	slogger := slog.New(lslog.NewHandler(logger, &lslog.HandlerOptions{
+		// Preserve slog's source location as Logrus caller information.
+		AddSource: true,
+
+		// Map this custom slog level to Logrus WarnLevel.
+		LevelMapper: func(level slog.Level) logrus.Level {
+			if level == slog.LevelInfo+1 {
+				return logrus.WarnLevel
+			}
+			return logrus.InfoLevel
+		},
+	}))
+
+	slogger.Info("regular info", "animal", "walrus")
+	slogger.Log(context.Background(), slog.LevelInfo+1, "custom level", "animal", "walrus")
+
+	// Output:
 }
 
 // ExampleNewHook demonstrates forwarding existing Logrus logging to an slog


### PR DESCRIPTION
Align the Handler constructor and configuration model with the standard library slog handlers by accepting *HandlerOptions and copying the supplied options at construction time.

Move custom level mapping into HandlerOptions so handler configuration has a single source of truth and is preserved by derived handlers.

Add AddSource support to preserve slog.Record caller information as Logrus caller metadata, avoiding Logrus caller rediscovery when the record already contains the original call site.

Add coverage for caller preservation and an example showing source reporting and custom level mapping.