### PR TITLE
entry: allow function-backed error fields

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -159,15 +159,7 @@ func (entry *Entry) String() (string, error) {
 // WithError adds an error as single field (using the key defined in [ErrorKey])
 // to the Entry.
 func (entry *Entry) WithError(err error) *Entry {
-	// Avoid reflection work in WithFields; we know the type is an error;
-	// copy the entry data and set the ErrorKey directly.
-	dup := entry.dup()
-	dup.Data = maps.Clone(entry.Data)
-	if dup.Data == nil {
-		dup.Data = make(Fields, 1)
-	}
-	dup.Data[ErrorKey] = err
-	return dup
+	return entry.WithField(ErrorKey, err)
 }
 
 // WithContext adds a context to the Entry.
@@ -207,14 +199,16 @@ func (entry *Entry) WithTime(t time.Time) *Entry {
 }
 
 func (entry *Entry) addField(key string, value any) {
-	t := reflect.TypeOf(value)
-	if t != nil && (t.Kind() == reflect.Func || t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Func) {
-		if entry.err != "" {
-			entry.err += ", skipping unsupported field " + strconv.Quote(key)
-		} else {
-			entry.err = "skipping unsupported field " + strconv.Quote(key)
+	if _, ok := value.(error); !ok {
+		t := reflect.TypeOf(value)
+		if t != nil && (t.Kind() == reflect.Func || t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Func) {
+			if entry.err != "" {
+				entry.err += ", skipping unsupported field " + strconv.Quote(key)
+			} else {
+				entry.err = "skipping unsupported field " + strconv.Quote(key)
+			}
+			return
 		}
-		return
 	}
 
 	if entry.Data == nil {

--- a/entry_test.go
+++ b/entry_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -106,11 +105,6 @@ func TestEntryErrorFieldValues(t *testing.T) {
 	for _, tc := range tests {
 		for _, val := range values {
 			t.Run(tc.doc+"("+val.name+")", func(t *testing.T) {
-				valid := val.valid
-				// TODO: remove once generic fields recognize error values before rejecting function-backed values.
-				if tc.doc != "WithError" && strings.HasPrefix(val.name, "function error") {
-					valid = false
-				}
 				if _, ok := val.value.(error); tc.doc == "WithError" && !ok {
 					skip(t, "WithError only accepts error values")
 					return
@@ -127,7 +121,7 @@ func TestEntryErrorFieldValues(t *testing.T) {
 				var data map[string]any
 				require.NoError(t, json.Unmarshal(buf.Bytes(), &data))
 
-				if valid {
+				if val.valid {
 					assert.Equal(t, "boom", data[logrus.ErrorKey])
 					assert.NotContains(t, data, logrus.FieldKeyLogrusError)
 				} else {

--- a/exported.go
+++ b/exported.go
@@ -55,7 +55,7 @@ func AddHook(hook Hook) {
 // WithError creates an entry from the standard logger and adds an error to it,
 // using the value defined in [ErrorKey] as key.
 func WithError(err error) *Entry {
-	return std.WithField(ErrorKey, err)
+	return std.WithError(err)
 }
 
 // WithContext creates an entry from the standard logger and adds a context to it.


### PR DESCRIPTION
### entry: allow function-backed error fields

Treat values implementing error as supported fields before checking their
underlying kind.

This allows function-backed error implementations to be added through
WithError, WithField, and WithFields, matching formatter behavior that renders
error values through Error(), while continuing to reject unsupported function
values.


### logger: WithError: wrap logger.WithError for consistency

The utility was skipping WithError as intermediate; wrap the logger's
WithError method instead.


Performance remains identical, or even slightly improved for some cases;


```
pkg: github.com/sirupsen/logrus/benches
cpu: Apple M3 Pro
                           │ before.txt  │             after.txt              │
                           │   sec/op    │   sec/op     vs base               │
Entry_WithError/WithError    121.2n ± 1%   121.7n ± 1%       ~ (p=0.984 n=20)
Entry_WithError/WithField    123.7n ± 1%   121.0n ± 1%  -2.14% (p=0.000 n=20)
Entry_WithError/WithFields   212.5n ± 1%   209.3n ± 1%  -1.51% (p=0.000 n=20)
geomean                      147.2n        145.6n       -1.08%

                           │ before.txt │              after.txt              │
                           │    B/op    │    B/op     vs base                 │
Entry_WithError/WithError    448.0 ± 0%   448.0 ± 0%       ~ (p=1.000 n=20) ¹
Entry_WithError/WithField    448.0 ± 0%   448.0 ± 0%       ~ (p=1.000 n=20) ¹
Entry_WithError/WithFields   448.0 ± 0%   448.0 ± 0%       ~ (p=1.000 n=20) ¹
geomean                      448.0        448.0       +0.00%
¹ all samples are equal

                           │ before.txt │              after.txt              │
                           │ allocs/op  │ allocs/op   vs base                 │
Entry_WithError/WithError    3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=20) ¹
Entry_WithError/WithField    3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=20) ¹
Entry_WithError/WithFields   3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=20) ¹
geomean                      3.000        3.000       +0.00%
¹ all samples are equal
```
