### PR TITLE
formatter: differentiate debug and trace colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changed:
 
   * Raise minimum supported Go version to 1.23.
   * TextFormatter now renders `[]byte` values as raw/quoted strings instead of slice-of-ints.
+  * TextFormatter now uses distinct dimmed colors for debug and trace output.
   * TextFormatter now automatically enables colors on Windows terminals with ANSI support,
     matching the behavior on other platforms.
   * `Entry.HasCaller` is now deprecated in favor of checking `Entry.Caller` directly.

--- a/level.go
+++ b/level.go
@@ -6,11 +6,12 @@ import (
 )
 
 const (
-	ansiReset  = "\x1b[0m"  // reset attributes
-	ansiRed    = "\x1b[31m" // red
-	ansiYellow = "\x1b[33m" // yellow
-	ansiCyan   = "\x1b[36m" // cyan
-	ansiWhite  = "\x1b[37m" // white (light gray)
+	ansiReset    = "\x1b[0m"    // reset attributes
+	ansiRed      = "\x1b[31m"   // red
+	ansiYellow   = "\x1b[33m"   // yellow
+	ansiCyan     = "\x1b[36m"   // cyan
+	ansiDimCyan  = "\x1b[2;36m" // dim cyan
+	ansiDimWhite = "\x1b[2;37m" // dim white (light gray)
 )
 
 type lvlPrefix struct {
@@ -22,8 +23,10 @@ type lvlPrefix struct {
 func colorize(level Level, s string) string {
 	color := ansiCyan
 	switch level {
-	case DebugLevel, TraceLevel:
-		color = ansiWhite
+	case TraceLevel:
+		color = ansiDimWhite
+	case DebugLevel:
+		color = ansiDimCyan
 	case WarnLevel:
 		color = ansiYellow
 	case ErrorLevel, FatalLevel, PanicLevel:


### PR DESCRIPTION
- alternative to / closes https://github.com/sirupsen/logrus/pull/1481

Use dim cyan for debug output and dim white for trace output to make lower-severity log messages easier to distinguish in TTY output.

Before

<img width="740" height="140" alt="Screenshot 2026-08-13 at 16 28 21" src="https://github.com/user-attachments/assets/d7f27f6e-69ec-49e7-9caf-36adb2b25567" />


After

<img width="744" height="173" alt="Screenshot 2026-08-13 at 16 27 10" src="https://github.com/user-attachments/assets/a1282075-1979-4044-8342-2b8e978db0d2" />
