### PR TITLE
hooks/slog: add HookOptions

### DIFF
--- a/hooks/slog/slog.go
+++ b/hooks/slog/slog.go
@@ -37,40 +37,54 @@ func hasLogrusLogger(ctx context.Context, logger *logrus.Logger) bool {
 	return ok
 }
 
+// HookOptions are options for a [Hook].
+// A zero HookOptions consists entirely of default values.
+type HookOptions struct {
+	// LevelMapper maps Logrus levels to slog levels. If nil, the default
+	// mapping is used. Set it to customize level mapping, for example to map
+	// custom Logrus levels to specific slog levels.
+	LevelMapper func(logrus.Level) slog.Level
+}
+
 // Hook sends Logrus entries to slog.
 //
-// By default, Logrus levels are mapped using [Level].
-// Set [Hook.LevelMapper] to customize the mapping.
+// It is intended for bridging libraries or application code that log via
+// Logrus into an existing slog logger, for example during a gradual migration.
+//
+// By default, Logrus levels are mapped using [Level]. Set
+// [HookOptions.LevelMapper] to customize the mapping.
 type Hook struct {
 	logger *slog.Logger
-
-	// LevelMapper maps Logrus levels to slog levels. If nil, the default
-	// mapping is used. Set it to customize level mapping, for example to
-	// support custom or dynamic slog levels.
-	LevelMapper func(logrus.Level) slog.Level
+	opts   HookOptions
 }
 
 var _ logrus.Hook = (*Hook)(nil)
 
-// NewHook creates a hook that sends logs to an existing slog Logger.
+// NewHook creates a [logrus.Hook] that sends logs to the provided [slog.Logger].
+//
 // This hook is intended to be used during transition from Logrus to slog,
 // or as a shim between different parts of your application or different
 // libraries that depend on different loggers.
 //
 // The provided logger must not be nil. NewHook panics if logger is nil.
-func NewHook(logger *slog.Logger) *Hook {
+// If opts is nil, the default options are used.
+func NewHook(logger *slog.Logger, opts *HookOptions) *Hook {
 	if logger == nil {
 		panic("cannot create hook from nil logger")
 	}
+	if opts == nil {
+		opts = &HookOptions{}
+	}
 	return &Hook{
 		logger: logger,
+		opts:   *opts,
 	}
 }
 
 // toSlogLevel maps a Logrus level using LevelMapper or the default mapping.
 func (h *Hook) toSlogLevel(level logrus.Level) slog.Level {
-	if h.LevelMapper != nil {
-		return h.LevelMapper(level)
+	if h.opts.LevelMapper != nil {
+		return h.opts.LevelMapper(level)
 	}
 	return Level(level).Level()
 }

--- a/hooks/slog/slog_example_test.go
+++ b/hooks/slog/slog_example_test.go
@@ -82,7 +82,7 @@ func ExampleNewHook() {
 	logger := logrus.New()
 	// Discard Logrus's own output; the hook forwards the entry to slog.
 	logger.SetOutput(io.Discard)
-	logger.AddHook(lslog.NewHook(slogger))
+	logger.AddHook(lslog.NewHook(slogger, nil))
 
 	// Log through Logrus; the hook forwards this to slog.
 	logger.WithField("animal", "walrus").Info("hello from logrus")
@@ -118,7 +118,7 @@ func ExampleNewHook_migration() {
 	}))
 
 	// Existing Logrus code is forwarded to the slog backend.
-	legacy.AddHook(lslog.NewHook(slogger))
+	legacy.AddHook(lslog.NewHook(slogger, nil))
 
 	// New slog code can continue using the existing Logrus backend.
 	bridged := slog.New(lslog.NewHandler(legacy, nil))

--- a/hooks/slog/slog_test.go
+++ b/hooks/slog/slog_test.go
@@ -65,7 +65,7 @@ func TestHook(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			slogLogger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
+			slogger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
 				// Remove timestamps from logs, for easier comparison
 				ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
 					if a.Key == slog.TimeKey {
@@ -76,9 +76,9 @@ func TestHook(t *testing.T) {
 			}))
 			log := logrus.New()
 			log.Out = io.Discard
-			hook := lslog.NewHook(slogLogger)
-			hook.LevelMapper = tt.mapper
-			log.AddHook(hook)
+			log.AddHook(lslog.NewHook(slogger, &lslog.HookOptions{
+				LevelMapper: tt.mapper,
+			}))
 			tt.fn(log)
 			got := strings.Split(strings.TrimSpace(buf.String()), "\n")
 			if len(got) != len(tt.want) {
@@ -125,10 +125,10 @@ func TestHook_error_propagates(t *testing.T) {
 		_ = r.Close()
 	})
 
-	slogLogger := slog.New(&errorHandler{})
+	slogger := slog.New(&errorHandler{})
 	log := logrus.New()
 	log.SetOutput(io.Discard)
-	log.AddHook(lslog.NewHook(slogLogger))
+	log.AddHook(lslog.NewHook(slogger, nil))
 	log.WithField("key", "value").Error("test error")
 
 	// Restore stderr before closing the pipe writer to avoid leaving os.Stderr
@@ -149,7 +149,7 @@ func TestHook_source(t *testing.T) {
 		return
 	}
 	buf := &bytes.Buffer{}
-	slogLogger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
+	slogger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
 		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey {
 				return slog.Attr{}
@@ -161,7 +161,7 @@ func TestHook_source(t *testing.T) {
 	log := logrus.New()
 	log.Out = io.Discard
 	log.ReportCaller = true
-	log.AddHook(lslog.NewHook(slogLogger))
+	log.AddHook(lslog.NewHook(slogger, nil))
 	log.Info("info with source")
 	got := strings.TrimSpace(buf.String())
 	wantRE := regexp.MustCompile(`source=.*hooks[\\/]+slog[\\/]+slog_test\.go:\d+`)
@@ -195,7 +195,7 @@ func TestHookLevelMapping(t *testing.T) {
 					}
 					return attr
 				},
-			})))
+			})), nil)
 
 			logger := logrus.New()
 			logger.SetOutput(io.Discard)
@@ -217,7 +217,7 @@ func TestHookHandler_RecursionGuard(t *testing.T) {
 		logger, hook := test.NewNullLogger()
 
 		slogger := slog.New(lslog.NewHandler(logger, nil))
-		logger.AddHook(lslog.NewHook(slogger))
+		logger.AddHook(lslog.NewHook(slogger, nil))
 
 		logger.Info("hello")
 
@@ -231,7 +231,7 @@ func TestHookHandler_RecursionGuard(t *testing.T) {
 		loggerB, hookB := test.NewNullLogger()
 
 		slogger := slog.New(lslog.NewHandler(loggerB, nil))
-		loggerA.AddHook(lslog.NewHook(slogger))
+		loggerA.AddHook(lslog.NewHook(slogger, nil))
 
 		loggerA.Info("hello")
 
@@ -251,8 +251,8 @@ func TestHookHandler_RecursionGuard(t *testing.T) {
 		sloggerA := slog.New(lslog.NewHandler(loggerA, nil))
 		sloggerB := slog.New(lslog.NewHandler(loggerB, nil))
 
-		loggerA.AddHook(lslog.NewHook(sloggerB))
-		loggerB.AddHook(lslog.NewHook(sloggerA))
+		loggerA.AddHook(lslog.NewHook(sloggerB, nil))
+		loggerB.AddHook(lslog.NewHook(sloggerA, nil))
 
 		loggerA.Info("hello")
 
@@ -273,7 +273,7 @@ func TestHookHandler_RecursionGuardPreservesContext(t *testing.T) {
 
 	logger, hook := test.NewNullLogger()
 	slogger := slog.New(lslog.NewHandler(logger, nil))
-	logger.AddHook(lslog.NewHook(slogger))
+	logger.AddHook(lslog.NewHook(slogger, nil))
 
 	ctx := context.WithValue(context.Background(), ctxKey{}, "value")
 	logger.WithContext(ctx).Info("hello")


### PR DESCRIPTION
Add HookOptions and update NewHook to accept optional configuration, matching the configuration pattern used by NewHandler.

Move LevelMapper into HookOptions and copy the supplied options at construction time. Nil options use the default level mapping.
