### PR TITLE
hooks/slog: add level adapters

### DIFF
--- a/hooks/slog/handler.go
+++ b/hooks/slog/handler.go
@@ -29,21 +29,8 @@ type HandlerOptions struct {
 // It is intended for bridging libraries or application code that log via slog
 // into an existing Logrus logger, for example during a gradual migration.
 //
-// By default, slog levels map to their corresponding Logrus levels. Trace,
-// Fatal, and Panic use custom slog levels below Debug and above Error,
-// respectively, preserving their relative severity:
-//
-//   - [slog.LevelDebug] - 4 -> [logrus.TraceLevel]
-//   - [slog.LevelDebug] -> [logrus.DebugLevel]
-//   - [slog.LevelInfo] -> [logrus.InfoLevel]
-//   - [slog.LevelWarn] -> [logrus.WarnLevel]
-//   - [slog.LevelError] -> [logrus.ErrorLevel]
-//   - [slog.LevelError] + 2 -> [logrus.FatalLevel]
-//   - [slog.LevelError] + 4 -> [logrus.PanicLevel]
-//
-// Levels between these boundaries map to the next lower Logrus severity.
-// Levels below Debug map to [logrus.TraceLevel], and levels above Panic map
-// to [logrus.PanicLevel].
+// By default, slog levels are mapped using [SlogLevel].
+// Set [HandlerOptions.LevelMapper] to customize the mapping.
 //
 // Mapping to [logrus.FatalLevel] or [logrus.PanicLevel] preserves the level
 // only; handling a record does not exit or panic.
@@ -84,24 +71,7 @@ func (h *Handler) toLogrusLevel(level slog.Level) logrus.Level {
 	if h.opts.LevelMapper != nil {
 		return h.opts.LevelMapper(level)
 	}
-	switch {
-	case level >= slogLevelPanic:
-		return logrus.PanicLevel
-	case level >= slogLevelFatal:
-		return logrus.FatalLevel
-	case level >= slogLevelError:
-		return logrus.ErrorLevel
-	case level >= slogLevelWarn:
-		return logrus.WarnLevel
-	case level >= slogLevelInfo:
-		return logrus.InfoLevel
-	case level >= slogLevelDebug:
-		return logrus.DebugLevel
-	case level >= slogLevelTrace:
-		return logrus.TraceLevel
-	default:
-		return logrus.TraceLevel
-	}
+	return SlogLevel(level).Level()
 }
 
 // Enabled reports whether the handler handles records at the given level.

--- a/hooks/slog/level.go
+++ b/hooks/slog/level.go
@@ -1,0 +1,119 @@
+package slog
+
+import (
+	"log/slog"
+
+	"github.com/sirupsen/logrus"
+)
+
+// slog levels corresponding to Logrus levels.
+const (
+	slogLevelTrace = slog.LevelDebug - 4
+	slogLevelDebug = slog.LevelDebug
+	slogLevelInfo  = slog.LevelInfo
+	slogLevelWarn  = slog.LevelWarn
+	slogLevelError = slog.LevelError
+	slogLevelFatal = slog.LevelError + 2
+	slogLevelPanic = slog.LevelError + 4
+)
+
+// A Leveler provides a [logrus.Level] value.
+//
+// It is the Logrus counterpart of [slog.Leveler].
+//
+// As [SlogLevel] itself implements Leveler, clients typically supply
+// a SlogLevel value wherever a Leveler is needed.
+// Clients who need to vary the level dynamically can provide a more complex
+// Leveler implementation.
+type Leveler interface {
+	Level() logrus.Level
+}
+
+// Level adapts a [logrus.Level] to a [slog.Leveler] using the default
+// Logrus-to-slog level mapping:
+//
+//   - [logrus.TraceLevel] -> [slog.LevelDebug] - 4
+//   - [logrus.DebugLevel] -> [slog.LevelDebug]
+//   - [logrus.InfoLevel] -> [slog.LevelInfo]
+//   - [logrus.WarnLevel] -> [slog.LevelWarn]
+//   - [logrus.ErrorLevel] -> [slog.LevelError]
+//   - [logrus.FatalLevel] -> [slog.LevelError] + 2
+//   - [logrus.PanicLevel] -> [slog.LevelError] + 4
+//
+// Unknown Logrus levels map to [slog.LevelError].
+type Level logrus.Level
+
+// Level returns l mapped to the corresponding slog level.
+func (l Level) Level() slog.Level {
+	return toSlogLevel(logrus.Level(l))
+}
+
+var _ slog.Leveler = Level(0)
+
+// SlogLevel adapts a [slog.Level] to a [Leveler] using the default
+// slog-to-Logrus level mapping:
+//
+//   - [slog.LevelDebug] - 4 -> [logrus.TraceLevel]
+//   - [slog.LevelDebug] -> [logrus.DebugLevel]
+//   - [slog.LevelInfo] -> [logrus.InfoLevel]
+//   - [slog.LevelWarn] -> [logrus.WarnLevel]
+//   - [slog.LevelError] -> [logrus.ErrorLevel]
+//   - [slog.LevelError] + 2 -> [logrus.FatalLevel]
+//   - [slog.LevelError] + 4 -> [logrus.PanicLevel]
+//
+// Levels between these boundaries map to the next lower Logrus severity.
+// Levels below [slog.LevelDebug] map to [logrus.TraceLevel], and levels at or
+// above the Panic boundary map to [logrus.PanicLevel].
+type SlogLevel slog.Level
+
+// Level returns l mapped to the corresponding Logrus level.
+func (l SlogLevel) Level() logrus.Level {
+	return toLogrusLevel(slog.Level(l))
+}
+
+var _ Leveler = SlogLevel(0)
+
+// toLogrusLevel maps a slog level using the default mapping.
+func toLogrusLevel(level slog.Level) logrus.Level {
+	switch {
+	case level >= slogLevelPanic:
+		return logrus.PanicLevel
+	case level >= slogLevelFatal:
+		return logrus.FatalLevel
+	case level >= slogLevelError:
+		return logrus.ErrorLevel
+	case level >= slogLevelWarn:
+		return logrus.WarnLevel
+	case level >= slogLevelInfo:
+		return logrus.InfoLevel
+	case level >= slogLevelDebug:
+		return logrus.DebugLevel
+	case level >= slogLevelTrace:
+		return logrus.TraceLevel
+	default:
+		return logrus.TraceLevel
+	}
+}
+
+// toSlogLevel maps a Logrus level using the default mapping.
+func toSlogLevel(level logrus.Level) slog.Level {
+	switch level {
+	case logrus.PanicLevel:
+		return slogLevelPanic
+	case logrus.FatalLevel:
+		return slogLevelFatal
+	case logrus.ErrorLevel:
+		return slogLevelError
+	case logrus.WarnLevel:
+		return slogLevelWarn
+	case logrus.InfoLevel:
+		return slogLevelInfo
+	case logrus.DebugLevel:
+		return slogLevelDebug
+	case logrus.TraceLevel:
+		return slogLevelTrace
+	default:
+		// Treat all unknown levels as errors
+		return slogLevelError
+	}
+}

--- a/hooks/slog/level_example_test.go
+++ b/hooks/slog/level_example_test.go
@@ -1,0 +1,51 @@
+package slog_test
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
+)
+
+// LoggerLevel exposes a Logrus logger's configured level as a slog.Leveler.
+//
+// This lets slog handlers follow changes to the Logrus logger's level without
+// keeping a separate slog.LevelVar in sync.
+type LoggerLevel struct {
+	Logger *logrus.Logger
+}
+
+func (l LoggerLevel) Level() slog.Level {
+	return lslog.Level(l.Logger.GetLevel()).Level()
+}
+
+// ExampleLevel_dynamic demonstrates using Level to share dynamic level
+// configuration between Logrus and slog.
+func ExampleLevel_dynamic() {
+	logger := logrus.New()
+	logger.SetLevel(logrus.InfoLevel)
+
+	slogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: LoggerLevel{Logger: logger},
+		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.TimeKey {
+				return slog.Attr{} // Suppress timestamps for the example.
+			}
+			return attr
+		},
+	}))
+
+	slogger.Info("before")
+
+	// The slog handler follows changes to the Logrus logger's level without
+	// requiring a separate slog.LevelVar to be updated.
+	logger.SetLevel(logrus.WarnLevel)
+
+	slogger.Info("ignored")
+	slogger.Warn("after")
+
+	// Output:
+	// level=INFO msg=before
+	// level=WARN msg=after
+}

--- a/hooks/slog/level_test.go
+++ b/hooks/slog/level_test.go
@@ -1,0 +1,160 @@
+package slog_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
+)
+
+// TestLevel verifies the default Logrus-to-slog level mapping.
+func TestLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level logrus.Level
+		want  slog.Level
+	}{
+		{
+			name:  "panic",
+			level: logrus.PanicLevel,
+			want:  slog.LevelError + 4,
+		},
+		{
+			name:  "fatal",
+			level: logrus.FatalLevel,
+			want:  slog.LevelError + 2,
+		},
+		{
+			name:  "error",
+			level: logrus.ErrorLevel,
+			want:  slog.LevelError,
+		},
+		{
+			name:  "warn",
+			level: logrus.WarnLevel,
+			want:  slog.LevelWarn,
+		},
+		{
+			name:  "info",
+			level: logrus.InfoLevel,
+			want:  slog.LevelInfo,
+		},
+		{
+			name:  "debug",
+			level: logrus.DebugLevel,
+			want:  slog.LevelDebug,
+		},
+		{
+			name:  "trace",
+			level: logrus.TraceLevel,
+			want:  slog.LevelDebug - 4,
+		},
+		{
+			name:  "unknown",
+			level: logrus.Level(255),
+			want:  slog.LevelError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lslog.Level(tc.level).Level(); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSlogLevel verifies the default slog-to-Logrus level mapping.
+func TestSlogLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level slog.Level
+		want  logrus.Level
+	}{
+		{
+			name:  "above panic",
+			level: slog.LevelError + 5,
+			want:  logrus.PanicLevel,
+		},
+		{
+			name:  "panic",
+			level: slog.LevelError + 4,
+			want:  logrus.PanicLevel,
+		},
+		{
+			name:  "between fatal and panic",
+			level: slog.LevelError + 3,
+			want:  logrus.FatalLevel,
+		},
+		{
+			name:  "fatal",
+			level: slog.LevelError + 2,
+			want:  logrus.FatalLevel,
+		},
+		{
+			name:  "between error and fatal",
+			level: slog.LevelError + 1,
+			want:  logrus.ErrorLevel,
+		},
+		{
+			name:  "error",
+			level: slog.LevelError,
+			want:  logrus.ErrorLevel,
+		},
+		{
+			name:  "between warn and error",
+			level: slog.LevelError - 1,
+			want:  logrus.WarnLevel,
+		},
+		{
+			name:  "warn",
+			level: slog.LevelWarn,
+			want:  logrus.WarnLevel,
+		},
+		{
+			name:  "between info and warn",
+			level: slog.LevelWarn - 1,
+			want:  logrus.InfoLevel,
+		},
+		{
+			name:  "info",
+			level: slog.LevelInfo,
+			want:  logrus.InfoLevel,
+		},
+		{
+			name:  "between debug and info",
+			level: slog.LevelInfo - 1,
+			want:  logrus.DebugLevel,
+		},
+		{
+			name:  "debug",
+			level: slog.LevelDebug,
+			want:  logrus.DebugLevel,
+		},
+		{
+			name:  "between trace and debug",
+			level: slog.LevelDebug - 1,
+			want:  logrus.TraceLevel,
+		},
+		{
+			name:  "trace",
+			level: slog.LevelDebug - 4,
+			want:  logrus.TraceLevel,
+		},
+		{
+			name:  "below trace",
+			level: slog.LevelDebug - 5,
+			want:  logrus.TraceLevel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lslog.SlogLevel(tc.level).Level(); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/hooks/slog/slog.go
+++ b/hooks/slog/slog.go
@@ -13,17 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// slog levels corresponding to Logrus levels.
-const (
-	slogLevelTrace = slog.LevelDebug - 4
-	slogLevelDebug = slog.LevelDebug
-	slogLevelInfo  = slog.LevelInfo
-	slogLevelWarn  = slog.LevelWarn
-	slogLevelError = slog.LevelError
-	slogLevelFatal = slog.LevelError + 2
-	slogLevelPanic = slog.LevelError + 4
-)
-
 // logrusLoggerContextKey is the context key used to track Logrus loggers a
 // record has already traversed while being forwarded through slog adapters.
 type logrusLoggerContextKey struct{}
@@ -50,19 +39,8 @@ func hasLogrusLogger(ctx context.Context, logger *logrus.Logger) bool {
 
 // Hook sends Logrus entries to slog.
 //
-// By default, Logrus levels map to their corresponding slog levels. Trace,
-// Fatal, and Panic use custom slog levels below Debug and above Error,
-// respectively, preserving their relative severity:
-//
-//   - [logrus.TraceLevel] -> [slog.LevelDebug] - 4
-//   - [logrus.DebugLevel] -> [slog.LevelDebug]
-//   - [logrus.InfoLevel] -> [slog.LevelInfo]
-//   - [logrus.WarnLevel] -> [slog.LevelWarn]
-//   - [logrus.ErrorLevel] -> [slog.LevelError]
-//   - [logrus.FatalLevel] -> [slog.LevelError] + 2
-//   - [logrus.PanicLevel] -> [slog.LevelError] + 4
-//
-// Set [Hook.LevelMapper] to customize this mapping.
+// By default, Logrus levels are mapped using [Level].
+// Set [Hook.LevelMapper] to customize the mapping.
 type Hook struct {
 	logger *slog.Logger
 
@@ -94,25 +72,7 @@ func (h *Hook) toSlogLevel(level logrus.Level) slog.Level {
 	if h.LevelMapper != nil {
 		return h.LevelMapper(level)
 	}
-	switch level {
-	case logrus.PanicLevel:
-		return slogLevelPanic
-	case logrus.FatalLevel:
-		return slogLevelFatal
-	case logrus.ErrorLevel:
-		return slogLevelError
-	case logrus.WarnLevel:
-		return slogLevelWarn
-	case logrus.InfoLevel:
-		return slogLevelInfo
-	case logrus.DebugLevel:
-		return slogLevelDebug
-	case logrus.TraceLevel:
-		return slogLevelTrace
-	default:
-		// Treat all unknown levels as errors
-		return slogLevelError
-	}
+	return Level(level).Level()
 }
 
 // Levels always returns all levels, since slog allows controlling level
@@ -133,9 +93,9 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 	// Track this logger to guard against recursive forwarding.
 	ctx = withLogrusLogger(ctx, entry.Logger)
 
-	lvl := h.toSlogLevel(entry.Level).Level()
+	level := h.toSlogLevel(entry.Level)
 	handler := h.logger.Handler()
-	if !handler.Enabled(ctx, lvl) {
+	if !handler.Enabled(ctx, level) {
 		return nil
 	}
 	attrs := make([]slog.Attr, 0, len(entry.Data))
@@ -146,7 +106,7 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 	if entry.Caller != nil {
 		pc = entry.Caller.PC
 	}
-	r := slog.NewRecord(entry.Time, lvl, entry.Message, pc)
+	r := slog.NewRecord(entry.Time, level, entry.Message, pc)
 	r.AddAttrs(attrs...)
 	return handler.Handle(ctx, r)
 }


### PR DESCRIPTION
Add Level and SlogLevel adapters for converting between Logrus and slog levels using the default mappings.

Level implements slog.Leveler, allowing a Logrus level to be used directly where slog expects a level provider. SlogLevel provides the corresponding Logrus-side Leveler interface for the reverse direction.

Centralize the default level mappings in these adapters and reuse them from Hook and Handler.