### PR TITLE
entry: improve error-handling benchmarks and coverage

### DIFF
--- a/entry_bench_test.go
+++ b/entry_bench_test.go
@@ -33,17 +33,38 @@ func BenchmarkEntry_NewEntry(b *testing.B) {
 	})
 }
 
+// BenchmarkEntry_WithError compares the ways an error can be added to an Entry.
 func BenchmarkEntry_WithError(b *testing.B) {
-	base := &logrus.Entry{Data: logrus.Fields{"a": 1}}
+	logger := logrus.New()
+	base := logrus.NewEntry(logger).WithField("a", 1)
 	errBoom := errors.New("boom")
-	b.ReportAllocs()
-	b.ResetTimer()
 
-	var result *logrus.Entry
-	for range b.N {
-		result = base.WithError(errBoom)
-	}
-	runtime.KeepAlive(result)
+	b.Run("WithError", func(b *testing.B) {
+		b.ReportAllocs()
+		var entry *logrus.Entry
+		for range b.N {
+			entry = base.WithError(errBoom)
+		}
+		runtime.KeepAlive(entry)
+	})
+
+	b.Run("WithField", func(b *testing.B) {
+		b.ReportAllocs()
+		var entry *logrus.Entry
+		for range b.N {
+			entry = base.WithField(logrus.ErrorKey, errBoom)
+		}
+		runtime.KeepAlive(entry)
+	})
+
+	b.Run("WithFields", func(b *testing.B) {
+		b.ReportAllocs()
+		var entry *logrus.Entry
+		for range b.N {
+			entry = base.WithFields(logrus.Fields{logrus.ErrorKey: errBoom})
+		}
+		runtime.KeepAlive(entry)
+	})
 }
 
 func BenchmarkEntry_WithField_Chain(b *testing.B) {

--- a/entry_test.go
+++ b/entry_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -32,6 +33,10 @@ type nopFormatter struct{}
 
 func (nopFormatter) Format(*logrus.Entry) ([]byte, error) { return nil, nil }
 
+type funcError func()
+
+func (funcError) Error() string { return "boom" }
+
 type contextKeyType string
 
 func TestEntryWithError(t *testing.T) {
@@ -51,6 +56,87 @@ func TestEntryWithError(t *testing.T) {
 	require.Len(t, hook.Entries, 2)
 	assert.Equal(t, expErr, hook.Entries[0].Data["error"])
 	assert.Equal(t, expErr, hook.Entries[1].Data["err"])
+}
+
+// TestEntryErrorFieldValues verifies that error fields are accepted, rejected,
+// and formatted consistently across WithError, WithField, and WithFields.
+//
+// relates to https://github.com/sirupsen/logrus/pull/1577#discussion_r3799339160
+func TestEntryErrorFieldValues(t *testing.T) {
+	errFunc := funcError(func() {})
+	fn := func() {}
+
+	values := []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "error", value: errors.New("boom"), valid: true},
+		{name: "function error", value: errFunc, valid: true},
+		{name: "function error pointer", value: &errFunc, valid: true},
+		{name: "string", value: "boom", valid: true},
+		{name: "function", value: fn, valid: false},
+		{name: "function pointer", value: &fn, valid: false},
+	}
+
+	tests := []struct {
+		doc   string
+		apply func(*logrus.Logger, any) *logrus.Entry
+	}{
+		{
+			doc: "WithError",
+			apply: func(logger *logrus.Logger, value any) *logrus.Entry {
+				return logger.WithError(value.(error))
+			},
+		},
+		{
+			doc: "WithField",
+			apply: func(logger *logrus.Logger, value any) *logrus.Entry {
+				return logger.WithField(logrus.ErrorKey, value)
+			},
+		},
+		{
+			doc: "WithFields",
+			apply: func(logger *logrus.Logger, value any) *logrus.Entry {
+				return logger.WithFields(logrus.Fields{logrus.ErrorKey: value})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		for _, val := range values {
+			t.Run(tc.doc+"("+val.name+")", func(t *testing.T) {
+				valid := val.valid
+				// TODO: remove once generic fields recognize error values before rejecting function-backed values.
+				if tc.doc != "WithError" && strings.HasPrefix(val.name, "function error") {
+					valid = false
+				}
+				if _, ok := val.value.(error); tc.doc == "WithError" && !ok {
+					skip(t, "WithError only accepts error values")
+					return
+				}
+
+				var buf bytes.Buffer
+
+				logger := logrus.New()
+				logger.SetOutput(&buf)
+				logger.SetFormatter(&logrus.JSONFormatter{})
+
+				tc.apply(logger, val.value).Error("test")
+
+				var data map[string]any
+				require.NoError(t, json.Unmarshal(buf.Bytes(), &data))
+
+				if valid {
+					assert.Equal(t, "boom", data[logrus.ErrorKey])
+					assert.NotContains(t, data, logrus.FieldKeyLogrusError)
+				} else {
+					assert.NotContains(t, data, logrus.ErrorKey)
+					assert.Contains(t, data, logrus.FieldKeyLogrusError)
+				}
+			})
+		}
+	}
 }
 
 func TestEntryWithContext(t *testing.T) {

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -21,13 +21,26 @@ import (
 
 func skipReportCaller(t *testing.T) bool {
 	t.Helper()
-	if runtime.Compiler == "tinygo" {
+	switch runtime.Compiler {
+	case "tinygo":
 		// TinyGo currently (v0.41.1) doesn't support `runtime.Caller`;
 		// https://tinygo.org/docs/reference/lang-support/stdlib/#logslog
-		t.Log("SKIP: TinyGo does not support runtime.Caller") // no t.Skip on tinygo
+		skip(t, "TinyGo does not support runtime.Caller")
 		return true
+	default:
+		return false
 	}
-	return false
+}
+
+// tinygo doesn't support t.Skip
+func skip(t *testing.T, msg string) {
+	t.Helper()
+	switch runtime.Compiler {
+	case "tinygo":
+		t.Log(msg+"\n\r--- SKIP:", t.Name(), "(0.00s)")
+	default:
+		t.Skip(msg)
+	}
 }
 
 // TestReportCallerWhenConfigured verifies that when ReportCaller is set, the 'func' field


### PR DESCRIPTION
- relates to https://github.com/sirupsen/logrus/pull/1577#discussion_r3799339160

### entry: improve error-handling benchmarks

Depending on which function is called, these currently go through
slightly different paths; benchmark all of them to compare performance.


### entry: add coverage for error field values

Add tests covering error values passed through WithError, WithField, and
WithFields.

Verify that supported values are preserved and formatted without internal
field errors, including function-backed error implementations, while
unsupported function values continue to be rejected.