### PR TITLE
test: add TestLevelStringUnknown and TestParseLevelVariations in level_test.go

### DIFF
--- a/level_test.go
+++ b/level_test.go
@@ -60,3 +60,43 @@ func TestLevelMarshalText(t *testing.T) {
 		})
 	}
 }
+
+func TestLevelStringUnknown(t *testing.T) {
+	unknownLevel := logrus.Level(99)
+	require.Equal(t, "unknown", unknownLevel.String())
+}
+
+func TestParseLevelVariations(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected logrus.Level
+		hasErr   bool
+	}{
+		{"panic", logrus.PanicLevel, false},
+		{"PANIC", logrus.PanicLevel, false},
+		{"fatal", logrus.FatalLevel, false},
+		{"error", logrus.ErrorLevel, false},
+		{"warn", logrus.WarnLevel, false},
+		{"WARN", logrus.WarnLevel, false},
+		{"warning", logrus.WarnLevel, false},
+		{"WARNING", logrus.WarnLevel, false},
+		{"info", logrus.InfoLevel, false},
+		{"INFO", logrus.InfoLevel, false},
+		{"debug", logrus.DebugLevel, false},
+		{"trace", logrus.TraceLevel, false},
+		{"TRACE", logrus.TraceLevel, false},
+		{"invalid", logrus.Level(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			lvl, err := logrus.ParseLevel(tt.input)
+			if tt.hasErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, lvl)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
- In `level_test.go`, add unit test `TestLevelStringUnknown` to verify `Level.String()` for unknown level values.
- Add `TestParseLevelVariations` to verify case-insensitive matching and alias handling (e.g., `warn`/`warning`, uppercase, invalid input).