### PR TITLE
docs: clarify formatter field handling

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -27,7 +27,7 @@ const (
 )
 
 // Formatter is implemented by types that format log entries. It receives an
-// [*Entry], which contains all fields, including the standard ones:
+// [*Entry], which contains:
 //
 //   - entry.Message: the message passed to logging methods such as [Info], [Warn], [Error]
 //   - entry.Time: the timestamp

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -21,7 +21,13 @@ func (f FieldMap) resolve(key fieldKey) string {
 	return string(key)
 }
 
-// JSONFormatter formats logs into parsable json
+// JSONFormatter formats logs into parsable JSON.
+//
+// Fields from [Entry.Data] are included in the JSON object together with the
+// standard fields derived from the entry. If a field conflicts with a standard
+// field, it is prefixed with "fields.". Standard field names can be customized
+// through FieldMap. When DataKey is set, fields from [Entry.Data] are nested
+// under that key instead.
 type JSONFormatter struct {
 	// TimestampFormat sets the format used for marshaling timestamps.
 	// The format to use is the same than for time.Format or time.Parse from the standard

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -17,10 +17,14 @@ var baseTimestamp = time.Now()
 
 // TextFormatter formats logs into text.
 //
-// Output is logfmt-like: key=value pairs separated by spaces. Field keys are
-// written as-is (unquoted and unescaped) in the plain (non-colored) format;
-// only field values may be quoted depending on DisableQuote, ForceQuote,
-// QuoteEmptyFields, and the value content.
+// Output is logfmt-like: key=value pairs separated by spaces. Fields from
+// [Entry.Data] are included together with the standard fields derived from the
+// entry. If a field conflicts with a standard field, it is prefixed with
+// "fields.". Standard field names can be customized through FieldMap.
+//
+// Field keys are written as-is (unquoted and unescaped) in the plain
+// (non-colored) format; only field values may be quoted depending on
+// DisableQuote, ForceQuote, QuoteEmptyFields, and the value content.
 //
 // When colors are enabled, ANSI escape sequences may be added for presentation.
 // For fully escaped structured output (including safe keys), use JSONFormatter.


### PR DESCRIPTION
- replaces, closes https://github.com/sirupsen/logrus/pull/1356

Clarify that Formatter receives standard log fields through Entry itself, while fields added with WithField and WithFields are available in Entry.Data.

Document how TextFormatter and JSONFormatter combine Entry.Data with standard fields, including conflict prefixing and configurable field names.