### PR TITLE
hooks/slog: use concrete slog.Level for hook level mapping

### DIFF
--- a/hooks/slog/slog.go
+++ b/hooks/slog/slog.go
@@ -69,7 +69,7 @@ type Hook struct {
 	// LevelMapper maps Logrus levels to slog levels. If nil, the default
 	// mapping is used. Set it to customize level mapping, for example to
 	// support custom or dynamic slog levels.
-	LevelMapper func(logrus.Level) slog.Leveler
+	LevelMapper func(logrus.Level) slog.Level
 }
 
 var _ logrus.Hook = (*Hook)(nil)
@@ -90,7 +90,7 @@ func NewHook(logger *slog.Logger) *Hook {
 }
 
 // toSlogLevel maps a Logrus level using LevelMapper or the default mapping.
-func (h *Hook) toSlogLevel(level logrus.Level) slog.Leveler {
+func (h *Hook) toSlogLevel(level logrus.Level) slog.Level {
 	if h.LevelMapper != nil {
 		return h.LevelMapper(level)
 	}

--- a/hooks/slog/slog_test.go
+++ b/hooks/slog/slog_test.go
@@ -22,7 +22,7 @@ import (
 func TestHook(t *testing.T) {
 	tests := []struct {
 		name   string
-		mapper func(logrus.Level) slog.Leveler
+		mapper func(logrus.Level) slog.Level
 		fn     func(*logrus.Logger)
 		want   []string
 	}{
@@ -48,7 +48,7 @@ func TestHook(t *testing.T) {
 		},
 		{
 			name: "level mapper",
-			mapper: func(logrus.Level) slog.Leveler {
+			mapper: func(logrus.Level) slog.Level {
 				return slog.LevelInfo
 			},
 			fn: func(log *logrus.Logger) {


### PR DESCRIPTION
Change Hook.LevelMapper to return slog.Level instead of slog.Leveler.

LevelMapper is already evaluated for each record, allowing mappings to be dynamic. Returning slog.Level makes the mapped record severity concrete while reserving slog.Leveler for dynamically evaluated level thresholds.