### PR TITLE
improve test- and benchmark coverage

### DIFF
--- a/entry_bench_test.go
+++ b/entry_bench_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// BenchmarkEntry_NewEntry measures the cost of creating entries that are not
+// subsequently logged.
+func BenchmarkEntry_NewEntry(b *testing.B) {
+	logger := logrus.New()
+
+	b.Run("empty", func(b *testing.B) {
+		b.ReportAllocs()
+		var entry *logrus.Entry
+		for range b.N {
+			entry = logrus.NewEntry(logger)
+		}
+		runtime.KeepAlive(entry)
+	})
+
+	b.Run("with_field", func(b *testing.B) {
+		b.ReportAllocs()
+		var entry *logrus.Entry
+		for range b.N {
+			entry = logrus.NewEntry(logger).WithField("key", "value")
+		}
+		runtime.KeepAlive(entry)
+	})
+}
+
 func BenchmarkEntry_WithError(b *testing.B) {
 	base := &logrus.Entry{Data: logrus.Fields{"a": 1}}
 	errBoom := errors.New("boom")
@@ -42,6 +66,55 @@ func BenchmarkEntry_WithField_Chain(b *testing.B) {
 		result = e
 	}
 	runtime.KeepAlive(result)
+}
+
+// BenchmarkEntry_WithField_Chain_Disabled measures the cost of constructing a
+// chain of fields when the resulting log call is disabled by the log level.
+func BenchmarkEntry_WithField_Chain_Disabled(b *testing.B) {
+	logger := logrus.New()
+	logger.SetFormatter(nopFormatter{})
+	logger.SetLevel(logrus.InfoLevel)
+
+	base := logrus.NewEntry(logger).WithField("a", 1)
+	errBoom := errors.New("boom")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		base.
+			WithField("k0", 0).
+			WithField("k1", 1).
+			WithField("k2", 2).
+			WithField("k3", 3).
+			WithError(errBoom).
+			Debug("message")
+	}
+}
+
+// BenchmarkEntry_WithField_Chain_Enabled measures the cost of constructing and
+// logging a chain of fields when the log level is enabled.
+func BenchmarkEntry_WithField_Chain_Enabled(b *testing.B) {
+	logger := logrus.New()
+	logger.SetFormatter(nopFormatter{})
+	logger.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(io.Discard)
+
+	base := logrus.NewEntry(logger).WithField("a", 1)
+	errBoom := errors.New("boom")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		base.
+			WithField("k0", 0).
+			WithField("k1", 1).
+			WithField("k2", 2).
+			WithField("k3", 3).
+			WithError(errBoom).
+			Debug("message")
+	}
 }
 
 func BenchmarkEntry_WithFields(b *testing.B) {
@@ -90,6 +163,63 @@ func BenchmarkEntry_WithFields(b *testing.B) {
 				result = e.WithFields(tc.fields)
 			}
 			runtime.KeepAlive(result)
+		})
+	}
+}
+
+// BenchmarkEntry_WithFields_Reused measures logging through an Entry that was
+// constructed once with fields and reused across multiple log calls.
+func BenchmarkEntry_WithFields_Reused(b *testing.B) {
+	tests := []struct {
+		name  string
+		entry func(*logrus.Logger) *logrus.Entry
+	}{
+		{
+			name: "small",
+			entry: func(logger *logrus.Logger) *logrus.Entry {
+				return logger.WithFields(smallFields)
+			},
+		},
+		{
+			name: "small_duplicates",
+			entry: func(logger *logrus.Logger) *logrus.Entry {
+				return logger.
+					WithFields(smallFields).
+					WithFields(smallFields).
+					WithFields(smallFields)
+			},
+		},
+		{
+			name: "large",
+			entry: func(logger *logrus.Logger) *logrus.Entry {
+				return logger.WithFields(largeFields)
+			},
+		},
+		{
+			name: "large_duplicates",
+			entry: func(logger *logrus.Logger) *logrus.Entry {
+				return logger.
+					WithFields(largeFields).
+					WithFields(largeFields).
+					WithFields(largeFields)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			logger := logrus.New()
+			logger.SetFormatter(nopFormatter{})
+			logger.SetOutput(io.Discard)
+
+			entry := tc.entry(logger)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range b.N {
+				entry.Info("message")
+			}
 		})
 	}
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -18,6 +18,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type noopHook struct{}
+
+func (noopHook) Levels() []logrus.Level   { return logrus.AllLevels }
+func (noopHook) Fire(*logrus.Entry) error { return nil }
+
+type nopBufferPool struct{}
+
+func (nopBufferPool) Get() *bytes.Buffer { return new(bytes.Buffer) }
+func (nopBufferPool) Put(*bytes.Buffer)  {}
+
+type nopFormatter struct{}
+
+func (nopFormatter) Format(*logrus.Entry) ([]byte, error) { return nil, nil }
+
 type contextKeyType string
 
 func TestEntryWithError(t *testing.T) {
@@ -412,16 +426,6 @@ func TestEntryLoggerMutationRace(t *testing.T) {
 		})
 	}
 }
-
-type noopHook struct{}
-
-func (noopHook) Levels() []logrus.Level   { return logrus.AllLevels }
-func (noopHook) Fire(*logrus.Entry) error { return nil }
-
-type nopBufferPool struct{}
-
-func (nopBufferPool) Get() *bytes.Buffer { return new(bytes.Buffer) }
-func (nopBufferPool) Put(*bytes.Buffer)  {}
 
 func runEntryLoggerRace(t *testing.T, mutate func(logger *logrus.Logger)) {
 	t.Helper()

--- a/entry_test.go
+++ b/entry_test.go
@@ -523,3 +523,55 @@ func TestEntryWithFieldsThenBranch(t *testing.T) {
 		"b": 2,
 	}, hook.Entries[2].Data)
 }
+
+// TestEntryDataIsMutable verifies that Entry.Data exposes materialized fields,
+// can be modified directly, and remains isolated between derived entries.
+func TestEntryDataIsMutable(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+
+	// Fields added to an entry are exposed immediately through Data.
+	parent := logger.WithFields(logrus.Fields{
+		"foo": "bar",
+		"one": 1,
+	})
+
+	assert.Equal(t, "bar", parent.Data["foo"])
+	assert.Equal(t, 1, parent.Data["one"])
+
+	// Derived entries inherit the parent's fields without sharing its Data map.
+	child := parent.WithFields(logrus.Fields{
+		"two": 2,
+	})
+
+	assert.Equal(t, "bar", child.Data["foo"])
+	assert.Equal(t, 1, child.Data["one"])
+	assert.Equal(t, 2, child.Data["two"])
+
+	// Data is public and mutable. Changes to the child must not affect its
+	// parent, and newly added fields must be preserved.
+	child.Data["foo"] = "changed"
+	child.Data["three"] = 3
+
+	assert.Equal(t, "bar", parent.Data["foo"])
+	assert.Equal(t, 1, parent.Data["one"])
+	assert.NotContains(t, parent.Data, "three")
+
+	// Logging must use the currently exposed Data and must not overwrite direct
+	// mutations by re-materializing fields from internal state.
+	parent.Info("parent")
+	child.Info("child")
+
+	require.Len(t, hook.Entries, 2)
+
+	assert.Equal(t, logrus.Fields{
+		"foo": "bar",
+		"one": 1,
+	}, hook.Entries[0].Data)
+
+	assert.Equal(t, logrus.Fields{
+		"foo":   "changed",
+		"one":   1,
+		"two":   2,
+		"three": 3,
+	}, hook.Entries[1].Data)
+}

--- a/entry_test.go
+++ b/entry_test.go
@@ -36,13 +36,9 @@ type contextKeyType string
 
 func TestEntryWithError(t *testing.T) {
 	expErr := fmt.Errorf("kaboom at layer %d", 4711)
-	assert.Equal(t, expErr, logrus.WithError(expErr).Data["error"])
+	logger, hook := test.NewNullLogger()
 
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	entry := logrus.NewEntry(logger)
-
-	assert.Equal(t, expErr, entry.WithError(expErr).Data["error"])
+	logger.WithError(expErr).Error("default key")
 
 	tmpKey := logrus.ErrorKey
 	logrus.ErrorKey = "err" //nolint:reassign // ignore "reassigning variable ErrorKey in other package logrus (reassign)"
@@ -50,7 +46,11 @@ func TestEntryWithError(t *testing.T) {
 		logrus.ErrorKey = tmpKey //nolint:reassign // ignore "reassigning variable ErrorKey in other package logrus (reassign)"
 	})
 
-	assert.Equal(t, expErr, entry.WithError(expErr).Data["err"])
+	logger.WithError(expErr).Error("custom key")
+
+	require.Len(t, hook.Entries, 2)
+	assert.Equal(t, expErr, hook.Entries[0].Data["error"])
+	assert.Equal(t, expErr, hook.Entries[1].Data["err"])
 }
 
 func TestEntryWithContext(t *testing.T) {
@@ -67,82 +67,58 @@ func TestEntryWithContext(t *testing.T) {
 	assert.Equal(ctx, entry.WithContext(ctx).Context)
 }
 
-func TestEntryWithContextCopiesData(t *testing.T) {
-	assert := assert.New(t)
+func TestEntryWithContextPreservesData(t *testing.T) {
+	logger, hook := test.NewNullLogger()
 
-	// Initialize a parent Entry object with a key/value set in its Data map
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	parentEntry := logrus.NewEntry(logger).WithField("parentKey", "parentValue")
+	// Initialize a parent Entry object with a key/value field.
+	parentEntry := logger.WithField("parentKey", "parentValue")
 
-	// Create two children Entry objects from the parent in different contexts
+	// Create two child Entry objects from the parent in different contexts.
 	var contextKey1 contextKeyType = "foo"
 	ctx1 := context.WithValue(context.Background(), contextKey1, "bar")
 	childEntry1 := parentEntry.WithContext(ctx1)
-	assert.Equal(ctx1, childEntry1.Context)
+	assert.Equal(t, ctx1, childEntry1.Context)
 
 	var contextKey2 contextKeyType = "bar"
 	ctx2 := context.WithValue(context.Background(), contextKey2, "baz")
 	childEntry2 := parentEntry.WithContext(ctx2)
-	assert.Equal(ctx2, childEntry2.Context)
-	assert.NotEqual(ctx1, ctx2)
+	assert.Equal(t, ctx2, childEntry2.Context)
+	assert.NotEqual(t, ctx1, ctx2)
 
-	// Ensure that data set in the parent Entry are preserved to both children
-	assert.Equal("parentValue", childEntry1.Data["parentKey"])
-	assert.Equal("parentValue", childEntry2.Data["parentKey"])
+	childEntry1.Info("child 1")
+	childEntry2.Info("child 2")
+	parentEntry.Info("parent")
 
-	// Modify data stored in the child entry
-	childEntry1.Data["childKey"] = "childValue"
+	require.Len(t, hook.Entries, 3)
 
-	// Verify that data is successfully stored in the child it was set on
-	val, exists := childEntry1.Data["childKey"]
-	assert.True(exists)
-	assert.Equal("childValue", val)
-
-	// Verify that the data change to child 1 has not affected its sibling
-	val, exists = childEntry2.Data["childKey"]
-	assert.False(exists)
-	assert.Empty(val)
-
-	// Verify that the data change to child 1 has not affected its parent
-	val, exists = parentEntry.Data["childKey"]
-	assert.False(exists)
-	assert.Empty(val)
+	// Ensure that data set in the parent Entry are preserved in both children
+	// and when the parent is reused.
+	assert.Equal(t, "parentValue", hook.Entries[0].Data["parentKey"])
+	assert.Equal(t, "parentValue", hook.Entries[1].Data["parentKey"])
+	assert.Equal(t, "parentValue", hook.Entries[2].Data["parentKey"])
 }
 
-func TestEntryWithTimeCopiesData(t *testing.T) {
-	assert := assert.New(t)
+func TestEntryWithTimePreservesData(t *testing.T) {
+	logger, hook := test.NewNullLogger()
 
-	// Initialize a parent Entry object with a key/value set in its Data map
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	parentEntry := logrus.NewEntry(logger).WithField("parentKey", "parentValue")
+	// Initialize a parent Entry object with a key/value field.
+	parentEntry := logger.WithField("parentKey", "parentValue")
 
-	// Create two children Entry objects from the parent with two different times
+	// Create two child Entry objects from the parent with two different times.
 	childEntry1 := parentEntry.WithTime(time.Now().AddDate(0, 0, 1))
 	childEntry2 := parentEntry.WithTime(time.Now().AddDate(0, 0, 2))
 
-	// Ensure that data set in the parent Entry are preserved to both children
-	assert.Equal("parentValue", childEntry1.Data["parentKey"])
-	assert.Equal("parentValue", childEntry2.Data["parentKey"])
+	childEntry1.Info("child 1")
+	childEntry2.Info("child 2")
+	parentEntry.Info("parent")
 
-	// Modify data stored in the child entry
-	childEntry1.Data["childKey"] = "childValue"
+	require.Len(t, hook.Entries, 3)
 
-	// Verify that data is successfully stored in the child it was set on
-	val, exists := childEntry1.Data["childKey"]
-	assert.True(exists)
-	assert.Equal("childValue", val)
-
-	// Verify that the data change to child 1 has not affected its sibling
-	val, exists = childEntry2.Data["childKey"]
-	assert.False(exists)
-	assert.Empty(val)
-
-	// Verify that the data change to child 1 has not affected its parent
-	val, exists = parentEntry.Data["childKey"]
-	assert.False(exists)
-	assert.Empty(val)
+	// Ensure that data set in the parent Entry are preserved in both children
+	// and when the parent is reused.
+	assert.Equal(t, "parentValue", hook.Entries[0].Data["parentKey"])
+	assert.Equal(t, "parentValue", hook.Entries[1].Data["parentKey"])
+	assert.Equal(t, "parentValue", hook.Entries[2].Data["parentKey"])
 }
 
 // TestEntryLogPanicLevelDoesNotPanic verifies that generic Log methods treat
@@ -347,41 +323,42 @@ func TestEntryDerivationPreservesCaller(t *testing.T) {
 }
 
 func TestEntryWithIncorrectField(t *testing.T) {
+	var buf bytes.Buffer
+
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.JSONFormatter{})
-	logger.SetOutput(io.Discard)
-	entry := logrus.NewEntry(logger)
+	logger.SetOutput(&buf)
 
 	fn := func() {}
-	eWithFunc := entry.WithFields(logrus.Fields{"func": fn})
-	eWithFuncPtr := entry.WithFields(logrus.Fields{"funcPtr": &fn})
+	eWithFunc := logger.WithFields(logrus.Fields{"func": fn})
+	eWithFuncPtr := logger.WithFields(logrus.Fields{"funcPtr": &fn})
 
-	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, eWithFunc))
-	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, eWithFuncPtr))
+	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, &buf, eWithFunc))
+	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, &buf, eWithFuncPtr))
 
 	eWithFunc = eWithFunc.WithField("not_a_func", "it is a string")
 	eWithFuncPtr = eWithFuncPtr.WithField("not_a_func", "it is a string")
 
-	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, eWithFunc))
-	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, eWithFuncPtr))
+	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, &buf, eWithFunc))
+	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, &buf, eWithFuncPtr))
 
 	eWithFunc = eWithFunc.WithTime(time.Now())
 	eWithFuncPtr = eWithFuncPtr.WithTime(time.Now())
 
-	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, eWithFunc))
-	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, eWithFuncPtr))
+	assert.Equal(t, `skipping unsupported field "func"`, getErr(t, &buf, eWithFunc))
+	assert.Equal(t, `skipping unsupported field "funcPtr"`, getErr(t, &buf, eWithFuncPtr))
 }
 
-func getErr(t *testing.T, e *logrus.Entry) string {
+func getErr(t *testing.T, buf *bytes.Buffer, entry *logrus.Entry) string {
 	t.Helper()
 
-	out, err := e.String()
-	require.NoError(t, err)
+	buf.Reset()
+	entry.Info("test")
 
-	var m map[string]any
-	require.NoError(t, json.Unmarshal([]byte(out), &m))
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &data))
 
-	got, _ := m[logrus.FieldKeyLogrusError].(string)
+	got, _ := data[logrus.FieldKeyLogrusError].(string)
 	return got
 }
 

--- a/entry_test.go
+++ b/entry_test.go
@@ -509,3 +509,40 @@ func TestEntryReentrantLoggingDeadlock(t *testing.T) {
 		t.Fatal("deadlock detected: reentrant logging from MarshalJSON blocked for 5 seconds")
 	}
 }
+
+// TestEntryWithFieldsThenBranch verifies that an Entry with fields can be
+// logged, used as the parent of a derived Entry, and reused without inheriting
+// fields added to the derived Entry.
+func TestEntryWithFieldsThenBranch(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+
+	entry := logger.
+		WithField("a", 1).
+		WithField("b", 2)
+
+	entry.Info("parent")
+
+	require.Len(t, hook.Entries, 1)
+	assert.Equal(t, logrus.Fields{
+		"a": 1,
+		"b": 2,
+	}, hook.Entries[0].Data)
+
+	child := entry.WithField("c", 3)
+	child.Info("child")
+
+	require.Len(t, hook.Entries, 2)
+	assert.Equal(t, logrus.Fields{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	}, hook.Entries[1].Data)
+
+	entry.Info("parent again")
+
+	require.Len(t, hook.Entries, 3)
+	assert.Equal(t, logrus.Fields{
+		"a": 1,
+		"b": 2,
+	}, hook.Entries[2].Data)
+}

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -12,19 +12,28 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func TestErrorNotLost(t *testing.T) {
-	formatter := &logrus.JSONFormatter{}
+func formatJSONEntry(t *testing.T, formatter *logrus.JSONFormatter, fields logrus.Fields) map[string]any {
+	t.Helper()
 
-	b, err := formatter.Format(logrus.WithField("error", errors.New("wild walrus")))
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
+	var buf bytes.Buffer
+
+	logger := logrus.New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(formatter)
+
+	logger.WithFields(fields).Info("")
 
 	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
-	if err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
 		t.Fatal("Unable to unmarshal formatted entry: ", err)
 	}
+	return entry
+}
+
+func TestErrorNotLost(t *testing.T) {
+	entry := formatJSONEntry(t, &logrus.JSONFormatter{}, logrus.Fields{
+		"error": errors.New("wild walrus"),
+	})
 
 	if entry["error"] != "wild walrus" {
 		t.Fatal("Error field not set")
@@ -32,18 +41,9 @@ func TestErrorNotLost(t *testing.T) {
 }
 
 func TestErrorNotLostOnFieldNotNamedError(t *testing.T) {
-	formatter := &logrus.JSONFormatter{}
-
-	b, err := formatter.Format(logrus.WithField("omg", errors.New("wild walrus")))
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
-
-	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
-	if err != nil {
-		t.Fatal("Unable to unmarshal formatted entry: ", err)
-	}
+	entry := formatJSONEntry(t, &logrus.JSONFormatter{}, logrus.Fields{
+		"omg": errors.New("wild walrus"),
+	})
 
 	if entry["omg"] != "wild walrus" {
 		t.Fatal("Error field not set")
@@ -51,41 +51,24 @@ func TestErrorNotLostOnFieldNotNamedError(t *testing.T) {
 }
 
 func TestFieldClashWithTime(t *testing.T) {
-	formatter := &logrus.JSONFormatter{}
-
-	b, err := formatter.Format(logrus.WithField("time", "right now!"))
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
-
-	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
-	if err != nil {
-		t.Fatal("Unable to unmarshal formatted entry: ", err)
-	}
+	entry := formatJSONEntry(t, &logrus.JSONFormatter{}, logrus.Fields{
+		"time": "right now!",
+	})
 
 	if entry["fields.time"] != "right now!" {
 		t.Fatal("fields.time not set to original time field")
 	}
 
-	if entry["time"] != "0001-01-01T00:00:00Z" {
-		t.Fatal("time field not set to current time, was: ", entry["time"])
+	timeVal, ok := entry["time"].(string)
+	if !ok || timeVal == "" || timeVal == "right now!" {
+		t.Fatal("time field not set to Entry time")
 	}
 }
 
 func TestFieldClashWithMsg(t *testing.T) {
-	formatter := &logrus.JSONFormatter{}
-
-	b, err := formatter.Format(logrus.WithField("msg", "something"))
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
-
-	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
-	if err != nil {
-		t.Fatal("Unable to unmarshal formatted entry: ", err)
-	}
+	entry := formatJSONEntry(t, &logrus.JSONFormatter{}, logrus.Fields{
+		"msg": "something",
+	})
 
 	if entry["fields.msg"] != "something" {
 		t.Fatal("fields.msg not set to original msg field")
@@ -93,18 +76,9 @@ func TestFieldClashWithMsg(t *testing.T) {
 }
 
 func TestFieldClashWithLevel(t *testing.T) {
-	formatter := &logrus.JSONFormatter{}
-
-	b, err := formatter.Format(logrus.WithField("level", "something"))
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
-
-	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
-	if err != nil {
-		t.Fatal("Unable to unmarshal formatted entry: ", err)
-	}
+	entry := formatJSONEntry(t, &logrus.JSONFormatter{}, logrus.Fields{
+		"level": "something",
+	})
 
 	if entry["fields.level"] != "something" {
 		t.Fatal("fields.level not set to original level field")
@@ -119,24 +93,14 @@ func TestFieldClashWithRemappedFields(t *testing.T) {
 			logrus.FieldKeyMsg:   "@message",
 		},
 	}
-
-	b, err := formatter.Format(logrus.WithFields(logrus.Fields{
+	entry := formatJSONEntry(t, formatter, logrus.Fields{
 		"@timestamp": "@timestamp",
 		"@level":     "@level",
 		"@message":   "@message",
 		"timestamp":  "timestamp",
 		"level":      "level",
 		"msg":        "msg",
-	}))
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
-
-	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
-	if err != nil {
-		t.Fatal("Unable to unmarshal formatted entry: ", err)
-	}
+	})
 
 	for _, field := range []string{"timestamp", "level", "msg"} {
 		if entry[field] != field {
@@ -166,23 +130,23 @@ func TestFieldClashWithRemappedFields(t *testing.T) {
 }
 
 func TestFieldsInNestedDictionary(t *testing.T) {
-	formatter := &logrus.JSONFormatter{
-		DataKey: "args",
-	}
+	var buf bytes.Buffer
 
-	logEntry := logrus.WithFields(logrus.Fields{
+	logger := logrus.New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(&logrus.JSONFormatter{
+		DataKey: "args",
+	})
+
+	logEntry := logger.WithFields(logrus.Fields{
 		"level": "level",
 		"test":  "test",
 	})
-	logEntry.Level = logrus.InfoLevel
+	logEntry.Info("test")
 
-	b, err := formatter.Format(logEntry)
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
-
+	b := buf.Bytes()
 	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
+	err := json.Unmarshal(b, &entry)
 	if err != nil {
 		t.Fatal("Unable to unmarshal formatted entry: ", err)
 	}
@@ -285,13 +249,15 @@ func TestJSONEntryFieldValueError(t *testing.T) {
 }
 
 func TestJSONEntryEndsWithNewline(t *testing.T) {
-	formatter := &logrus.JSONFormatter{}
+	var buf bytes.Buffer
 
-	b, err := formatter.Format(logrus.WithField("level", "something"))
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
+	logger := logrus.New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(&logrus.JSONFormatter{})
 
+	logger.WithField("level", "something").Info("")
+
+	b := buf.Bytes()
 	if b[len(b)-1] != '\n' {
 		t.Fatal("Expected JSON log entry to end with a newline")
 	}
@@ -349,17 +315,17 @@ func TestJSONTimeKey(t *testing.T) {
 }
 
 func TestFieldDoesNotClashWithCaller(t *testing.T) {
-	logrus.SetReportCaller(false)
-	formatter := &logrus.JSONFormatter{}
+	var buf bytes.Buffer
 
-	b, err := formatter.Format(logrus.WithField("func", "howdy pardner"))
-	if err != nil {
-		t.Fatal("Unable to format entry: ", err)
-	}
+	logger := logrus.New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetReportCaller(false)
 
-	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
-	if err != nil {
+	logger.WithField("func", "howdy pardner").Info("")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
 		t.Fatal("Unable to unmarshal formatted entry: ", err)
 	}
 
@@ -369,21 +335,22 @@ func TestFieldDoesNotClashWithCaller(t *testing.T) {
 }
 
 func TestFieldClashWithCaller(t *testing.T) {
-	logrus.SetReportCaller(true)
-	t.Cleanup(func() {
-		logrus.SetReportCaller(false) // return to default value
-	})
 	formatter := &logrus.JSONFormatter{}
-	e := logrus.WithField("func", "howdy pardner")
-	e.Caller = &runtime.Frame{Function: "somefunc"}
-	b, err := formatter.Format(e)
+
+	b, err := formatter.Format(&logrus.Entry{
+		Data: logrus.Fields{
+			"func": "howdy pardner",
+		},
+		Caller: &runtime.Frame{
+			Function: "somefunc",
+		},
+	})
 	if err != nil {
 		t.Fatal("Unable to format entry: ", err)
 	}
 
 	entry := make(map[string]any)
-	err = json.Unmarshal(b, &entry)
-	if err != nil {
+	if err := json.Unmarshal(b, &entry); err != nil {
 		t.Fatal("Unable to unmarshal formatted entry: ", err)
 	}
 

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -72,22 +72,23 @@ func BenchmarkLoggerLog(b *testing.B) {
 	logger.SetLevel(logrus.InfoLevel)
 	logger.SetOutput(io.Discard)
 
-	b.ReportAllocs()
-
 	b.Run("disabled_level", func(b *testing.B) {
 		b.ReportAllocs()
+		b.ResetTimer()
 		for range b.N {
 			logger.Log(logrus.DebugLevel, "test")
 		}
 	})
 	b.Run("enabled_log", func(b *testing.B) {
 		b.ReportAllocs()
+		b.ResetTimer()
 		for range b.N {
 			logger.Log(logrus.WarnLevel, "test")
 		}
 	})
 	b.Run("enabled_logln", func(b *testing.B) {
 		b.ReportAllocs()
+		b.ResetTimer()
 		for range b.N {
 			logger.Logln(logrus.WarnLevel, "test")
 		}

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -60,12 +60,6 @@ func doLoggerBenchmarkNoLock(b *testing.B, out *os.File, formatter logrus.Format
 	})
 }
 
-type nopFormatter struct{}
-
-func (nopFormatter) Format(*logrus.Entry) ([]byte, error) {
-	return nil, nil
-}
-
 func BenchmarkLoggerLog(b *testing.B) {
 	logger := logrus.New()
 	logger.SetFormatter(nopFormatter{})

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -17,30 +17,48 @@ import (
 )
 
 func TestFormatting(t *testing.T) {
-	tf := &TextFormatter{DisableColors: true}
+	var buf bytes.Buffer
 
-	testCases := []struct {
+	tf := &TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	}
+
+	logger := New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(tf)
+
+	tests := []struct {
 		value    string
 		expected string
 	}{
-		{`foo`, "time=\"0001-01-01T00:00:00Z\" level=panic test=foo\n"},
+		{`foo`, "level=info test=foo\n"},
 	}
 
-	for _, tc := range testCases {
-		b, _ := tf.Format(WithField("test", tc.value))
+	for _, tc := range tests {
+		buf.Reset()
+		logger.WithField("test", tc.value).Info("")
 
-		if string(b) != tc.expected {
-			t.Errorf("formatting expected for %q (result was %q instead of %q)", tc.value, string(b), tc.expected)
+		if buf.String() != tc.expected {
+			t.Errorf("formatting expected for %q (result was %q instead of %q)", tc.value, buf.String(), tc.expected)
 		}
 	}
 }
 
 func TestQuoting(t *testing.T) {
+	var buf bytes.Buffer
+
 	tf := &TextFormatter{DisableColors: true}
 
+	logger := New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(tf)
+
 	checkQuoting := func(q bool, value any) {
-		b, _ := tf.Format(WithField("test", value))
-		_, after, _ := bytes.Cut(b, ([]byte)("test="))
+		buf.Reset()
+		logger.WithField("test", value).Info("")
+
+		_, after, _ := bytes.Cut(buf.Bytes(), []byte("test="))
 		cont := bytes.Contains(after, []byte("\""))
 		if cont != q {
 			if q {
@@ -130,41 +148,32 @@ func TestQuoting(t *testing.T) {
 }
 
 func TestEscaping(t *testing.T) {
+	var buf bytes.Buffer
+
 	tf := &TextFormatter{DisableColors: true}
 
-	testCases := []struct {
-		value    string
+	logger := New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(tf)
+
+	ts := time.Now()
+
+	tests := []struct {
+		value    any
 		expected string
 	}{
 		{`ba"r`, `ba\"r`},
 		{`ba'r`, `ba'r`},
-	}
-
-	for _, tc := range testCases {
-		b, _ := tf.Format(WithField("test", tc.value))
-		if !bytes.Contains(b, []byte(tc.expected)) {
-			t.Errorf("escaping expected for %q (result was %q instead of %q)", tc.value, string(b), tc.expected)
-		}
-	}
-}
-
-func TestEscaping_Interface(t *testing.T) {
-	tf := &TextFormatter{DisableColors: true}
-
-	ts := time.Now()
-
-	testCases := []struct {
-		value    any
-		expected string
-	}{
 		{ts, fmt.Sprintf("\"%s\"", ts.String())},
 		{errors.New("error: something went wrong"), "\"error: something went wrong\""},
 	}
 
-	for _, tc := range testCases {
-		b, _ := tf.Format(WithField("test", tc.value))
-		if !bytes.Contains(b, []byte(tc.expected)) {
-			t.Errorf("escaping expected for %q (result was %q instead of %q)", tc.value, string(b), tc.expected)
+	for _, tc := range tests {
+		buf.Reset()
+		logger.WithField("test", tc.value).Info("")
+
+		if !bytes.Contains(buf.Bytes(), []byte(tc.expected)) {
+			t.Errorf("escaping expected for %q (result was %q instead of %q)", tc.value, buf.String(), tc.expected)
 		}
 	}
 }


### PR DESCRIPTION
improve test- and benchmark coverage

### logger: reset timer before LoggerLog sub-benchmarks

Reset the benchmark timer after logger setup in each `LoggerLog` sub-benchmark.
This keeps logger configuration and other setup work out of the measured loop.


### entry: add benchmarks for entry construction and reuse

Add benchmarks for creating entries, chained field construction, and logging
through entries reused across multiple calls.

Cover chained logging with the target level both enabled and disabled to
provide baselines for evaluating changes to how Entry fields are accumulated,
materialized, and reused.


### entry: add test for branching from reused entries

Verify that an Entry can be logged, used as the parent of a derived Entry,
and then reused without inheriting fields added to the child.

This provides coverage for preserving parent field state when entries are
branched and reused.


### entry, formatter: test formatters through the logging path

Update formatter and Entry tests to exercise fields through a Logger instead
of relying on fields being eagerly exposed through Entry.Data.

Use local loggers where possible instead of the package-level standard logger,
keeping the tests focused on their observable logging and formatting behavior.


### entry: add coverage for mutable Entry.Data

Add a focused test for the existing Entry.Data behavior.

Verify that fields are exposed through Data, derived entries inherit fields
without sharing the same map, and direct mutations remain visible when the
entry is logged.
