### PR TITLE
hooks/slog: prevent recursive forwarding between adapters

### DIFF
--- a/hooks/slog/handler.go
+++ b/hooks/slog/handler.go
@@ -116,6 +116,10 @@ func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
 // attached as logrus fields; group names are joined with "." as a key prefix
 // (similar to [slog.TextHandler]).
 func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+	// Stop recursive forwarding before it can cycle back through this logger.
+	if hasLogrusLogger(ctx, h.logger) {
+		return nil
+	}
 	level := h.toLogrusLevel(record.Level)
 	if !h.logger.IsLevelEnabled(level) {
 		return nil

--- a/hooks/slog/slog.go
+++ b/hooks/slog/slog.go
@@ -8,6 +8,7 @@ package slog
 import (
 	"context"
 	"log/slog"
+	"maps"
 
 	"github.com/sirupsen/logrus"
 )
@@ -22,6 +23,30 @@ const (
 	slogLevelFatal = slog.LevelError + 2
 	slogLevelPanic = slog.LevelError + 4
 )
+
+// logrusLoggerContextKey is the context key used to track Logrus loggers a
+// record has already traversed while being forwarded through slog adapters.
+type logrusLoggerContextKey struct{}
+
+// withLogrusLogger returns a context that records logger as having already
+// handled the current log record.
+func withLogrusLogger(ctx context.Context, logger *logrus.Logger) context.Context {
+	seen, _ := ctx.Value(logrusLoggerContextKey{}).(map[*logrus.Logger]struct{})
+	seen = maps.Clone(seen)
+	if seen == nil {
+		seen = make(map[*logrus.Logger]struct{}, 1)
+	}
+	seen[logger] = struct{}{}
+	return context.WithValue(ctx, logrusLoggerContextKey{}, seen)
+}
+
+// hasLogrusLogger reports whether logger has already handled the current log
+// record while it was forwarded through slog adapters.
+func hasLogrusLogger(ctx context.Context, logger *logrus.Logger) bool {
+	seen, _ := ctx.Value(logrusLoggerContextKey{}).(map[*logrus.Logger]struct{})
+	_, ok := seen[logger]
+	return ok
+}
 
 // Hook sends Logrus entries to slog.
 //
@@ -105,6 +130,9 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	// Track this logger to guard against recursive forwarding.
+	ctx = withLogrusLogger(ctx, entry.Logger)
+
 	lvl := h.toSlogLevel(entry.Level).Level()
 	handler := h.logger.Handler()
 	if !handler.Enabled(ctx, lvl) {

--- a/hooks/slog/slog_example_test.go
+++ b/hooks/slog/slog_example_test.go
@@ -93,3 +93,50 @@ func ExampleNewHook() {
 	// Output:
 	// level=INFO msg="hello from logrus" animal=walrus
 }
+
+// ExampleNewHook_migration demonstrates using both adapters while migrating
+// from Logrus to slog. Records can cross the bridge without being forwarded
+// back into a Logrus logger they have already passed through.
+func ExampleNewHook_migration() {
+	var logrusOutput bytes.Buffer
+	var slogOutput bytes.Buffer
+
+	legacy := logrus.New()
+	legacy.SetOutput(&logrusOutput)
+	legacy.SetFormatter(&logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	})
+
+	slogger := slog.New(slog.NewTextHandler(&slogOutput, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.TimeKey {
+				return slog.Attr{} // Suppress timestamps for the example.
+			}
+			return attr
+		},
+	}))
+
+	// Existing Logrus code is forwarded to the slog backend.
+	legacy.AddHook(lslog.NewHook(slogger))
+
+	// New slog code can continue using the existing Logrus backend.
+	bridged := slog.New(lslog.NewHandler(legacy, nil))
+
+	legacy.Info("hello from logrus")
+	bridged.Info("hello from slog")
+
+	fmt.Println("Logrus output:")
+	fmt.Print(logrusOutput.String())
+
+	fmt.Println("slog output:")
+	fmt.Print(slogOutput.String())
+
+	// Output:
+	// Logrus output:
+	// level=info msg="hello from logrus"
+	// level=info msg="hello from slog"
+	// slog output:
+	// level=INFO msg="hello from logrus"
+	// level=INFO msg="hello from slog"
+}

--- a/hooks/slog/slog_test.go
+++ b/hooks/slog/slog_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	lslog "github.com/sirupsen/logrus/hooks/slog"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -206,4 +207,79 @@ func TestHookLevelMapping(t *testing.T) {
 			assert.Contains(t, buf.String(), "level="+tc.want+" ")
 		})
 	}
+}
+
+// TestHookHandler_RecursionGuard verifies that the slog Hook and Handler can be
+// composed without recursively forwarding a record back through Logrus
+// loggers it has already traversed.
+func TestHookHandler_RecursionGuard(t *testing.T) {
+	t.Run("same logger", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+
+		slogger := slog.New(lslog.NewHandler(logger, nil))
+		logger.AddHook(lslog.NewHook(slogger))
+
+		logger.Info("hello")
+
+		entries := hook.AllEntries()
+		require.Len(t, entries, 1)
+		assert.Equal(t, "hello", entries[0].Message)
+	})
+
+	t.Run("different logger", func(t *testing.T) {
+		loggerA, hookA := test.NewNullLogger()
+		loggerB, hookB := test.NewNullLogger()
+
+		slogger := slog.New(lslog.NewHandler(loggerB, nil))
+		loggerA.AddHook(lslog.NewHook(slogger))
+
+		loggerA.Info("hello")
+
+		entriesA := hookA.AllEntries()
+		require.Len(t, entriesA, 1)
+		assert.Equal(t, "hello", entriesA[0].Message)
+
+		entriesB := hookB.AllEntries()
+		require.Len(t, entriesB, 1)
+		assert.Equal(t, "hello", entriesB[0].Message)
+	})
+
+	t.Run("multiple loggers", func(t *testing.T) {
+		loggerA, hookA := test.NewNullLogger()
+		loggerB, hookB := test.NewNullLogger()
+
+		sloggerA := slog.New(lslog.NewHandler(loggerA, nil))
+		sloggerB := slog.New(lslog.NewHandler(loggerB, nil))
+
+		loggerA.AddHook(lslog.NewHook(sloggerB))
+		loggerB.AddHook(lslog.NewHook(sloggerA))
+
+		loggerA.Info("hello")
+
+		entriesA := hookA.AllEntries()
+		require.Len(t, entriesA, 1)
+		assert.Equal(t, "hello", entriesA[0].Message)
+
+		entriesB := hookB.AllEntries()
+		require.Len(t, entriesB, 1)
+		assert.Equal(t, "hello", entriesB[0].Message)
+	})
+}
+
+// TestHookHandler_RecursionGuardPreservesContext verifies that adding recursion
+// tracking does not discard context values carried by a Logrus entry.
+func TestHookHandler_RecursionGuardPreservesContext(t *testing.T) {
+	type ctxKey struct{}
+
+	logger, hook := test.NewNullLogger()
+	slogger := slog.New(lslog.NewHandler(logger, nil))
+	logger.AddHook(lslog.NewHook(slogger))
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "value")
+	logger.WithContext(ctx).Info("hello")
+
+	entries := hook.AllEntries()
+	require.Len(t, entries, 1)
+	require.NotNil(t, entries[0].Context)
+	assert.Equal(t, "value", entries[0].Context.Value(ctxKey{}))
 }


### PR DESCRIPTION
Track Logrus loggers in the context while records are forwarded through the slog Hook, and have Handler stop records that would otherwise be forwarded back into a logger they already traversed.

This prevents Hook and Handler configurations from recursively forwarding records until the stack overflows, while still allowing records to pass between different Logrus and slog backends during migration.

Add coverage for direct and multi-logger recursion, context preservation, and an example showing Logrus and slog integrations working in both directions.