### PR TITLE
update changelog for v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## 1.10.1
 
+Fixes:
+
   * Fix a regression introduced in v1.10.0 where `TextFormatter` could panic
     when formatting nil or panicking `error` and `fmt.Stringer` values.
+  * Allow function-backed implementations of `error` as field values.
 
 ## 1.10.0
 


### PR DESCRIPTION
And for GitHub;

```markdown
This patch release fixes two issues in field formatting and handling:

- Fix a regression introduced in v1.10.0 where `TextFormatter` could panic
  when formatting nil or panicking `error` and `fmt.Stringer` values.
- Allow function-backed values implementing `error` to be used with
  `WithError`, `WithField`, and `WithFields`.

Dependency Changes

- update github.com/stretchr/testify to v1.12.0
```
