### PR TITLE
fix(hooks): fire remaining hooks after a Hook.Fire error

### DIFF
--- a/hook_test.go
+++ b/hook_test.go
@@ -1,6 +1,7 @@
 package logrus_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -258,4 +259,34 @@ func TestHookFireOrder(t *testing.T) {
 		t.Error("unexpected error:", err)
 	}
 	require.Equal(t, []string{"first hook", "second hook", "third hook"}, checkers)
+}
+
+type errHook struct {
+	name string
+	err  error
+	hit  *[]string
+}
+
+func (h *errHook) Levels() []Level { return AllLevels }
+
+func (h *errHook) Fire(*Entry) error {
+	if h.hit != nil {
+		*h.hit = append(*h.hit, h.name)
+	}
+	return h.err
+}
+
+func TestHookFireContinuesAfterError(t *testing.T) {
+	// Issue #408: an error from one hook must not skip later hooks.
+	var hit []string
+	h := LevelHooks{}
+	h.Add(&errHook{name: "first", err: errors.New("boom-first"), hit: &hit})
+	h.Add(&errHook{name: "second", err: nil, hit: &hit})
+	h.Add(&errHook{name: "third", err: errors.New("boom-third"), hit: &hit})
+
+	err := h.Fire(InfoLevel, &Entry{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "boom-first")
+	require.ErrorContains(t, err, "boom-third")
+	require.Equal(t, []string{"first", "second", "third"}, hit)
 }

--- a/hooks.go
+++ b/hooks.go
@@ -1,5 +1,7 @@
 package logrus
 
+import "errors"
+
 // Hook describes hooks to be fired when logging on the logging levels returned from
 // [Hook.Levels] on your implementation of the interface. Note that this is not
 // fired in a goroutine or a channel with workers, you should handle such
@@ -23,12 +25,16 @@ func (hooks LevelHooks) Add(hook Hook) {
 
 // Fire all the hooks for the passed level. Used by `entry.log` to fire
 // appropriate hooks for a log entry.
+//
+// Every hook for the level is invoked even if an earlier hook returns an
+// error. When multiple hooks fail, the returned error is the join of all
+// errors (Go 1.20+ errors.Join). This matches the doc comment: fire all hooks.
 func (hooks LevelHooks) Fire(level Level, entry *Entry) error {
+	var errs []error
 	for _, hook := range hooks[level] {
 		if err := hook.Fire(entry); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-
-	return nil
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
## Summary
Fixes #408.

`LevelHooks.Fire` previously returned on the first hook error, so later hooks never ran (contradicting the doc: fire **all** hooks for the level).

Now every hook for the level is invoked; errors are combined with `errors.Join`.

As suggested by the maintainer, this avoids importing a multierror package.

## Test plan
- [x] `TestHookFireContinuesAfterError`
- [x] Existing `TestHookFireOrder` still passes