### PR TITLE
TextFormatter: recover panics from Error and String methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.10.1
+
+  * Fix a regression introduced in v1.10.0 where `TextFormatter` could panic
+    when formatting nil or panicking `error` and `fmt.Stringer` values.
+
 ## 1.10.0
 
 Fixes:

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"reflect"
 	"runtime"
 	"slices"
 	"strconv"
@@ -329,10 +330,10 @@ func (f *TextFormatter) appendValue(b *bytes.Buffer, value any) {
 		f.appendBytes(b, strconv.AppendBool(raw[:0], v))
 		return
 	case error:
-		f.appendString(b, v.Error())
+		f.appendError(b, v)
 		return
 	case fmt.Stringer:
-		f.appendString(b, v.String())
+		f.appendStringer(b, v)
 		return
 	}
 
@@ -415,6 +416,29 @@ func (f *TextFormatter) appendNumeric(b *bytes.Buffer, out []byte) {
 		return
 	}
 	b.Write(out)
+}
+
+func (f *TextFormatter) appendError(b *bytes.Buffer, v error) {
+	defer f.recoverValue(b, v, "Error")
+
+	f.appendString(b, v.Error())
+}
+
+func (f *TextFormatter) appendStringer(b *bytes.Buffer, v fmt.Stringer) {
+	defer f.recoverValue(b, v, "String")
+
+	f.appendString(b, v.String())
+}
+
+func (f *TextFormatter) recoverValue(b *bytes.Buffer, v any, method string) {
+	if r := recover(); r != nil {
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Pointer && rv.IsNil() {
+			f.appendString(b, "<nil>")
+		} else {
+			f.appendString(b, fmt.Sprintf("%%!v(PANIC=%s method: %v)", method, r))
+		}
+	}
 }
 
 // needsQuoting returns true if the string contains any byte that

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -691,3 +691,71 @@ func TestTextEntryFieldValueError(t *testing.T) {
 		}
 	})
 }
+
+type panicError string
+
+func (e panicError) Error() string { panic(string(e)) }
+
+type panicStringer string
+
+func (s panicStringer) String() string { panic(string(s)) }
+
+type nilError struct{}
+
+func (*nilError) Error() string { panic("unexpected") }
+
+type nilStringer struct{}
+
+func (*nilStringer) String() string { panic("unexpected") }
+
+// TestTextFormatterPanickingValue verifies panicking Error and Stringer
+// methods are recovered.
+//
+// regression test for https://github.com/sirupsen/logrus/issues/1580
+func TestTextFormatterPanickingValue(t *testing.T) {
+	var nilErr *nilError
+	var nilString *nilStringer
+
+	tests := []struct {
+		doc   string
+		value any
+		want  string
+	}{
+		{
+			doc:   "error",
+			value: panicError("boom"),
+			want:  `level=info test="%!v(PANIC=Error method: boom)"` + "\n",
+		},
+		{
+			doc:   "stringer",
+			value: panicStringer("boom"),
+			want:  `level=info test="%!v(PANIC=String method: boom)"` + "\n",
+		},
+		{
+			doc:   "nil error",
+			value: nilErr,
+			want:  `level=info test="<nil>"` + "\n",
+		},
+		{
+			doc:   "nil stringer",
+			value: nilString,
+			want:  `level=info test="<nil>"` + "\n",
+		},
+	}
+
+	formatter := &TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			got, err := formatter.Format(&Entry{
+				Level: InfoLevel,
+				Data:  Fields{"test": tc.value},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
- fixes https://github.com/sirupsen/logrus/issues/1580
- updates (regression point): https://github.com/sirupsen/logrus/pull/1489
- relates to https://github.com/moby/moby/pull/52462#issuecomment-5335190992


Preserve fmt.Sprint behavior for values whose Error or String methods panic.

Fix a regression introduced in v1.10.0 (76da6028fadfcf96b9e6b9add546d8b0ff793e02), which added fast-paths for error and Stringer implementations, but did not handle nil values or panicking implementations.

Using fmt.Sprint for these values restores the previous behavior, but regresses StringerTextFormatter by 38% and ErrorTextFormatter by 23%, and increases allocations by 60% and 22%, respectively. The custom recovery keeps performance effectively unchanged from v1.10.0, with no additional allocations:

    pkg: github.com/sirupsen/logrus/benches
    cpu: Apple M3 Pro
                          │    v1.10.0    │             fmt.Sprint              │               custom               │
                          │    sec/op     │   sec/op     vs base                │   sec/op     vs base               │
    StringerTextFormatter   1.161µ ± 0%     1.600µ ± 0%  +37.81% (p=0.000 n=60)   1.165µ ± 0%  +0.34% (p=0.000 n=60)
    ErrorTextFormatter      595.9n ± 0%     733.4n ± 0%  +23.07% (p=0.000 n=60)   594.7n ± 0%  -0.21% (p=0.036 n=60)
    geomean                 831.8n          1.083µ       +30.23%                  832.3n       +0.07%

                          │    v1.10.0    │             fmt.Sprint              │                custom                │
                          │      B/s      │     B/s       vs base               │      B/s       vs base               │
    StringerTextFormatter   115.00Mi ± 0%   83.43Mi ± 0%  -27.45% (n=60)          114.64Mi ± 0%  -0.31% (p=0.000 n=60)
    ErrorTextFormatter      107.22Mi ± 0%   87.12Mi ± 0%  -18.75% (n=60)          107.45Mi ± 0%  +0.21% (p=0.037 n=60)
    geomean                  111.0Mi        85.26Mi       -23.22%                  111.0Mi       -0.05%

Bytes and allocations per operation are unchanged.

updates 76da6028fadfcf96b9e6b9add546d8b0ff793e02